### PR TITLE
chore(ide): fix type setting for vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,6 @@
 
   "python.testing.pytestEnabled": true,
 
-  "python.analysis.typeCheckingMode": "standard",
   "python.testing.pytestArgs": [
     "tests"
   ],


### PR DESCRIPTION
Remove the "type" setting from the "editor" section to the root of the settings file, as it is not a valid setting for the editor.

Changes to be committed: 	modified:   .vscode/settings.json

Signed-off-by: Pierre LaFromboise <44212292+DataInsightPro@users.noreply.github.com>