### PR TITLE
chore(devcontainer): modernise features and fix Claude Code installer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,13 +6,16 @@
     "features": {
         "ghcr.io/devcontainers/features/common-utils:2": {},
         "ghcr.io/devcontainers/features/github-cli:1": {},
+        "ghcr.io/devcontainers/features/copilot-cli:1": {},
         "ghcr.io/devcontainers/features/node:1": {},
         "ghcr.io/devcontainers/features/java:1": {
             "version": "17.0.12-tem"
         },
         "ghcr.io/jsburckhardt/devcontainer-features/uv:1": {},
-        "ghcr.io/anthropics/devcontainer-features/claude-code:1": {},
-        "ghcr.io/jsburckhardt/devcontainer-features/codex:1": {}
+        "ghcr.io/jsburckhardt/devcontainer-features/codex:1": {},
+        "ghcr.io/ksh5022/devcontainer-features/d2:1": {},
+        "ghcr.io/devcontainers-extra/features/actionlint:1": {},
+        "ghcr.io/devcontainers-extra/features/shellcheck:1": {}
     },
 
     "mounts": [
@@ -24,8 +27,7 @@
         "source=${localEnv:USERPROFILE}/.codex,target=/home/vscode/.codex,type=bind,consistency=cached"
     ],
 
-    // Sync all dev dependencies (including pyspark + delta-spark) on first open.
-    "postCreateCommand": "uv sync --dev",
+    "postCreateCommand": "git config --global --add safe.directory /workspaces/weevr && curl -fsSL https://claude.ai/install.sh | sh && uv sync --dev",
 
     // Keep the venv current on every container start (not just first create).
     "postStartCommand": "uv sync",


### PR DESCRIPTION
## Summary

- Replace deprecated `claude-code` devcontainer feature (npm-based) with the Claude native installer
- Fix git dubious ownership error on container create
- Add GitHub Copilot CLI, D2, actionlint, and shellcheck features

## Why

- The `ghcr.io/anthropics/devcontainer-features/claude-code:1` feature installs via npm, which is deprecated and blocks updating to the latest Claude version
- The workspace directory ownership mismatch in devcontainers triggers a git safe.directory error without an explicit config step
- D2 is required for `mkdocs build --strict` to succeed (multiple docs pages use D2 diagrams)
- actionlint and shellcheck provide static analysis for the 6 GitHub Actions workflows and `.claude/hooks/` scripts

## What changed

- Removed `ghcr.io/anthropics/devcontainer-features/claude-code:1` feature
- Added `curl -fsSL https://claude.ai/install.sh | sh` to `postCreateCommand` for native Claude installation
- Added `git config --global --add safe.directory /workspaces/weevr` to `postCreateCommand`
- Added `ghcr.io/devcontainers/features/copilot-cli:1`
- Added `ghcr.io/ksh5022/devcontainer-features/d2:1`
- Added `ghcr.io/devcontainers-extra/features/actionlint:1`
- Added `ghcr.io/devcontainers-extra/features/shellcheck:1`

## How to test

- [ ] Rebuild the devcontainer and verify Claude Code installs successfully via native installer
- [ ] Verify `git status` works without safe.directory errors on container create
- [ ] Verify `gh copilot` is available
- [ ] Verify `d2 --version` is available and `uv run mkdocs build --strict` succeeds
- [ ] Verify `actionlint` and `shellcheck` are available on PATH

## Release / Versioning

- [x] PR title follows Conventional Commit format (`chore:` — no release triggered)
- [ ] Breaking change indicated (feat!: / fix!: or BREAKING CHANGE in body)

## Notes

- No source code changes; devcontainer only
- Existing mounts for `~/.claude`, `~/.codex`, and `~/.config/gh` are unchanged