### PR TITLE
chore: pin d2 devcontainer feature to v0.7.1

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,9 @@
         },
         "ghcr.io/jsburckhardt/devcontainer-features/uv:1": {},
         "ghcr.io/jsburckhardt/devcontainer-features/codex:1": {},
-        "ghcr.io/ksh5022/devcontainer-features/d2:1": {},
+        "ghcr.io/ksh5022/devcontainer-features/d2:1": {
+            "version": "0.7.1"
+        },
         "ghcr.io/devcontainers-extra/features/actionlint:1": {},
         "ghcr.io/devcontainers-extra/features/shellcheck:1": {}
     },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,14 @@
   "workbench.colorCustomizations": {
     "activityBar.background": "#0F323B",
     "titleBar.activeBackground": "#154553",
-    "titleBar.activeForeground": "#F7FCFD"
+    "titleBar.activeForeground": "#F7FCFD",
+    "titleBar.inactiveBackground": "#0F323B",
+    "titleBar.inactiveForeground": "#F7FCFD",
+    "statusBar.background": "#0F323B",
+    "statusBar.foreground": "#F7FCFD",
+    "statusBar.debuggingBackground": "#0F323B",
+    "statusBar.debuggingForeground": "#F7FCFD",
+    "statusBar.noFolderBackground": "#0F323B",
+    "statusBar.noFolderForeground": "#F7FCFD"
   }
 }


### PR DESCRIPTION
## Summary

- Pin D2 devcontainer feature to explicit version `v0.7.1` to avoid transient GitHub API failures when resolving `latest` tag

## Why

- The D2 feature's install script queries GitHub to resolve `D2_VERSION=latest`, which failed with a 500 error during container builds
- Pinning to an explicit version makes the build deterministic and avoids external API queries that can transienctly fail

## What changed

- Updated `.devcontainer/devcontainer.json` to specify `"version": "0.7.1"` for the D2 feature instead of relying on `latest`

## How to test

- [ ] uv sync --dev
- [ ] uv run ruff check .
- [ ] uv run ruff format .
- [ ] uv run pyright .
- [ ] uv run pytest
- [ ] Rebuild devcontainer and verify D2 is available: `d2 --version`

## Release / Versioning

- [x] PR title follows Conventional Commit format (`chore:`)
- [ ] Breaking change indicated (not applicable)

## Notes

- GitHub's D2 repository experienced a transient 500 error; pinning the version is a more robust approach for container builds