### PR TITLE
chore(meta): add PyPI metadata for project URLs, keywords, and classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,10 +8,27 @@ authors = [
     { name = "Pierre LaFromboise", email = "44212292+DataInsightPro@users.noreply.github.com" }
 ]
 requires-python = ">=3.11,<3.12"
+keywords = ["spark", "pyspark", "fabric", "etl", "data-pipeline", "yaml", "configuration", "delta-lake"]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Topic :: Database",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Typing :: Typed",
+]
 dependencies = [
     "pydantic>=2.0,<3.0",
     "pyyaml>=6.0,<7.0",
 ]
+
+[project.urls]
+Documentation = "https://ardent-data.github.io/weevr/"
+Repository = "https://github.com/ardent-data/weevr"
+Issues = "https://github.com/ardent-data/weevr/issues"
+Changelog = "https://github.com/ardent-data/weevr/blob/main/CHANGELOG.md"
 
 [build-system]
 requires = ["uv_build>=0.9.28,<0.10.0"]


### PR DESCRIPTION
## Summary

- Add complete PyPI metadata to `pyproject.toml` for improved package discoverability and sidebar links

## Why

- PyPI was not displaying project URLs (docs, repo, issues, changelog) in the sidebar
- Package lacked keywords and classifiers for search and categorization

## What changed

- Added `[project.urls]` with Documentation, Repository, Issues, and Changelog links
- Added `keywords` array with 8 terms (spark, pyspark, fabric, etl, data-pipeline, yaml, configuration, delta-lake)
- Added trove `classifiers` for Development Status (Production/Stable), License, Python version, Topic, and Typing

## How to test

- [x] uv sync --dev
- [x] uv run ruff check .
- [x] uv run ruff format .
- [x] uv run pyright .
- [x] uv run pytest

## Release / Versioning

- [x] PR title follows Conventional Commit format (feat:, fix:, chore:, docs:, ci:, etc.)
- [ ] Breaking change indicated (feat!: / fix!: or BREAKING CHANGE in body)

## Notes

- All 8 classifiers validated against the canonical `trove-classifiers` package
- All 4 URLs verified as reachable
- `Typing :: Typed` classifier backed by existing `src/weevr/py.typed` marker