### PR TITLE
fix(ci): add production PyPI publishing to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,6 +69,25 @@ jobs:
           verbose: true
           attestations: false
 
+  publish-pypi:
+    needs: publish-testpypi
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true
+          attestations: false
+
   deploy-docs:
     needs: release
     if: ${{ needs.release.outputs.releases_created == 'true' }}


### PR DESCRIPTION
## Summary

- Add production PyPI publishing job to the release workflow

## Why

- Releases currently only publish to TestPyPI; users cannot `pip install weevr` from production PyPI

## What changed

- Added `publish-pypi` job to `release.yaml` that runs after TestPyPI publish succeeds
- Uses OIDC trusted publishing via the `pypi` GitHub environment (no API tokens)

## How to test

- [ ] Verify `pypi` GitHub environment exists with required reviewers and branch restriction to `main`
- [ ] Verify PyPI trusted publisher is configured for `ardent-data/weevr` with workflow `release.yaml` and environment `pypi`
- [ ] Merge this PR, then merge the Release Please PR to trigger the full pipeline

## Release / Versioning

- [x] PR title follows Conventional Commit format (feat:, fix:, chore:, docs:, ci:, etc.)
- [ ] Breaking change indicated (feat!: / fix!: or BREAKING CHANGE in body)

## Notes

- TestPyPI publish acts as a gate — production PyPI only runs if TestPyPI succeeds
- If required reviewers are enabled on the `pypi` environment, you'll get a manual approval prompt before each production publish