### PR TITLE
fix(ci): trigger publish on release event instead of tag push

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,9 +1,8 @@
 name: Publish to TestPyPI
 
 on:
-  push:
-    tags:
-      - "weevr-v*"
+  release:
+    types: [published]
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

- Switch publish workflow trigger from `push.tags` to `release.published`

## Why

- Release Please v4 creates tags via the GitHub API when it publishes a release
- Tags created through the GitHub API do **not** fire `push` events in GitHub Actions
- Only tags pushed via `git push` trigger `on: push: tags:` workflows
- This is why the publish workflow never ran despite the correct tag pattern

## What changed

- Replaced `on: push: tags: ["weevr-v*"]` with `on: release: types: [published]` in `.github/workflows/publish.yaml`
- The `release.published` event fires whenever Release Please creates a new GitHub Release, which is the actual mechanism it uses

## How to test

- [x] uv sync --dev
- [x] uv run ruff check .
- [x] uv run ruff format .
- [x] uv run pyright .
- [x] uv run pytest
- [ ] Verify next Release Please release triggers the publish workflow

## Release / Versioning

- [x] PR title follows Conventional Commit format (feat:, fix:, chore:, docs:, ci:, etc.)
- [ ] Breaking change indicated (feat!: / fix!: or BREAKING CHANGE in body)

## Notes

- CI-only fix, no source code changes
- To test with the existing v0.7.1 release, you can manually re-run the release from the GitHub Actions UI after merging