### PR TITLE
fix(ci): correct publish workflow tag pattern

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,7 +3,7 @@ name: Publish to TestPyPI
 on:
   push:
     tags:
-      - "v*"
+      - "weevr-v*"
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

- Fix publish workflow tag pattern to match Release Please tag format

## Why

- Release Please creates tags like `weevr-v0.7.0` (due to `package-name: "weevr"` + `include-v-in-tag: true`)
- The publish workflow was matching `v*`, which never matched these tags
- As a result, the TestPyPI publish job never triggered on new releases

## What changed

- Updated `.github/workflows/publish.yaml` tag filter from `v*` to `weevr-v*`

## How to test

- [x] uv sync --dev
- [x] uv run ruff check .
- [x] uv run ruff format .
- [x] uv run pyright .
- [x] uv run pytest
- [ ] Verify next Release Please tag triggers the publish workflow

## Release / Versioning

- [x] PR title follows Conventional Commit format (feat:, fix:, chore:, docs:, ci:, etc.)
- [ ] Breaking change indicated (feat!: / fix!: or BREAKING CHANGE in body)

## Notes

- No breaking change; this is a CI-only fix
- The existing `weevr-v0.7.0` tag will not retroactively trigger; the fix applies to future releases