### PR TITLE
chore: fix devcontainer postCreateCommand to use bash for Claude Code installer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,7 +29,7 @@
         "source=${localEnv:USERPROFILE}/.codex,target=/home/vscode/.codex,type=bind,consistency=cached"
     ],
 
-    "postCreateCommand": "git config --global --add safe.directory /workspaces/weevr && curl -fsSL https://claude.ai/install.sh | sh && uv sync --dev",
+    "postCreateCommand": "git config --global --add safe.directory /workspaces/weevr && curl -fsSL https://claude.ai/install.sh | bash && uv sync --dev",
 
     // Keep the venv current on every container start (not just first create).
     "postStartCommand": "uv sync",


### PR DESCRIPTION
## Summary

- Fixed `postCreateCommand` in devcontainer.json to pipe the Claude Code installer script to `bash` instead of `sh`

## Why

- The Claude Code installer script uses bash-specific syntax that is not compatible with POSIX shell (`sh`)
- The original command failed with "Syntax error: "(" unexpected" because `sh` doesn't support bash features like process substitution and other advanced syntax

## What changed

- Changed `postCreateCommand` to pipe installer to `bash` instead of `sh`:
  - Before: `curl -fsSL https://claude.ai/install.sh | sh`
  - After: `curl -fsSL https://claude.ai/install.sh | bash`

## How to test

- [ ] Rebuild devcontainer
- [ ] Verify Claude Code installer completes without syntax errors
- [ ] Confirm `gh auth login` works for GitHub authentication
- [ ] Verify venv is created at `/home/vscode/.venv`

## Release / Versioning

- [x] PR title follows Conventional Commit format (chore:)
- [ ] Breaking change indicated (no breaking changes)

## Notes

- This is a dev environment setup fix with no user-facing impact