### PR TITLE
fix(ci): move docs deployment into release workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,12 +9,9 @@ on:
     branches:
       - main
       - "release-please--*"
-  release:
-    types: [published]
 
 jobs:
   docs-check:
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
 
     steps:
@@ -39,38 +36,3 @@ jobs:
 
       - name: Lint markdown
         run: npx markdownlint-cli2 "docs/**/*.md"
-
-  deploy-docs:
-    if: github.event_name == 'release'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version-file: ".python-version"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          version: "0.9.28"
-          enable-cache: true
-
-      - name: Sync (locked)
-        run: uv sync --locked --dev
-
-      - name: Configure git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Deploy docs
-        run: |
-          VERSION=$(echo "${{ github.ref_name }}" | sed -E 's/^v([0-9]+\.[0-9]+).*/\1/')
-          uv run mike deploy "$VERSION" latest --update-aliases --push

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - name: Run Release Please
         id: release
@@ -67,3 +68,40 @@ jobs:
           repository-url: https://test.pypi.org/legacy/
           verbose: true
           attestations: false
+
+  deploy-docs:
+    needs: release
+    if: ${{ needs.release.outputs.releases_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: ".python-version"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.9.28"
+          enable-cache: true
+
+      - name: Sync (locked)
+        run: uv sync --locked --dev
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Deploy docs
+        run: |
+          TAG="${{ needs.release.outputs.tag_name }}"
+          VERSION=$(echo "$TAG" | sed -E 's/^(weevr-)?v([0-9]+\.[0-9]+).*/\2/')
+          uv run mike deploy "$VERSION" latest --update-aliases --push

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,6 @@
     ".": {
       "release-type": "python",
       "package-name": "weevr",
-      "release-as": "1.0.0",
       "changelog-path": "CHANGELOG.md",
       "include-v-in-tag": true,
       "extra-files": [


### PR DESCRIPTION
## Summary

Move the `deploy-docs` job from `docs.yml` into `release.yaml` and unpin the `release-as` version override.

## Why

Events created by the default `GITHUB_TOKEN` do not trigger other workflows. The `release: [published]` trigger in `docs.yml` never fires after Release Please creates a GitHub Release, so docs are never deployed. Additionally, the `release-as: "1.0.0"` pin in `release-please-config.json` would force every future release to be 1.0.0.

## What changed

- Added `deploy-docs` job to `release.yaml`, gated on `releases_created == 'true'`
- Exposed `tag_name` output from the Release Please step for version extraction
- Version extraction handles the `weevr-v1.0.0` tag format
- Removed the dead `deploy-docs` job and `release:` trigger from `docs.yml`
- Removed the `if: github.event_name == 'pull_request'` guard from `docs-check` (now the only job)
- Removed `release-as: "1.0.0"` from `release-please-config.json` so future releases resume normal semver bumps

## How to test

- [x] uv sync --dev
- [x] uv run ruff check .
- [x] uv run ruff format .
- [x] uv run pyright .
- [x] uv run pytest
- [ ] Merge and verify next release triggers docs deployment in the release workflow

## Release / Versioning

- [x] PR title follows Conventional Commit format (feat:, fix:, chore:, docs:, ci:, etc.)
- [ ] Breaking change indicated (feat!: / fix!: or BREAKING CHANGE in body)

## Notes

- This does not retroactively deploy v1.0.0 docs. After merging, a manual `mike deploy` or a patch release will trigger the first deployment.