### PR TITLE
fix(ci): disable attestations and enable verbose for TestPyPI publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,3 +65,5 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+          verbose: true
+          attestations: false


### PR DESCRIPTION
## Summary

- Fix TestPyPI publish failing with `400 Bad Request` by disabling attestations and enabling verbose output

## Why

- The `publish-testpypi` job fails with an opaque `400 Bad Request` from TestPyPI despite the version not existing and the trusted publisher being correctly configured
- Attestation verification is the likely cause; disabling it isolates the issue and unblocks publishing
- Verbose output was missing, hiding the actual error details from TestPyPI

## What changed

- Disabled Sigstore attestations (`attestations: false`) on the TestPyPI publish step
- Enabled verbose logging (`verbose: true`) for better diagnostics

## How to test

- [ ] Merge and trigger a release to verify TestPyPI publish succeeds
- [ ] If publish succeeds without attestations, re-enable in a follow-up to confirm root cause

## Release / Versioning

- [x] PR title follows Conventional Commit format (feat:, fix:, chore:, docs:, ci:, etc.)
- [ ] Breaking change indicated (feat!: / fix!: or BREAKING CHANGE in body)

## Notes

- Once publishing is confirmed working, attestations can be re-enabled in a follow-up PR to pinpoint the exact attestation issue