### PR TITLE
fix(engine): surface thread errors in result detail and summary

### DIFF
--- a/src/weevr/engine/result.py
+++ b/src/weevr/engine/result.py
@@ -20,6 +20,7 @@ class ThreadResult(FrozenBase):
         target_path: Physical path of the Delta table that was written.
         telemetry: Thread-level telemetry with validation/assertion results and row counts.
         skip_reason: The condition expression that caused the thread to be skipped.
+        error: Error message when the thread failed, ``None`` on success or skip.
     """
 
     status: Literal["success", "failure", "skipped"]
@@ -29,6 +30,7 @@ class ThreadResult(FrozenBase):
     target_path: str
     telemetry: ThreadTelemetry | None = None
     skip_reason: str | None = None
+    error: str | None = None
 
 
 class WeaveResult(FrozenBase):

--- a/src/weevr/engine/runner.py
+++ b/src/weevr/engine/runner.py
@@ -204,7 +204,8 @@ def execute_weave(
                         if name in thread_collectors and collector is not None:
                             collector.merge(thread_collectors[name])
 
-                        # Record a failure result
+                        # Record a failure result with the error message
+                        error_msg = f"{type(exc).__name__}: {exc}"
                         thread_results.append(
                             ThreadResult(
                                 status="failure",
@@ -212,6 +213,7 @@ def execute_weave(
                                 rows_written=0,
                                 write_mode="",
                                 target_path="",
+                                error=error_msg,
                             )
                         )
                         logger.debug("Thread '%s' failed: %s", name, exc)

--- a/src/weevr/result.py
+++ b/src/weevr/result.py
@@ -154,7 +154,42 @@ class RunResult:
                         f"  {wr.weave_name}  {wr.status}  {thread_count} threads  {wr_dur}"
                     )
 
+        # Collect thread errors from the detail tree
+        errors = self._collect_thread_errors()
+        if errors:
+            lines.append("")
+            lines.append("Errors:")
+            for err in errors:
+                lines.append(f"  - {err}")
+
         return lines
+
+    def _collect_thread_errors(self) -> list[str]:
+        """Extract error messages from failed threads in the detail tree."""
+        if self.detail is None:
+            return []
+
+        errors: list[str] = []
+        thread_results: list[Any] = []
+
+        if self.config_type == "thread":
+            error = getattr(self.detail, "error", None)
+            if error:
+                name = getattr(self.detail, "thread_name", "unknown")
+                errors.append(f"[{name}] {error}")
+        elif self.config_type == "weave":
+            thread_results = getattr(self.detail, "thread_results", [])
+        elif self.config_type == "loom":
+            for wr in getattr(self.detail, "weave_results", []):
+                thread_results.extend(getattr(wr, "thread_results", []))
+
+        for tr in thread_results:
+            error = getattr(tr, "error", None)
+            if error:
+                name = getattr(tr, "thread_name", "unknown")
+                errors.append(f"[{name}] {error}")
+
+        return errors
 
     def _summary_validate(self) -> list[str]:
         lines: list[str] = [

--- a/tests/weevr/engine/test_result.py
+++ b/tests/weevr/engine/test_result.py
@@ -33,6 +33,28 @@ class TestThreadResult:
         )
         assert result.status == "failure"
 
+    def test_failure_result_with_error(self) -> None:
+        result = ThreadResult(
+            status="failure",
+            thread_name="fact_orders",
+            rows_written=0,
+            write_mode="",
+            target_path="",
+            error="FileNotFoundError: Source path not found: /data/raw_orders",
+        )
+        assert result.status == "failure"
+        assert result.error == "FileNotFoundError: Source path not found: /data/raw_orders"
+
+    def test_error_defaults_to_none(self) -> None:
+        result = ThreadResult(
+            status="success",
+            thread_name="dim_customer",
+            rows_written=100,
+            write_mode="overwrite",
+            target_path="/data/dim_customer",
+        )
+        assert result.error is None
+
     def test_invalid_status_raises_validation_error(self) -> None:
         with pytest.raises(ValidationError):
             ThreadResult(

--- a/tests/weevr/engine/test_runner.py
+++ b/tests/weevr/engine/test_runner.py
@@ -166,6 +166,13 @@ class TestWeaveRunnerFailureHandling:
         assert result.status == "failure"
         # B and C should be skipped (abort stops everything)
         assert set(result.threads_skipped) >= {"B", "C"}
+        # Failed thread result carries the error message
+        failed = [r for r in result.thread_results if r.status == "failure"]
+        assert len(failed) == 1
+        assert failed[0].thread_name == "A"
+        assert failed[0].error is not None
+        assert "A failed" in failed[0].error
+        assert failed[0].error.startswith("ExecutionError:")
 
     @patch("weevr.engine.runner.execute_thread")
     def test_skip_downstream_skips_only_dependents(self, mock_exec):

--- a/tests/weevr/test_result.py
+++ b/tests/weevr/test_result.py
@@ -268,6 +268,150 @@ class TestRunResult:
         )
         assert result.status == "partial"
 
+    def test_summary_execute_thread_with_error(self) -> None:
+        from weevr.engine.result import ThreadResult
+
+        detail = ThreadResult(
+            status="failure",
+            thread_name="dim_customer",
+            rows_written=0,
+            write_mode="",
+            target_path="",
+            error="Source path not found: /data/raw_customers",
+        )
+        result = RunResult(
+            status="failure",
+            mode=ExecutionMode.EXECUTE,
+            config_type="thread",
+            config_name="dim_customer",
+            duration_ms=50,
+            detail=detail,
+        )
+        s = result.summary()
+        assert "Errors:" in s
+        assert "[dim_customer] Source path not found: /data/raw_customers" in s
+
+    def test_summary_execute_weave_with_thread_errors(self) -> None:
+        from weevr.engine.result import ThreadResult, WeaveResult
+
+        detail = WeaveResult(
+            status="partial",
+            weave_name="dims",
+            thread_results=[
+                ThreadResult(
+                    status="success",
+                    thread_name="dim_product",
+                    rows_written=50,
+                    write_mode="overwrite",
+                    target_path="/data/dim_product",
+                ),
+                ThreadResult(
+                    status="failure",
+                    thread_name="dim_customer",
+                    rows_written=0,
+                    write_mode="",
+                    target_path="",
+                    error="Column 'email' not found",
+                ),
+            ],
+            threads_skipped=[],
+            duration_ms=200,
+        )
+        result = RunResult(
+            status="partial",
+            mode=ExecutionMode.EXECUTE,
+            config_type="weave",
+            config_name="dims",
+            duration_ms=200,
+            detail=detail,
+        )
+        s = result.summary()
+        assert "Errors:" in s
+        assert "[dim_customer] Column 'email' not found" in s
+        assert "dim_product" not in s.split("Errors:")[1]
+
+    def test_summary_execute_loom_with_thread_errors(self) -> None:
+        from weevr.engine.result import LoomResult, ThreadResult, WeaveResult
+
+        detail = LoomResult(
+            status="partial",
+            loom_name="nightly",
+            weave_results=[
+                WeaveResult(
+                    status="success",
+                    weave_name="dims",
+                    thread_results=[
+                        ThreadResult(
+                            status="success",
+                            thread_name="dim_product",
+                            rows_written=100,
+                            write_mode="overwrite",
+                            target_path="/data/dim_product",
+                        ),
+                    ],
+                    threads_skipped=[],
+                    duration_ms=100,
+                ),
+                WeaveResult(
+                    status="failure",
+                    weave_name="facts",
+                    thread_results=[
+                        ThreadResult(
+                            status="failure",
+                            thread_name="fact_orders",
+                            rows_written=0,
+                            write_mode="",
+                            target_path="",
+                            error="Bad Request: file not found",
+                        ),
+                    ],
+                    threads_skipped=["fact_revenue"],
+                    duration_ms=50,
+                ),
+            ],
+            duration_ms=150,
+        )
+        result = RunResult(
+            status="partial",
+            mode=ExecutionMode.EXECUTE,
+            config_type="loom",
+            config_name="nightly",
+            duration_ms=150,
+            detail=detail,
+        )
+        s = result.summary()
+        assert "Errors:" in s
+        assert "[fact_orders] Bad Request: file not found" in s
+
+    def test_summary_execute_no_errors_when_all_succeed(self) -> None:
+        from weevr.engine.result import ThreadResult, WeaveResult
+
+        detail = WeaveResult(
+            status="success",
+            weave_name="dims",
+            thread_results=[
+                ThreadResult(
+                    status="success",
+                    thread_name="dim_product",
+                    rows_written=50,
+                    write_mode="overwrite",
+                    target_path="/data/dim_product",
+                ),
+            ],
+            threads_skipped=[],
+            duration_ms=100,
+        )
+        result = RunResult(
+            status="success",
+            mode=ExecutionMode.EXECUTE,
+            config_type="weave",
+            config_name="dims",
+            duration_ms=100,
+            detail=detail,
+        )
+        s = result.summary()
+        assert "Errors:" not in s
+
 
 class TestLoadedConfig:
     @pytest.fixture()


### PR DESCRIPTION
## Summary

- Surface thread execution errors in `ThreadResult.error` and `RunResult.summary()` so failures are diagnosable without debug logging.

## Why

- Thread execution errors were only logged at DEBUG level in `runner.py` and never stored on the result model. Callers inspecting `result.detail` or `result.summary()` saw `status="failure"` with zero diagnostic information, making failures completely opaque.

## What changed

- **`ThreadResult` model** (`engine/result.py`): Added `error: str | None = None` field to store the error message on failure.
- **`execute_weave` exception handler** (`engine/runner.py`): Captures `f"{type(exc).__name__}: {exc}"` and passes it to `ThreadResult(error=...)`. Includes exception type for diagnostic clarity.
- **`RunResult.summary()`** (`result.py`): Added `_collect_thread_errors()` that walks the detail tree (thread/weave/loom) and renders an "Errors:" section in the summary output.
- **Tests**: Model tests for the new field, summary tests for all three config types (thread, weave, loom), negative test for success case, and runner integration test asserting the error field is populated on failure.

## How to test

- [ ] uv sync --dev
- [ ] uv run ruff check .
- [ ] uv run ruff format .
- [ ] uv run pyright .
- [ ] uv run pytest

## Release / Versioning

- [x] PR title follows Conventional Commit format (feat:, fix:, chore:, docs:, ci:, etc.)
- [ ] Breaking change indicated (feat!: / fix!: or BREAKING CHANGE in body)

## Notes

- Backward compatible: `error` defaults to `None`, so existing code constructing `ThreadResult` without `error=` is unaffected.
- The DEBUG log in the exception handler is preserved unchanged.