### PR TITLE
feat(engine): expand hash algorithms and add output mode

### DIFF
--- a/src/weevr/model/keys.py
+++ b/src/weevr/model/keys.py
@@ -36,7 +36,7 @@ class ChangeDetectionConfig(FrozenBase):
         algorithm: Hash algorithm to use. ``crc32`` has a small 32-bit output
             space with higher collision risk. ``murmur3`` (Spark's ``hash()``)
             may produce different results across Spark major versions. Neither
-            is recommended for high-cardinality surrogate key use cases.
+            is recommended for high-cardinality change detection use cases.
         output: Controls the output type for integer-returning algorithms
             (xxhash64, crc32, murmur3). ``native`` preserves the algorithm's
             return type; ``string`` casts to StringType. Has no practical

--- a/src/weevr/operations/hashing.py
+++ b/src/weevr/operations/hashing.py
@@ -1,6 +1,6 @@
 """Hashing operations — surrogate key generation and change detection."""
 
-from pyspark.sql import DataFrame
+from pyspark.sql import Column, DataFrame
 from pyspark.sql import functions as F
 
 from weevr.errors.exceptions import ExecutionError
@@ -91,7 +91,7 @@ def _compute_change_hash(df: DataFrame, config: ChangeDetectionConfig) -> DataFr
     return df.withColumn(config.name, hash_col)
 
 
-def _build_concat_expr(columns: list[str]):  # type: ignore[return]
+def _build_concat_expr(columns: list[str]) -> Column:
     """Build a Spark Column that concatenates the named columns with a separator.
 
     Each column is cast to string and null values are replaced with the sentinel
@@ -101,7 +101,7 @@ def _build_concat_expr(columns: list[str]):  # type: ignore[return]
     return F.concat_ws(_KEY_SEPARATOR, *coerced)
 
 
-def _apply_hash(col_expr, algorithm: str, output: str = "native"):  # type: ignore[return]
+def _apply_hash(col_expr: Column, algorithm: str, output: str = "native") -> Column:
     """Apply the specified hash algorithm to a Column expression.
 
     Note:

--- a/tests/weevr/model/test_keys.py
+++ b/tests/weevr/model/test_keys.py
@@ -67,6 +67,26 @@ class TestChangeDetectionConfig:
         c = ChangeDetectionConfig(name="h", columns=["x"], algorithm="sha256")
         assert c.algorithm == "sha256"
 
+    def test_xxhash64_algorithm(self):
+        """ChangeDetectionConfig accepts xxhash64 algorithm."""
+        c = ChangeDetectionConfig(name="h", columns=["x"], algorithm="xxhash64")
+        assert c.algorithm == "xxhash64"
+
+    def test_output_default_native(self):
+        """ChangeDetectionConfig defaults output to native."""
+        c = ChangeDetectionConfig(name="h", columns=["x"])
+        assert c.output == "native"
+
+    def test_output_string(self):
+        """ChangeDetectionConfig accepts string output."""
+        c = ChangeDetectionConfig(name="h", columns=["x"], algorithm="xxhash64", output="string")
+        assert c.output == "string"
+
+    def test_invalid_algorithm_raises(self):
+        """Unknown algorithm raises ValidationError."""
+        with pytest.raises(ValidationError):
+            ChangeDetectionConfig(name="h", columns=["x"], algorithm="blake2")  # type: ignore[arg-type]
+
     def test_frozen(self):
         """ChangeDetectionConfig is immutable."""
         c = ChangeDetectionConfig(name="h", columns=["x"])

--- a/tests/weevr/operations/test_hashing.py
+++ b/tests/weevr/operations/test_hashing.py
@@ -295,6 +295,28 @@ class TestChangeDetection:
         lengths = {len(r["ch"]) for r in result.collect()}
         assert lengths == {40}
 
+    def test_change_hash_sha384(self, people_df) -> None:
+        keys = KeyConfig(
+            change_detection=ChangeDetectionConfig(
+                name="ch", columns=["first", "dept"], algorithm="sha384"
+            )
+        )
+        result = compute_keys(people_df, keys)
+        assert "ch" in result.columns
+        lengths = {len(r["ch"]) for r in result.collect()}
+        assert lengths == {96}
+
+    def test_change_hash_sha512(self, people_df) -> None:
+        keys = KeyConfig(
+            change_detection=ChangeDetectionConfig(
+                name="ch", columns=["first", "dept"], algorithm="sha512"
+            )
+        )
+        result = compute_keys(people_df, keys)
+        assert "ch" in result.columns
+        lengths = {len(r["ch"]) for r in result.collect()}
+        assert lengths == {128}
+
     def test_change_hash_crc32(self, people_df) -> None:
         keys = KeyConfig(
             change_detection=ChangeDetectionConfig(name="ch", columns=["dept"], algorithm="crc32")
@@ -302,12 +324,30 @@ class TestChangeDetection:
         result = compute_keys(people_df, keys)
         assert result.schema["ch"].dataType == LongType()
 
+    def test_change_hash_crc32_string_output(self, people_df) -> None:
+        keys = KeyConfig(
+            change_detection=ChangeDetectionConfig(
+                name="ch", columns=["dept"], algorithm="crc32", output="string"
+            )
+        )
+        result = compute_keys(people_df, keys)
+        assert result.schema["ch"].dataType == StringType()
+
     def test_change_hash_murmur3(self, people_df) -> None:
         keys = KeyConfig(
             change_detection=ChangeDetectionConfig(name="ch", columns=["dept"], algorithm="murmur3")
         )
         result = compute_keys(people_df, keys)
         assert result.schema["ch"].dataType == IntegerType()
+
+    def test_change_hash_murmur3_string_output(self, people_df) -> None:
+        keys = KeyConfig(
+            change_detection=ChangeDetectionConfig(
+                name="ch", columns=["dept"], algorithm="murmur3", output="string"
+            )
+        )
+        result = compute_keys(people_df, keys)
+        assert result.schema["ch"].dataType == StringType()
 
 
 class TestComputeKeysCombined:


### PR DESCRIPTION
## Summary

- Expand supported hash algorithms from {sha256, md5} to {xxhash64, sha1, sha256, sha384, sha512, md5, crc32, murmur3}
- Add an `output` option (`native`/`string`) so integer-returning algorithms like xxhash64 can keep their native type or be cast to string
- Full type annotations and symmetric test coverage across both config classes

## Why

- xxhash64 is significantly faster than SHA-256 for non-cryptographic use cases like surrogate key generation and change detection
- crc32 and murmur3 are useful for partitioning and bucketing scenarios
- The `output` field gives users control over whether integer hashes stay as LongType/IntegerType or are cast to StringType for consistency with existing string-based hashes

## What changed

- `src/weevr/model/keys.py` — expanded `algorithm` Literal types on `SurrogateKeyConfig` and `ChangeDetectionConfig`, added `output` field with docstrings noting crc32/murmur3 limitations
- `src/weevr/operations/hashing.py` — added hash function branches for all 8 algorithms, `output` parameter passthrough, `Column` type annotations on internal helpers
- `tests/weevr/operations/test_hashing.py` — 16 new integration tests covering all algorithms and output modes for both surrogate keys and change detection
- `tests/weevr/model/test_keys.py` — 8 new model-level tests for algorithm acceptance, output field defaults, and invalid algorithm rejection on both config classes

## How to test

- [x] uv sync --dev
- [x] uv run ruff check .
- [x] uv run ruff format .
- [x] uv run pyright .
- [x] uv run pytest (1173 passed, 44 skipped)

## Release / Versioning

- [x] PR title follows Conventional Commit format (feat:, fix:, chore:, docs:, ci:, etc.)
- [ ] Breaking change indicated (feat!: / fix!: or BREAKING CHANGE in body)

## Notes

- Defaults preserved: `sha256` for surrogate keys, `md5` for change detection — existing configs work without changes
- `output` defaults to `native`, which is a no-op for sha*/md5 (already return strings)
- Docstrings note that crc32 (32-bit) has higher collision risk and murmur3 (Spark `hash()`) may vary across Spark major versions