### PR TITLE
ci: Limit push CI to main branch

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -2,6 +2,8 @@ name: Python CI
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
Set the push CI workflow to only run on the main branch. This will prevent unnecessary CI runs on feature branches and reduce resource usage.

Changes to be committed: 	modified:   .github/workflows/code-quality.yaml

Signed-off-by: Pierre LaFromboise <44212292+DataInsightPro@users.noreply.github.com>