### PR TITLE
fix(ci): disable D2 plugin cache to prevent gdbm lock error

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ plugins:
   - search
   - d2:
       layout: elk
+      cache: false
   - mkdocstrings:
       handlers:
         python:


### PR DESCRIPTION
## Summary

- Disable the mkdocs-d2-plugin file cache to fix deploy-docs CI failures.

## Why

- The D2 plugin opens a gdbm cache file during `mkdocs build`. On GitHub Actions runners, this fails with `_gdbm.error: [Errno 11] Resource temporarily unavailable` due to lock contention. This has blocked docs deployment since v1.0.4.

## What changed

- Added `cache: false` to the D2 plugin configuration in `mkdocs.yml`. The plugin's `on_config` method checks `self.config.cache` before calling `dbm.open`, so this skips the problematic cache initialization entirely.

## How to test

- [ ] uv sync --dev
- [ ] uv run ruff check .
- [ ] uv run ruff format .
- [ ] uv run pyright .
- [ ] uv run pytest
- [ ] Verify deploy-docs job succeeds after merge

## Release / Versioning

- [x] PR title follows Conventional Commit format (feat:, fix:, chore:, docs:, ci:, etc.)
- [ ] Breaking change indicated (feat!: / fix!: or BREAKING CHANGE in body)

## Notes

- CI runs are ephemeral so the D2 render cache provides no benefit there. Local `mkdocs serve` will also skip caching, but D2 renders are fast enough that this has negligible impact on the dev experience.