### PR TITLE
fix(ci): sync uv.lock version on release

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,14 @@
       "release-type": "python",
       "package-name": "weevr",
       "changelog-path": "CHANGELOG.md",
-      "include-v-in-tag": true
+      "include-v-in-tag": true,
+      "extra-files": [
+        {
+          "path": "uv.lock",
+          "type": "toml",
+          "jsonpath": "$.package[?(@.name.value=='weevr')].version"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

- Configure release-please to update the project version in `uv.lock` alongside `pyproject.toml` during releases

## Why

- When Release Please bumps the version in `pyproject.toml`, the `uv.lock` file becomes out of sync because it also tracks the project version
- This causes `uv sync --locked` to fail in the code quality workflow when the release PR is merged to main

## What changed

- Added `extra-files` configuration to `release-please-config.json` that targets the weevr package version entry in `uv.lock` using a TOML jsonpath
- This ensures release-please updates both `pyproject.toml` and `uv.lock` in the same release PR commit

## How to test

- [x] uv sync --dev
- [x] uv run ruff check .
- [x] uv run ruff format .
- [x] uv run pyright .
- [x] uv run pytest
- [ ] On the next release cycle, verify the release PR diff includes version bumps in both `pyproject.toml` and `uv.lock`

## Release / Versioning

- [x] PR title follows Conventional Commit format (feat:, fix:, chore:, docs:, ci:, etc.)
- [ ] Breaking change indicated (feat!: / fix!: or BREAKING CHANGE in body)

## Notes

- The `extra-files` TOML jsonpath uses a `.value` accessor required by release-please's internal TOML parser ([googleapis/release-please#2455](https://github.com/googleapis/release-please/issues/2455))
- This is the community-established pattern for uv.lock support ([googleapis/release-please#2561](https://github.com/googleapis/release-please/issues/2561))