### PR TITLE
fix(ci): add root redirect for GitHub Pages docs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -105,3 +105,4 @@ jobs:
           TAG="${{ needs.release.outputs.tag_name }}"
           VERSION=$(echo "$TAG" | sed -E 's/^(weevr-)?v([0-9]+\.[0-9]+).*/\2/')
           uv run mike deploy "$VERSION" latest --update-aliases --push
+          uv run mike set-default latest --push


### PR DESCRIPTION
## Summary

Add `mike set-default latest` to the docs deployment step.

## Why

The `gh-pages` branch has versioned docs under `1.0/` and `latest/` but no root `index.html`. Visitors to the base GitHub Pages URL see a 404. `mike set-default` creates a root redirect to the `latest` alias.

## What changed

- Added `uv run mike set-default latest --push` after `mike deploy` in the release workflow

## How to test

- [x] uv sync --dev
- [x] uv run ruff check .
- [x] uv run ruff format .
- [x] uv run pyright .
- [x] uv run pytest
- [ ] Merge and verify the root URL redirects to latest after the next release

## Release / Versioning

- [x] PR title follows Conventional Commit format (feat:, fix:, chore:, docs:, ci:, etc.)
- [ ] Breaking change indicated (feat!: / fix!: or BREAKING CHANGE in body)

## Notes

- The redirect will be created on the next release. To fix the current `gh-pages` state immediately, run `uv run mike set-default latest --push` locally.