### PR TITLE
fix(state): resolve CodeQL warnings for unreachable statements and cyclic imports

### DIFF
--- a/src/weevr/engine/executor.py
+++ b/src/weevr/engine/executor.py
@@ -24,7 +24,7 @@ from weevr.operations.readers import (
 )
 from weevr.operations.validation import validate_dataframe
 from weevr.operations.writers import apply_target_mapping, execute_cdc_merge, write_target
-from weevr.state.watermark import WatermarkState, WatermarkStore, resolve_store
+from weevr.state import WatermarkState, WatermarkStore, resolve_store
 from weevr.telemetry.collector import SpanBuilder, SpanCollector
 from weevr.telemetry.results import ThreadTelemetry
 from weevr.telemetry.span import ExecutionSpan, SpanStatus, generate_span_id, generate_trace_id

--- a/src/weevr/state/__init__.py
+++ b/src/weevr/state/__init__.py
@@ -1,5 +1,39 @@
 """Watermark state persistence for incremental processing."""
 
-from weevr.state.watermark import WatermarkState, WatermarkStore, resolve_store
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from weevr.state.watermark import WatermarkState, WatermarkStore
+
+if TYPE_CHECKING:
+    from weevr.model.load import LoadConfig
+
+
+def resolve_store(load_config: LoadConfig, target_path: str) -> WatermarkStore:
+    """Resolve the appropriate watermark store from config.
+
+    If ``load_config.watermark_store`` is ``None`` or its type is
+    ``table_properties``, returns a :class:`TablePropertiesStore`.
+    If the type is ``metadata_table``, returns a :class:`MetadataTableStore`.
+
+    Args:
+        load_config: Thread-level load configuration.
+        target_path: Path to the thread's Delta target table.
+
+    Returns:
+        A concrete ``WatermarkStore`` implementation.
+    """
+    from weevr.state.metadata_table import MetadataTableStore
+    from weevr.state.table_properties import TablePropertiesStore
+
+    store_config = load_config.watermark_store
+
+    if store_config is None or store_config.type == "table_properties":
+        return TablePropertiesStore(target_path)
+
+    # metadata_table — table_path is validated present by WatermarkStoreConfig
+    return MetadataTableStore(store_config.table_path)  # type: ignore[arg-type]
+
 
 __all__ = ["WatermarkState", "WatermarkStore", "resolve_store"]

--- a/src/weevr/state/watermark.py
+++ b/src/weevr/state/watermark.py
@@ -1,4 +1,4 @@
-"""Watermark state model, store ABC, and store resolution."""
+"""Watermark state model and store ABC."""
 
 from __future__ import annotations
 
@@ -10,8 +10,6 @@ from weevr.model.base import FrozenBase
 
 if TYPE_CHECKING:
     from pyspark.sql import SparkSession
-
-    from weevr.model.load import LoadConfig
 
 
 class WatermarkState(FrozenBase):
@@ -45,29 +43,3 @@ class WatermarkStore(ABC):
 
         Raises ``StateError`` on failure.
         """
-
-
-def resolve_store(load_config: LoadConfig, target_path: str) -> WatermarkStore:
-    """Resolve the appropriate watermark store from config.
-
-    If ``load_config.watermark_store`` is ``None`` or its type is
-    ``table_properties``, returns a :class:`TablePropertiesStore`.
-    If the type is ``metadata_table``, returns a :class:`MetadataTableStore`.
-
-    Args:
-        load_config: Thread-level load configuration.
-        target_path: Path to the thread's Delta target table.
-
-    Returns:
-        A concrete ``WatermarkStore`` implementation.
-    """
-    from weevr.state.metadata_table import MetadataTableStore
-    from weevr.state.table_properties import TablePropertiesStore
-
-    store_config = load_config.watermark_store
-
-    if store_config is None or store_config.type == "table_properties":
-        return TablePropertiesStore(target_path)
-
-    # metadata_table — table_path is validated present by WatermarkStoreConfig
-    return MetadataTableStore(store_config.table_path)  # type: ignore[arg-type]

--- a/tests/weevr/errors/test_exceptions.py
+++ b/tests/weevr/errors/test_exceptions.py
@@ -130,51 +130,46 @@ class TestSpecificExceptions:
 
     def test_config_parse_error(self):
         """ConfigParseError can be raised and caught."""
-        with pytest.raises(ConfigParseError) as exc_info:
+        with pytest.raises(ConfigParseError, match="YAML syntax error"):
             raise ConfigParseError("YAML syntax error")
-        assert "YAML syntax error" in str(exc_info.value)
 
     def test_config_schema_error(self):
         """ConfigSchemaError can be raised and caught."""
-        with pytest.raises(ConfigSchemaError) as exc_info:
+        with pytest.raises(ConfigSchemaError, match="Schema validation failed"):
             raise ConfigSchemaError("Schema validation failed")
-        assert "Schema validation failed" in str(exc_info.value)
 
     def test_config_version_error(self):
         """ConfigVersionError can be raised and caught."""
-        with pytest.raises(ConfigVersionError) as exc_info:
+        with pytest.raises(ConfigVersionError, match="Unsupported version"):
             raise ConfigVersionError("Unsupported version")
-        assert "Unsupported version" in str(exc_info.value)
 
     def test_variable_resolution_error(self):
         """VariableResolutionError can be raised and caught."""
-        with pytest.raises(VariableResolutionError) as exc_info:
+        with pytest.raises(VariableResolutionError, match="Unresolved variable"):
             raise VariableResolutionError("Unresolved variable")
-        assert "Unresolved variable" in str(exc_info.value)
 
     def test_reference_resolution_error(self):
         """ReferenceResolutionError can be raised and caught."""
-        with pytest.raises(ReferenceResolutionError) as exc_info:
+        with pytest.raises(ReferenceResolutionError, match="Circular reference"):
             raise ReferenceResolutionError("Circular reference")
-        assert "Circular reference" in str(exc_info.value)
 
     def test_inheritance_error(self):
         """InheritanceError can be raised and caught."""
-        with pytest.raises(InheritanceError) as exc_info:
+        with pytest.raises(InheritanceError, match="Cascade failed"):
             raise InheritanceError("Cascade failed")
-        assert "Cascade failed" in str(exc_info.value)
 
     def test_model_validation_error(self):
         """ModelValidationError can be raised and caught."""
-        with pytest.raises(ModelValidationError) as exc_info:
+        with pytest.raises(ModelValidationError, match="Hydration failed for thread"):
             raise ModelValidationError("Hydration failed for thread")
-        assert "Hydration failed for thread" in str(exc_info.value)
 
-    def test_catch_via_base_type(self):
-        """Specific errors catchable via ConfigError."""
+    def test_catch_config_error_via_base(self):
+        """ConfigParseError catchable via ConfigError."""
         with pytest.raises(ConfigError):
             raise ConfigParseError("test")
 
+    def test_catch_config_error_via_weev_error(self):
+        """ConfigSchemaError catchable via WeevError."""
         with pytest.raises(WeevError):
             raise ConfigSchemaError("test")
 
@@ -245,10 +240,12 @@ class TestExecutionError:
         assert "t1" in str(err)
 
     def test_catchable_as_execution_error(self):
-        """SparkError is catchable as ExecutionError and WeevError."""
+        """SparkError is catchable as ExecutionError."""
         with pytest.raises(ExecutionError):
             raise SparkError("spark failure")
 
+    def test_catchable_as_weev_error(self):
+        """SparkError is catchable as WeevError."""
         with pytest.raises(WeevError):
             raise SparkError("spark failure")
 

--- a/tests/weevr/state/test_watermark.py
+++ b/tests/weevr/state/test_watermark.py
@@ -6,9 +6,9 @@ import pytest
 from pydantic import ValidationError
 
 from weevr.model.load import LoadConfig, WatermarkStoreConfig
+from weevr.state import WatermarkState, WatermarkStore, resolve_store
 from weevr.state.metadata_table import MetadataTableStore
 from weevr.state.table_properties import TablePropertiesStore
-from weevr.state.watermark import WatermarkState, WatermarkStore, resolve_store
 
 
 class TestWatermarkState:


### PR DESCRIPTION
## Summary

- Resolve all 13 open CodeQL alerts: 9 unreachable-statement warnings and 4 cyclic-import notes.

## Why

- CodeQL code scanning flags these on every push, adding noise to the security dashboard. The unreachable-statement warnings are false positives (CodeQL doesn't model `pytest.raises`), and the cyclic imports, while safe at runtime due to deferred imports, are a static analysis smell.

## What changed

- **`tests/weevr/errors/test_exceptions.py`**: Replaced 7 post-block `assert` statements with `pytest.raises(match=...)` parameter. Split 2 multi-block raise tests (`test_catch_via_base_type`, `test_catchable_as_execution_error`) into separate methods.
- **`src/weevr/state/watermark.py`**: Removed `resolve_store` function and unused `LoadConfig` TYPE_CHECKING import.
- **`src/weevr/state/__init__.py`**: Now defines `resolve_store` directly, breaking the static import cycle between `watermark`, `table_properties`, and `metadata_table`.
- **`src/weevr/engine/executor.py`**: Updated import to `from weevr.state import ...`.
- **`tests/weevr/state/test_watermark.py`**: Updated import path and fixed isort order.

## How to test

- [x] uv sync --dev
- [x] uv run ruff check .
- [x] uv run ruff format .
- [x] uv run pyright .
- [x] uv run pytest (854 passed, 14 skipped)
- [ ] Verify CodeQL alerts close after merge

## Release / Versioning

- [x] PR title follows Conventional Commit format (feat:, fix:, chore:, docs:, ci:, etc.)
- [ ] Breaking change indicated (feat!: / fix!: or BREAKING CHANGE in body)

## Notes

- Public API is unchanged — `from weevr.state import resolve_store` continues to work.
- The deferred imports inside `resolve_store` remain function-local in `__init__.py` to avoid recreating the cycle.