### PR TITLE
chore(docs): update reference docs for hooks, lookups, and hash algorithms

### DIFF
--- a/docs/concepts/thread-weave-loom.md
+++ b/docs/concepts/thread-weave-loom.md
@@ -51,7 +51,7 @@ A thread encapsulates:
 
 ```yaml
 # dimensions/dim_customer.thread
-config_version: "1"
+config_version: "1.0"
 sources:
   customers:
     type: delta
@@ -97,7 +97,7 @@ Key responsibilities:
 
 ```yaml
 # dimensions.weave
-config_version: "1"
+config_version: "1.0"
 threads:
   - ref: dimensions/dim_customer.thread
   - ref: dimensions/dim_product.thread
@@ -124,7 +124,7 @@ Key responsibilities:
 
 ```yaml
 # nightly.loom
-config_version: "1"
+config_version: "1.0"
 weaves:
   - ref: dimensions.weave
   - ref: facts.weave

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -84,14 +84,13 @@ explanation.
 
 ## What write modes are supported?
 
-weevr supports four write modes:
+weevr supports three write modes:
 
 | Mode           | Behavior |
 |----------------|----------|
 | `overwrite`    | Replace the entire target table (default) |
 | `append`       | Insert new rows without modifying existing data |
 | `merge`        | Upsert: match on keys, update/insert/delete as configured |
-| `insert_only`  | Insert rows that do not already exist in the target |
 
 Merge mode is the most configurable, with separate controls for
 `on_match`, `on_no_match_target`, and `on_no_match_source` behaviors
@@ -225,27 +224,76 @@ participate in joins as expected.
 
 ## Can I cache lookup tables?
 
-Yes. weevr's `CacheManager` handles caching automatically within a weave
-execution. When the DAG analysis detects that a thread's output feeds
-multiple downstream consumers, it persists the output at
-`MEMORY_AND_DISK` storage level after the producing thread completes.
+Yes. There are two approaches:
 
-You can also force caching on a specific thread:
+**Thread-level auto-caching** — The `CacheManager` analyzes the thread
+dependency DAG within a weave. When it detects that a thread's output
+feeds multiple downstream consumers, it persists the output at
+`MEMORY_AND_DISK` level automatically. You can force caching on a
+specific thread with `cache: true` or disable it with `cache: false`.
+
+**Weave-level lookups** — Define named lookups in the weave's `lookups`
+block. Lookups can be pre-materialized (read once, cached or broadcast
+before threads run) and shared across threads via the `lookup` source
+field:
 
 ```yaml
-cache: true
+# In the weave
+lookups:
+  dim_product:
+    source:
+      type: delta
+      alias: silver.dim_product
+    materialize: true
+    strategy: cache
+    key: [product_id]
+    values: [product_name, category]
+
+# In a thread's sources
+sources:
+  products:
+    lookup: dim_product
 ```
 
-Or disable auto-caching for a thread whose output is too large to hold
-in memory:
+Narrow lookups (`key`, `values`, `filter`) reduce memory by retaining
+only the columns needed for the join. See
+[Cache a Lookup](how-to/cache-a-lookup.md) for the full guide.
+
+---
+
+## What are execution hooks?
+
+Hooks are steps that run before or after thread execution within a weave.
+Define them with `pre_steps` (run before any thread) and `post_steps`
+(run after all threads complete).
+
+Three hook step types are available:
+
+| Type | Purpose |
+|------|---------|
+| `quality_gate` | Run predefined quality checks (source freshness, row counts, table existence, expressions) |
+| `sql_statement` | Execute arbitrary Spark SQL. Optionally capture a scalar result into a weave variable. |
+| `log_message` | Emit a log message with variable placeholders |
+
+Each step has an `on_failure` policy (`abort` or `warn`). Pre-steps
+default to `abort`; post-steps default to `warn`.
 
 ```yaml
-cache: false
+pre_steps:
+  - type: quality_gate
+    check: source_freshness
+    source: raw.orders
+    max_age: "24h"
+
+post_steps:
+  - type: log_message
+    message: "Pipeline complete."
 ```
 
-Cache failures are non-fatal -- consumers fall back to reading from Delta
-directly. See [Cache a Lookup](how-to/cache-a-lookup.md) for the full
-configuration guide.
+See the [Weave YAML Schema](reference/yaml-schema/weave.md) for the full
+field reference.
+
+---
 
 ---
 

--- a/docs/guides/config-resolution.md
+++ b/docs/guides/config-resolution.md
@@ -6,10 +6,11 @@ that parses, validates, resolves, inherits, and hydrates configuration.
 
 ## Introduction
 
-A single call to `load_config()` drives the entire pipeline. The stages are
-designed to fail fast — syntax errors are caught before variable resolution,
-schema errors before reference loading, and semantic constraints after all
-values are concrete.
+When you call `Context.run()` or `Context.load()`, weevr runs the full
+config resolution pipeline internally. The stages are designed to fail
+fast — syntax errors are caught before variable resolution, schema errors
+before reference loading, and semantic constraints after all values are
+concrete.
 
 ## Key concepts
 

--- a/docs/guides/engine-internals.md
+++ b/docs/guides/engine-internals.md
@@ -82,31 +82,45 @@ Thread execution is orchestrated at two levels:
 
 **Loom level** (`execute_loom`) — Iterates weaves in declared order. Each weave
 gets its own plan and executor pass. Weave-level conditions are evaluated before
-planning; a false condition skips the entire weave.
+planning; a false condition skips the entire weave. If a weave's status is
+`"failure"`, the loom stops executing further weaves — remaining weaves are
+skipped.
 
-**Weave level** (`execute_weave`) — Processes parallel groups sequentially.
-Within each group, threads are submitted to a `ThreadPoolExecutor` for
-concurrent execution. After each thread completes:
+**Weave level** (`execute_weave`) — Orchestrates the full weave lifecycle:
+
+1. **Pre-steps** — If the weave defines `pre_steps`, hook steps run before
+   any thread executes. Failures with `on_failure: abort` stop the weave.
+2. **Lookup materialization** — Named lookups are pre-read and cached or
+   broadcast according to their `strategy`. Threads reference lookups via
+   `source.lookup` and receive the cached DataFrame.
+3. **Thread execution** — Parallel groups are processed sequentially. Within
+   each group, threads are submitted to a `ThreadPoolExecutor` for concurrent
+   execution.
+4. **Post-steps** — After all threads complete, `post_steps` hook steps run.
+   Failures with `on_failure: abort` mark the weave as failed.
+
+After each thread completes:
 
 - If it is a cache target, the output DataFrame is persisted.
 - Consumer reference counts are decremented; caches are unpersisted when no
   consumers remain.
 - Thread-level telemetry collectors are merged into the weave collector.
 
-**Thread level** (`execute_thread`) — A single thread runs through an 11-step
+**Thread level** (`execute_thread`) — A single thread runs through a 12-step
 pipeline:
 
-1. Read all declared sources (with watermark/CDC filtering if applicable)
-2. Set the primary source as the working DataFrame
-3. Run transform steps sequentially
-4. Evaluate validation rules; quarantine or abort on failures
-5. Apply column naming normalization
+1. Resolve lookup-based sources from cached or on-demand DataFrames
+2. Read all remaining declared sources (with watermark/CDC filtering if applicable)
+3. Set the primary (first) source as the working DataFrame
+4. Run pipeline steps against the working DataFrame
+5. Evaluate validation rules; quarantine or abort on failures
 6. Compute business keys and change detection hashes
-7. Apply target column mapping
-8. Write to the Delta target (standard write or CDC merge routing)
-9. Persist watermark or CDC state
-10. Run post-write assertions
-11. Build telemetry and return `ThreadResult`
+7. Resolve the target write path
+8. Apply target column mapping
+9. Write to the Delta target (standard write or CDC merge routing)
+10. Persist watermark or CDC state
+11. Run post-write assertions
+12. Build telemetry and return `ThreadResult`
 
 ### Failure handling
 
@@ -124,8 +138,8 @@ Transitive dependents are computed via BFS over the reverse dependency graph.
 
 The `CacheManager` uses reference counting to manage in-memory DataFrames:
 
-1. When a cache-target thread completes, its output is read from Delta and
-   persisted at `MEMORY_AND_DISK` level.
+1. When a cache-target thread completes, its output DataFrame is persisted
+   directly at `MEMORY_AND_DISK` level (no re-read from Delta).
 2. Each downstream consumer calls `notify_complete()` after finishing, which
    decrements the consumer count.
 3. When the count reaches zero, the cached DataFrame is automatically
@@ -146,6 +160,9 @@ without the cache optimization.
 | `engine/result.py` | Immutable result models: `ThreadResult`, `WeaveResult`, `LoomResult` |
 | `engine/cache_manager.py` | Reference-counted DataFrame caching |
 | `engine/conditions.py` | Condition evaluation: parameter resolution, built-in functions, boolean parsing |
+| `engine/hooks.py` | Pre/post hook step execution: quality gates, SQL statements, log messages |
+| `engine/lookups.py` | Lookup materialization: pre-read, narrow projection, caching/broadcast |
+| `engine/variables.py` | Weave-scoped variable binding and resolution |
 
 ## Design decisions
 

--- a/docs/how-to/cache-a-lookup.md
+++ b/docs/how-to/cache-a-lookup.md
@@ -94,6 +94,78 @@ This overrides the engine's auto-cache decision for that specific thread.
 - **Scope:** Caching operates within a single weave execution. Cached
   DataFrames do not persist across weave boundaries or Spark sessions.
 
+## Step 4 -- Use weave-level lookups
+
+For shared reference datasets, weave-level lookups provide more control than
+thread-level caching. Define the lookup in the weave's `lookups` block and
+reference it from thread sources:
+
+```yaml
+# orders.weave
+config_version: "1.0"
+
+lookups:
+  dim_product:
+    source:
+      type: delta
+      alias: silver.dim_product
+    materialize: true
+    strategy: cache
+
+threads:
+  - ref: facts/fact_orders.thread
+  - ref: facts/fact_returns.thread
+```
+
+```yaml
+# facts/fact_orders.thread — references the lookup
+sources:
+  orders:
+    type: delta
+    alias: raw.orders
+  products:
+    lookup: dim_product   # resolved from the weave's lookups map
+
+steps:
+  - join:
+      source: products
+      type: left
+      on: [product_id]
+```
+
+The lookup is read once before threads start and shared across all threads
+that reference it. Choose `strategy: broadcast` for small datasets that
+benefit from Spark broadcast join hints, or `strategy: cache` (the default)
+for larger datasets.
+
+## Step 5 -- Narrow a lookup for efficiency
+
+When a lookup table has many columns but threads only need a few, use narrow
+lookup fields to reduce memory:
+
+```yaml
+lookups:
+  dim_product:
+    source:
+      type: delta
+      alias: silver.dim_product
+    materialize: true
+    key: [product_id]
+    values: [product_name, category]
+    filter: "is_active = true"
+    unique_key: true
+```
+
+| Field | Purpose |
+|-------|---------|
+| `key` | Join key columns — always retained in the projection |
+| `values` | Payload columns to keep. Only `key` + `values` columns are cached. |
+| `filter` | SQL WHERE expression applied before projection |
+| `unique_key` | Validate that `key` columns are unique after filtering |
+| `on_failure` | Behavior on duplicate keys: `"abort"` (default) or `"warn"` |
+
+`key` and `values` must not overlap. If `values` is set, `key` is required.
+
 ## Verify caching behavior
 
 Use `verbose` or `debug` log level to see cache lifecycle events in the

--- a/docs/reference/api/context.md
+++ b/docs/reference/api/context.md
@@ -2,9 +2,20 @@
 
 The `Context` class is the primary entry point for running weevr pipelines.
 It manages configuration loading, parameter injection, and orchestrates
-thread, weave, and loom execution.
+thread, weave, and loom execution. The `run()` method returns a `RunResult`,
+and `load()` returns a `LoadedConfig` — both documented below.
 
 ::: weevr.context
+    options:
+      members: true
+      show_root_heading: true
+      show_source: false
+
+---
+
+## Result Types
+
+::: weevr.result
     options:
       members: true
       show_root_heading: true

--- a/docs/reference/api/engine.md
+++ b/docs/reference/api/engine.md
@@ -2,7 +2,9 @@
 
 The `weevr.engine` module contains the execution planner and executor. It
 resolves the thread dependency DAG, schedules execution order, and runs each
-thread through its read-transform-write lifecycle.
+thread through its read-transform-write lifecycle. The engine also handles
+pre/post weave hooks, lookup pre-materialization, conditional thread
+execution, and weave-scoped variable binding.
 
 ::: weevr.engine
     options:

--- a/docs/reference/api/errors.md
+++ b/docs/reference/api/errors.md
@@ -32,10 +32,12 @@ WeevError: WeevError {
     ReferenceResolutionError
     InheritanceError
     ModelValidationError
+    LookupResolutionError
   }
   ExecutionError: ExecutionError {
     SparkError
     StateError
+    HookError
   }
   DataValidationError
 }
@@ -322,6 +324,46 @@ result = ctx.run("daily.loom", mode="validate")
 
 ---
 
+### LookupResolutionError
+
+Raised when a thread references a lookup name that is not defined in the
+weave's `lookups` map. This is a fail-fast validation error caught during
+config resolution, before any data is read.
+
+**Common causes:**
+
+- Typo in the `lookup` field of a source definition
+- Thread uses `lookup: foo` but the weave does not declare a `foo` entry
+  in its `lookups` block
+- Thread was moved to a different weave that does not define the lookup
+
+**Resolution:**
+
+1. Check that the lookup name in the thread's source matches a key in the
+   weave's `lookups` block
+2. Verify the thread is referenced by the correct weave
+3. If the lookup was renamed, update all thread references
+
+**Example:**
+
+```yaml
+# Thread source references a lookup
+sources:
+  products:
+    lookup: dim_product   # must exist in the weave's lookups
+
+# Weave must define it
+lookups:
+  dim_product:            # matches the thread's lookup reference
+    source:
+      type: delta
+      alias: silver.dim_product
+```
+
+**Related:** [YAML Schema: Weave](../yaml-schema/weave.md)
+
+---
+
 ### ExecutionError
 
 Base exception for runtime execution failures. Carries optional context:
@@ -404,6 +446,53 @@ target:
 
 **Related:** [Idempotency](../../concepts/idempotency.md),
 [Execution Modes](../../concepts/execution-modes.md)
+
+---
+
+### HookError
+
+Raised when a hook step (in `pre_steps` or `post_steps`) fails and its
+`on_failure` policy is set to `abort`. Carries hook-specific context:
+`hook_name`, `hook_type`, and `phase`.
+
+**Common causes:**
+
+- A `quality_gate` check failed (e.g., source freshness exceeded
+  `max_age`, row count outside bounds, table does not exist)
+- A `sql_statement` hook produced an error
+- An `expression` quality gate evaluated to false
+
+**Resolution:**
+
+1. Check the error message for the hook name and phase (`pre` or `post`)
+2. For quality gate failures, verify the underlying data condition
+   (source freshness, row counts, table existence)
+3. To make the hook non-blocking, set `on_failure: warn` instead of
+   `abort`
+4. For SQL statement errors, test the SQL directly in Spark
+
+**Example:**
+
+```yaml
+pre_steps:
+  # This will raise HookError if the source is older than 24h
+  - type: quality_gate
+    name: check_freshness
+    check: source_freshness
+    source: raw.orders
+    max_age: "24h"
+    on_failure: abort    # raise HookError on failure
+
+  # Change to warn to log the issue without aborting
+  - type: quality_gate
+    name: check_freshness
+    check: source_freshness
+    source: raw.orders
+    max_age: "24h"
+    on_failure: warn     # log warning and continue
+```
+
+**Related:** [YAML Schema: Weave](../yaml-schema/weave.md)
 
 ---
 

--- a/docs/reference/api/model.md
+++ b/docs/reference/api/model.md
@@ -2,7 +2,7 @@
 
 The `weevr.model` package contains all Pydantic domain models that represent
 the configuration structure -- threads, weaves, looms, pipeline steps, sources,
-targets, and supporting types.
+targets, hooks, lookups, and supporting types.
 
 ::: weevr.model
     options:

--- a/docs/reference/api/operations.md
+++ b/docs/reference/api/operations.md
@@ -1,8 +1,8 @@
 # Operations API
 
 The `weevr.operations` module implements the concrete readers, transformation
-steps, and writers that the engine dispatches to. Each pipeline step type maps
-to an operation function.
+steps, writers, and quality gates that the engine dispatches to. Each pipeline
+step type maps to an operation function.
 
 ::: weevr.operations
     options:

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -3,6 +3,8 @@
 weevr is designed to run within the Microsoft Fabric runtime. The table below
 lists the tested and supported versions for each dependency.
 
+Last validated against weevr **1.2.0**.
+
 ## Runtime matrix
 
 | Component | Version | Notes |

--- a/docs/reference/configuration-keys.md
+++ b/docs/reference/configuration-keys.md
@@ -14,7 +14,7 @@ data_flow: Data Flow {
     shape: class
     config_version: str
     sources: "dict[str, Source]"
-    pipeline_steps: "list[Step]"
+    step_list: "list[Step]"
     target: Target
   }
   Source: Source {
@@ -22,6 +22,7 @@ data_flow: Data Flow {
     type: str
     alias: str
     path: str
+    lookup: str
   }
   Target: Target {
     shape: class
@@ -32,6 +33,24 @@ data_flow: Data Flow {
 
   Thread -> Source: "1..*" {style.stroke: "#1976D2"}
   Thread -> Target: "1..1" {style.stroke: "#1976D2"}
+}
+
+orchestration: Orchestration {
+  Weave: Weave {
+    shape: class
+    threads: "list[ThreadEntry]"
+    lookups: "dict[str, Lookup]"
+    pre_steps: "list[HookStep]"
+    post_steps: "list[HookStep]"
+    variables: "dict[str, VariableSpec]"
+  }
+  Loom: Loom {
+    shape: class
+    weaves: "list[WeaveEntry]"
+    defaults: dict
+  }
+  Loom -> Weave: "1..*" {style.stroke: "#7B1FA2"}
+  Weave -> data_flow.Thread: "1..*" {style.stroke: "#7B1FA2"}
 }
 
 behavior: Behavior {
@@ -99,11 +118,14 @@ The top-level configuration unit for a single data pipeline.
 
 ## Source
 
-A data source declaration referenced by alias within a thread.
+A data source declaration referenced by alias within a thread. A source
+is either a direct data reference (with `type`) or a lookup reference
+(with `lookup`). These are mutually exclusive.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `type` | `str` | *required* | Source type: `delta`, `csv`, `json`, `parquet`, `excel` |
+| `type` | `str` | conditional | Source type: `delta`, `csv`, `json`, `parquet`, `excel`. Required when `lookup` is not set. |
+| `lookup` | `str` | `None` | Weave-level lookup name. Mutually exclusive with `type`. |
 | `alias` | `str` | `None` | Table alias (required for `delta`) |
 | `path` | `str` | `None` | File path (required for file-based types) |
 | `options` | `dict[str, Any]` | `{}` | Spark reader options |
@@ -207,7 +229,8 @@ Business key, surrogate key, and change detection settings.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `name` | `str` | *required* | Output column name |
-| `algorithm` | `"sha256" \| "md5"` | `"sha256"` | Hash algorithm |
+| `algorithm` | `"xxhash64" \| "sha1" \| "sha256" \| "sha384" \| "sha512" \| "md5" \| "crc32" \| "murmur3"` | `"sha256"` | Hash algorithm |
+| `output` | `"native" \| "string"` | `"native"` | Output type for integer-returning algorithms (xxhash64, crc32, murmur3). `native` preserves the return type; `string` casts to StringType. |
 
 ### ChangeDetectionConfig
 
@@ -215,7 +238,8 @@ Business key, surrogate key, and change detection settings.
 |-------|------|---------|-------------|
 | `name` | `str` | *required* | Output column name |
 | `columns` | `list[str]` | *required* | Columns included in the hash |
-| `algorithm` | `"md5" \| "sha256"` | `"md5"` | Hash algorithm |
+| `algorithm` | `"xxhash64" \| "sha1" \| "sha256" \| "sha384" \| "sha512" \| "md5" \| "crc32" \| "murmur3"` | `"md5"` | Hash algorithm |
+| `output` | `"native" \| "string"` | `"native"` | Output type for integer-returning algorithms. `native` preserves the return type; `string` casts to StringType. |
 
 ---
 
@@ -294,3 +318,138 @@ Column and table naming normalization. Cascades through loom/weave/thread/target
 Supported `NamingPattern` values: `snake_case`, `camelCase`, `PascalCase`,
 `UPPER_SNAKE_CASE`, `Title_Snake_Case`, `Title Case`, `lowercase`, `UPPERCASE`,
 `none`.
+
+---
+
+## Weave
+
+A collection of threads with shared lookups, hooks, and defaults.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `config_version` | `str` | *required* | Schema version identifier |
+| `name` | `str` | `""` | Weave name |
+| `threads` | `list[ThreadEntry]` | *required* | Thread references |
+| `lookups` | `dict[str, Lookup]` | `None` | Named lookup sources shared across threads |
+| `variables` | `dict[str, VariableSpec]` | `None` | Weave-scoped typed variables |
+| `pre_steps` | `list[HookStep]` | `None` | Hook steps run before threads |
+| `post_steps` | `list[HookStep]` | `None` | Hook steps run after threads |
+| `defaults` | `dict[str, Any]` | `None` | Default values cascaded to threads |
+| `params` | `dict[str, ParamSpec]` | `None` | Parameter declarations |
+| `execution` | `ExecutionConfig` | `None` | Runtime settings cascaded to threads |
+| `naming` | `NamingConfig` | `None` | Naming normalization cascaded to threads |
+
+### ThreadEntry
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | `str` | `""` | Thread name (required for inline definitions) |
+| `ref` | `str` | `None` | Path to an external `.thread` file |
+| `dependencies` | `list[str]` | `None` | Explicit upstream thread names |
+| `condition` | `ConditionSpec` | `None` | Conditional execution gate |
+
+### ConditionSpec
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `when` | `str` | *required* | Condition expression. Supports `${param.x}` references, `table_exists()`, `table_empty()`, `row_count()`, and boolean operators. |
+
+---
+
+## Loom
+
+Deployment unit grouping one or more weaves.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `config_version` | `str` | *required* | Schema version identifier |
+| `name` | `str` | `""` | Loom name |
+| `weaves` | `list[WeaveEntry]` | *required* | Weave references |
+| `defaults` | `dict[str, Any]` | `None` | Default values cascaded to weaves and threads |
+| `params` | `dict[str, ParamSpec]` | `None` | Parameter declarations |
+| `execution` | `ExecutionConfig` | `None` | Runtime settings cascaded down |
+| `naming` | `NamingConfig` | `None` | Naming normalization cascaded down |
+
+### WeaveEntry
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | `str` | `""` | Weave name (required for inline definitions) |
+| `ref` | `str` | `None` | Path to an external `.weave` file |
+| `condition` | `ConditionSpec` | `None` | Conditional execution gate |
+
+---
+
+## Lookup
+
+A weave-level named data definition referenced by threads via `source.lookup`.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `source` | `Source` | *required* | Source definition for the lookup data |
+| `materialize` | `bool` | `False` | Pre-read and cache/broadcast before thread execution |
+| `strategy` | `"broadcast" \| "cache"` | `"cache"` | Materialization strategy |
+| `key` | `list[str]` | `None` | Join key columns for narrow projection |
+| `values` | `list[str]` | `None` | Payload columns to retain (requires `key`) |
+| `filter` | `str` | `None` | SQL WHERE expression applied before projection |
+| `unique_key` | `bool` | `False` | Validate key uniqueness after filtering |
+| `on_failure` | `"abort" \| "warn"` | `"abort"` | Behavior on duplicate keys (only valid when `unique_key` is true) |
+
+---
+
+## HookStep
+
+Discriminated union of hook step types, dispatched on the `type` field.
+Used in weave `pre_steps` and `post_steps`.
+
+### QualityGateStep
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `type` | `"quality_gate"` | *required* | Step type discriminator |
+| `name` | `str` | `None` | Step name for telemetry |
+| `on_failure` | `"abort" \| "warn"` | phase default | Failure behavior |
+| `check` | `str` | *required* | Check type: `source_freshness`, `row_count_delta`, `row_count`, `table_exists`, `expression` |
+| `source` | `str` | `None` | Table alias (for `source_freshness`, `table_exists`) |
+| `max_age` | `str` | `None` | Duration string (for `source_freshness`) |
+| `target` | `str` | `None` | Table alias (for `row_count_delta`, `row_count`) |
+| `max_decrease_pct` | `float` | `None` | Max decrease % (for `row_count_delta`) |
+| `max_increase_pct` | `float` | `None` | Max increase % (for `row_count_delta`) |
+| `min_delta` | `int` | `None` | Min absolute row change (for `row_count_delta`) |
+| `max_delta` | `int` | `None` | Max absolute row change (for `row_count_delta`) |
+| `min_count` | `int` | `None` | Min row count (for `row_count`) |
+| `max_count` | `int` | `None` | Max row count (for `row_count`) |
+| `sql` | `str` | `None` | SQL expression (for `expression`) |
+| `message` | `str` | `None` | Failure message (for `expression`) |
+
+### SqlStatementStep
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `type` | `"sql_statement"` | *required* | Step type discriminator |
+| `name` | `str` | `None` | Step name for telemetry |
+| `on_failure` | `"abort" \| "warn"` | phase default | Failure behavior |
+| `sql` | `str` | *required* | Spark SQL statement to execute |
+| `set_var` | `str` | `None` | Variable name to capture scalar result into |
+
+### LogMessageStep
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `type` | `"log_message"` | *required* | Step type discriminator |
+| `name` | `str` | `None` | Step name for telemetry |
+| `on_failure` | `"abort" \| "warn"` | phase default | Failure behavior |
+| `message` | `str` | *required* | Message template (supports `${var.name}`) |
+| `level` | `"info" \| "warn" \| "error"` | `"info"` | Log level |
+
+---
+
+## VariableSpec
+
+Weave-scoped variable declaration. Set by hook steps via `set_var`,
+referenced as `${var.name}` in config expressions.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `type` | `str` | *required* | Scalar type: `string`, `int`, `long`, `float`, `double`, `boolean`, `timestamp`, `date` |
+| `default` | `str \| int \| float \| bool` | `None` | Default value when no hook sets the variable |

--- a/docs/reference/yaml-schema/thread.md
+++ b/docs/reference/yaml-schema/thread.md
@@ -36,7 +36,8 @@ subsequent steps (e.g. in join, union). The value is a `Source` object.
 
 | Key | Type | Required | Default | Description |
 |-----|------|----------|---------|-------------|
-| `type` | `string` | yes | -- | Source type: `"delta"`, `"csv"`, `"json"`, `"parquet"`, `"excel"` |
+| `type` | `string` | conditional | -- | Source type: `"delta"`, `"csv"`, `"json"`, `"parquet"`, `"excel"`. Required when `lookup` is not set. |
+| `lookup` | `string` | conditional | `null` | Weave-level lookup name. Mutually exclusive with `type`. When set, the source is resolved from the weave's `lookups` map at execution time. |
 | `alias` | `string` | no | `null` | Lakehouse table alias. Required when `type` is `"delta"`. |
 | `path` | `string` | no | `null` | File path. Required for file-based types (`csv`, `json`, `parquet`, `excel`). |
 | `options` | `dict[string, any]` | no | `{}` | Reader options passed to Spark (e.g. `header`, `delimiter`) |
@@ -63,6 +64,8 @@ sources:
     options:
       header: "true"
       delimiter: ","
+  products:
+    lookup: dim_product   # resolved from the weave's lookups map
 ```
 
 ---
@@ -502,7 +505,14 @@ Key management for business keys, surrogate keys, and change detection hashes.
 | Key | Type | Required | Default | Description |
 |-----|------|----------|---------|-------------|
 | `name` | `string` | yes | -- | Output column name for the surrogate key |
-| `algorithm` | `string` | no | `"sha256"` | Hash algorithm: `"sha256"` or `"md5"` |
+| `algorithm` | `string` | no | `"sha256"` | Hash algorithm: `"xxhash64"`, `"sha1"`, `"sha256"`, `"sha384"`, `"sha512"`, `"md5"`, `"crc32"`, `"murmur3"` |
+| `output` | `string` | no | `"native"` | Output type for integer-returning algorithms (xxhash64, crc32, murmur3). `"native"` preserves the algorithm's return type; `"string"` casts to StringType. Has no effect on sha*/md5. |
+
+!!! note "Algorithm choice"
+    `crc32` has a small 32-bit output space with higher collision risk.
+    `murmur3` (Spark's `hash()`) may produce different results across
+    Spark major versions. Neither is recommended for high-cardinality
+    surrogate key use cases.
 
 ### keys.change_detection
 
@@ -510,7 +520,8 @@ Key management for business keys, surrogate keys, and change detection hashes.
 |-----|------|----------|---------|-------------|
 | `name` | `string` | yes | -- | Output column name for the change hash |
 | `columns` | `list[string]` | yes | -- | Columns included in the hash |
-| `algorithm` | `string` | no | `"md5"` | Hash algorithm: `"md5"` or `"sha256"` |
+| `algorithm` | `string` | no | `"md5"` | Hash algorithm: `"xxhash64"`, `"sha1"`, `"sha256"`, `"sha384"`, `"sha512"`, `"md5"`, `"crc32"`, `"murmur3"` |
+| `output` | `string` | no | `"native"` | Output type for integer-returning algorithms. `"native"` preserves the algorithm's return type; `"string"` casts to StringType. |
 
 ```yaml
 keys:

--- a/docs/reference/yaml-schema/weave.md
+++ b/docs/reference/yaml-schema/weave.md
@@ -10,9 +10,13 @@ runtime settings.
 
 | Key | Type | Required | Default | Description |
 |-----|------|----------|---------|-------------|
-| `config_version` | `string` | yes | -- | Schema version identifier (e.g. `"1"`) |
+| `config_version` | `string` | yes | -- | Schema version identifier (e.g. `"1.0"`) |
 | `name` | `string` | no | `""` | Human-readable weave name |
-| `threads` | `list[ThreadEntry or string]` | yes | -- | Thread references. Strings are shorthand for `{ name: "<value>" }` (inline definitions). Use `ref` for external file references. |
+| `threads` | `list[ThreadEntry or string]` | yes | -- | Thread references. Strings are shorthand for `{ name: "<value>" }` (local name references). Use `ref` for external file references. |
+| `lookups` | `dict[string, Lookup]` | no | `null` | Named lookup sources shared across threads in this weave |
+| `variables` | `dict[string, VariableSpec]` | no | `null` | Weave-scoped typed variables, settable by hook steps |
+| `pre_steps` | `list[HookStep]` | no | `null` | Hook steps executed before any thread runs |
+| `post_steps` | `list[HookStep]` | no | `null` | Hook steps executed after all threads complete |
 | `defaults` | `dict[string, any]` | no | `null` | Default values cascaded into every thread in this weave |
 | `params` | `dict[string, ParamSpec]` | no | `null` | Typed parameter declarations scoped to this weave |
 | `execution` | `ExecutionConfig` | no | `null` | Runtime settings (logging, tracing) cascaded to threads |
@@ -38,6 +42,163 @@ Each entry in the `threads` list is either a plain string (shorthand) or a
 | Key | Type | Required | Default | Description |
 |-----|------|----------|---------|-------------|
 | `when` | `string` | yes | -- | Condition expression. Supports `${param.x}` references, `table_exists()`, `table_empty()`, `row_count()`, and boolean operators. |
+
+---
+
+## lookups
+
+Named lookup data sources shared across threads. Each key is a lookup name
+that threads can reference via `source.lookup` instead of declaring a direct
+source type.
+
+| Key | Type | Required | Default | Description |
+|-----|------|----------|---------|-------------|
+| `source` | `Source` | yes | -- | Source definition for the lookup data |
+| `materialize` | `bool` | no | `false` | Pre-read and cache/broadcast the data before thread execution |
+| `strategy` | `string` | no | `"cache"` | Materialization strategy: `"broadcast"` (Spark broadcast join hints) or `"cache"` (DataFrame caching). Only meaningful when `materialize` is true. |
+| `key` | `list[string]` | no | `null` | Column(s) used for matching (join key). When set with `values`, only these columns plus `values` columns are retained. |
+| `values` | `list[string]` | no | `null` | Payload column(s) to retrieve. Requires `key` to be set. Must not overlap with `key`. |
+| `filter` | `string` | no | `null` | SQL WHERE expression applied to the source before projection |
+| `unique_key` | `bool` | no | `false` | Validate that `key` columns form a unique key after filtering and projection |
+| `on_failure` | `string` | no | `"abort"` | Behavior when `unique_key` check finds duplicates: `"abort"` or `"warn"`. Only valid when `unique_key` is true. |
+
+```yaml
+lookups:
+  dim_product:
+    source:
+      type: delta
+      alias: silver.dim_product
+    materialize: true
+    strategy: cache
+    key: [product_id]
+    values: [product_name, category]
+    unique_key: true
+
+  exchange_rates:
+    source:
+      type: delta
+      alias: ref.exchange_rates
+    filter: "effective_date = current_date()"
+    materialize: true
+    strategy: broadcast
+```
+
+Threads reference lookups via the `lookup` field on a source:
+
+```yaml
+# In a thread's sources block
+sources:
+  products:
+    lookup: dim_product   # resolved from the weave's lookups map
+```
+
+---
+
+## pre_steps / post_steps (HookStep)
+
+Hook steps that run before or after thread execution within a weave.
+`pre_steps` run before any thread starts; `post_steps` run after all
+threads complete.
+
+Each hook step is a discriminated union with three types, identified by
+the `type` field.
+
+### Common fields
+
+All hook step types share these fields:
+
+| Key | Type | Required | Default | Description |
+|-----|------|----------|---------|-------------|
+| `type` | `string` | yes | -- | Step type: `"quality_gate"`, `"sql_statement"`, or `"log_message"` |
+| `name` | `string` | no | `null` | Optional name for telemetry and diagnostics |
+| `on_failure` | `string` | no | phase default | Failure behavior: `"abort"` or `"warn"`. Defaults to `"abort"` for pre_steps and `"warn"` for post_steps. |
+
+### quality_gate
+
+Runs a predefined quality check against a data source or target.
+
+| Key | Type | Required | Default | Description |
+|-----|------|----------|---------|-------------|
+| `check` | `string` | yes | -- | Check type: `"source_freshness"`, `"row_count_delta"`, `"row_count"`, `"table_exists"`, `"expression"` |
+| `source` | `string` | conditional | `null` | Table alias. Required for `source_freshness` and `table_exists`. |
+| `max_age` | `string` | conditional | `null` | Duration string (e.g. `"24h"`). Required for `source_freshness`. |
+| `target` | `string` | conditional | `null` | Table alias. Required for `row_count_delta` and `row_count`. |
+| `max_decrease_pct` | `float` | no | `null` | Max allowed decrease percentage for `row_count_delta` |
+| `max_increase_pct` | `float` | no | `null` | Max allowed increase percentage for `row_count_delta` |
+| `min_delta` | `int` | no | `null` | Minimum absolute row change for `row_count_delta` |
+| `max_delta` | `int` | no | `null` | Maximum absolute row change for `row_count_delta` |
+| `min_count` | `int` | conditional | `null` | Minimum row count for `row_count`. At least one of `min_count` or `max_count` required. |
+| `max_count` | `int` | conditional | `null` | Maximum row count for `row_count` |
+| `sql` | `string` | conditional | `null` | Spark SQL boolean expression for `expression` check. Required for `expression`. |
+| `message` | `string` | no | `null` | Failure message for `expression` check diagnostics |
+
+### sql_statement
+
+Executes an arbitrary Spark SQL statement. Optionally captures the scalar
+result into a weave-scoped variable.
+
+| Key | Type | Required | Default | Description |
+|-----|------|----------|---------|-------------|
+| `sql` | `string` | yes | -- | Spark SQL statement to execute |
+| `set_var` | `string` | no | `null` | Variable name to capture the scalar result into. The variable must be declared in `variables`. |
+
+### log_message
+
+Emits a log message. Supports `${var.name}` placeholders resolved from
+weave variables.
+
+| Key | Type | Required | Default | Description |
+|-----|------|----------|---------|-------------|
+| `message` | `string` | yes | -- | Message template. Supports `${var.name}` placeholders. |
+| `level` | `string` | no | `"info"` | Log level: `"info"`, `"warn"`, `"error"` |
+
+```yaml
+pre_steps:
+  - type: quality_gate
+    name: check_source_freshness
+    check: source_freshness
+    source: raw.orders
+    max_age: "24h"
+
+  - type: sql_statement
+    name: capture_baseline
+    sql: "SELECT count(*) FROM silver.fact_orders"
+    set_var: baseline_count
+
+post_steps:
+  - type: quality_gate
+    name: check_row_count
+    check: row_count
+    target: silver.fact_orders
+    min_count: 1
+
+  - type: log_message
+    message: "Pipeline complete. Baseline was ${var.baseline_count} rows."
+    level: info
+```
+
+---
+
+## variables (VariableSpec)
+
+Typed scalar variables scoped to the weave. Variables can be set by
+`sql_statement` hook steps via `set_var` and referenced in downstream
+config as `${var.name}`.
+
+| Key | Type | Required | Default | Description |
+|-----|------|----------|---------|-------------|
+| `type` | `string` | yes | -- | Scalar type: `"string"`, `"int"`, `"long"`, `"float"`, `"double"`, `"boolean"`, `"timestamp"`, `"date"` |
+| `default` | `string\|int\|float\|bool` | no | `null` | Default value used when no hook step sets the variable |
+
+```yaml
+variables:
+  baseline_count:
+    type: int
+    default: 0
+  run_label:
+    type: string
+    default: "scheduled"
+```
 
 ---
 
@@ -71,8 +232,35 @@ Supported patterns: `snake_case`, `camelCase`, `PascalCase`, `UPPER_SNAKE_CASE`,
 ## Complete example
 
 ```yaml
-config_version: "1"
+config_version: "1.0"
 name: sales_pipeline
+
+lookups:
+  dim_product:
+    source:
+      type: delta
+      alias: silver.dim_product
+    materialize: true
+    strategy: cache
+    key: [product_id]
+    values: [product_name, category]
+    unique_key: true
+
+variables:
+  baseline_count:
+    type: int
+    default: 0
+
+pre_steps:
+  - type: quality_gate
+    name: check_orders_freshness
+    check: source_freshness
+    source: raw.orders
+    max_age: "24h"
+  - type: sql_statement
+    name: capture_baseline
+    sql: "SELECT count(*) FROM curated.order_summary"
+    set_var: baseline_count
 
 threads:
   - ref: staging/load_orders.thread
@@ -83,6 +271,16 @@ threads:
     dependencies: [build_order_summary]
     condition:
       when: "table_exists('curated.order_summary')"
+
+post_steps:
+  - type: quality_gate
+    name: verify_row_count
+    check: row_count
+    target: curated.order_summary
+    min_count: 1
+  - type: log_message
+    message: "Pipeline complete. Baseline was ${var.baseline_count} rows."
+    level: info
 
 defaults:
   write:

--- a/docs/release-notes/1.0.md
+++ b/docs/release-notes/1.0.md
@@ -43,14 +43,12 @@ orchestration.
 
 ## Write Modes
 
-Four write modes cover the most common data landing patterns:
+Three write modes cover the most common data landing patterns:
 
 - **overwrite** — Full table replacement. The target is rewritten on every run.
 - **append** — Adds rows to an existing table without modifying existing data.
 - **merge** — Upsert semantics using match keys. Configurable update and insert
   behavior with support for soft deletes.
-- **insert_only** — Inserts only new rows that do not match existing keys. No
-  updates are applied on match.
 
 ## Data Quality
 
@@ -140,9 +138,9 @@ Nineteen transform types cover standard data shaping needs:
 
 ### Writers
 
-- **Delta writer** — Writes to Delta Lake tables with support for all four
-  write modes (overwrite, append, merge, insert_only), partition management,
-  and schema evolution options.
+- **Delta writer** — Writes to Delta Lake tables with support for all three
+  write modes (overwrite, append, merge), partition management, and schema
+  evolution options.
 
 ## Engine
 
@@ -187,18 +185,6 @@ For task-oriented recipes, see the [How-to Guides](../how-to/add-a-thread.md).
 
 ## What's Next
 
-The v1.0 release delivers the core execution engine. Upcoming development will
-focus on:
-
-- **Naming normalization** — Automatic column name standardization
-- **Advanced merge patterns** — More flexible merge strategies for complex
-  slowly changing dimension scenarios
-- **Extensibility** — Stitch patterns for reusable transform sequences, helper
-  function registries, and project-level UDF registration
-- **Operational resilience** — Retry policies, circuit breakers, and mirror
-  targets for fault-tolerant pipelines
-- **Developer tooling** — CLI-based config validation, dry-run modes, and a
-  test framework for integration projects
-
-Follow the [GitHub repository](https://github.com/DataInsightPro/weevr) for
-updates and release announcements.
+See the [v1.1](1.1.md) and [v1.2](1.2.md) release notes for features
+delivered since this release, including execution hooks, weave-level lookups,
+narrow lookup projection, and expanded hash algorithms.

--- a/docs/release-notes/1.1.md
+++ b/docs/release-notes/1.1.md
@@ -1,0 +1,114 @@
+<!-- markdownlint-disable MD033 -->
+
+# Release Notes — v1.1
+
+**Release date:** March 2026
+
+This release introduces **execution hooks**, **weave-level lookups**, and
+**quality gates** — expanding the weave lifecycle with pre/post processing
+capabilities.
+
+---
+
+## Execution Hooks
+
+Weaves now support `pre_steps` and `post_steps` — hook steps that run before
+and after thread execution within a weave.
+
+Three hook step types are available:
+
+- **quality_gate** — Run predefined quality checks against data sources and
+  targets. Supported checks: `source_freshness`, `row_count_delta`,
+  `row_count`, `table_exists`, and `expression`.
+- **sql_statement** — Execute arbitrary Spark SQL. Optionally capture the
+  scalar result into a weave-scoped variable via `set_var`.
+- **log_message** — Emit a log message with `${var.name}` placeholders
+  resolved from weave variables.
+
+Each step has an `on_failure` policy: `abort` (stop the weave) or `warn`
+(log and continue). Pre-steps default to `abort`; post-steps default to
+`warn`.
+
+```yaml
+pre_steps:
+  - type: quality_gate
+    name: check_freshness
+    check: source_freshness
+    source: raw.orders
+    max_age: "24h"
+
+post_steps:
+  - type: log_message
+    message: "Pipeline complete."
+    level: info
+```
+
+## Weave-Level Lookups
+
+Weaves can now define named **lookups** — shared reference datasets that
+threads access via `source.lookup` instead of declaring a direct source type.
+
+Lookups support two materialization strategies:
+
+- **cache** — Pre-read the data and persist it as a cached DataFrame
+- **broadcast** — Pre-read and apply Spark broadcast join hints
+
+```yaml
+lookups:
+  dim_product:
+    source:
+      type: delta
+      alias: silver.dim_product
+    materialize: true
+    strategy: cache
+```
+
+Threads reference lookups by name:
+
+```yaml
+sources:
+  products:
+    lookup: dim_product
+```
+
+## Weave-Scoped Variables
+
+Weaves can declare typed variables via the `variables` block. Variables are
+set by `sql_statement` hook steps and referenced in downstream config as
+`${var.name}`.
+
+```yaml
+variables:
+  baseline_count:
+    type: int
+    default: 0
+
+pre_steps:
+  - type: sql_statement
+    sql: "SELECT count(*) FROM silver.fact_orders"
+    set_var: baseline_count
+```
+
+Supported types: `string`, `int`, `long`, `float`, `double`, `boolean`,
+`timestamp`, `date`.
+
+## New Exception Types
+
+- **`HookError`** — Raised when a hook step fails with `on_failure: abort`.
+  Carries `hook_name`, `hook_type`, and `phase` context.
+- **`LookupResolutionError`** — Raised when a thread references a lookup
+  name not defined in the weave's `lookups` map. Caught during config
+  resolution before any data is read.
+
+## Compatibility
+
+No breaking changes. All existing configurations continue to work without
+modification. The new weave fields (`lookups`, `variables`, `pre_steps`,
+`post_steps`) are optional and default to `null`.
+
+| Component | Version |
+|-----------|---------|
+| Python | 3.11 |
+| PySpark | 3.5.x |
+| Delta Lake | 3.2.x |
+| Microsoft Fabric Runtime | 1.3 |

--- a/docs/release-notes/1.2.md
+++ b/docs/release-notes/1.2.md
@@ -1,0 +1,84 @@
+<!-- markdownlint-disable MD033 -->
+
+# Release Notes — v1.2
+
+**Release date:** March 2026
+
+This release adds **narrow lookup projection** and **expanded hash
+algorithms** — improving memory efficiency for lookup-heavy pipelines
+and offering more flexibility for key generation.
+
+---
+
+## Narrow Lookup Projection
+
+Lookups now support `key`, `values`, `filter`, and `unique_key` fields
+that control projection and filtering applied during materialization:
+
+```yaml
+lookups:
+  dim_product:
+    source:
+      type: delta
+      alias: silver.dim_product
+    materialize: true
+    key: [product_id]
+    values: [product_name, category]
+    filter: "is_active = true"
+    unique_key: true
+```
+
+- **`key`** — Column(s) used for matching. Always retained in the cached
+  projection.
+- **`values`** — Payload column(s) to keep. When set, only `key` +
+  `values` columns are cached, reducing memory usage.
+- **`filter`** — SQL WHERE expression applied before projection.
+- **`unique_key`** — Validates that `key` columns form a unique key after
+  filtering. Controlled by `on_failure` (`abort` or `warn`).
+
+These fields are optional. Existing lookup configurations continue to work
+without changes.
+
+## Expanded Hash Algorithms
+
+Surrogate key and change detection hash generation now supports eight
+algorithms:
+
+| Algorithm | Output Type | Notes |
+|-----------|-------------|-------|
+| `xxhash64` | `LongType` | Fast, non-cryptographic 64-bit hash |
+| `sha1` | `StringType` | 160-bit cryptographic hash |
+| `sha256` | `StringType` | Default for surrogate keys |
+| `sha384` | `StringType` | 384-bit cryptographic hash |
+| `sha512` | `StringType` | 512-bit cryptographic hash |
+| `md5` | `StringType` | Default for change detection |
+| `crc32` | `IntegerType` | 32-bit CRC — small output, higher collision risk |
+| `murmur3` | `IntegerType` | Spark's `hash()` — may vary across Spark versions |
+
+A new `output` field controls the return type for integer-returning
+algorithms (`xxhash64`, `crc32`, `murmur3`):
+
+```yaml
+keys:
+  surrogate_key:
+    name: sk_order
+    algorithm: xxhash64
+    output: string     # cast to StringType instead of native LongType
+```
+
+- `native` (default) — preserves the algorithm's return type
+- `string` — casts to `StringType`
+
+This has no effect on sha*/md5 algorithms, which already return hex strings.
+
+## Compatibility
+
+No breaking changes. All existing configurations continue to work without
+modification.
+
+| Component | Version |
+|-----------|---------|
+| Python | 3.11 |
+| PySpark | 3.5.x |
+| Delta Lake | 3.2.x |
+| Microsoft Fabric Runtime | 1.3 |

--- a/docs/tutorials/your-first-loom.md
+++ b/docs/tutorials/your-first-loom.md
@@ -151,7 +151,7 @@ from weevr import Context
 # from pyspark.sql import SparkSession
 # spark = SparkSession.builder.master("local[*]").getOrCreate()
 
-ctx = Context(spark, "my-project")
+ctx = Context(spark, "my-project.weevr")
 result = ctx.run("daily.loom")
 
 print(result.status)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,8 @@ nav:
   - FAQ: faq.md
   - Contributing: contributing.md
   - Release Notes:
+      - "1.2": release-notes/1.2.md
+      - "1.1": release-notes/1.1.md
       - "1.0": release-notes/1.0.md
 
 markdown_extensions:


### PR DESCRIPTION
## Summary

- Add missing YAML schema documentation for execution hooks, weave-level lookups, variables, and narrow lookup projection
- Fix incorrect content across FAQ, engine-internals guide, and error catalog
- Add v1.1 and v1.2 release notes pages

## Why

- Several features (hooks, lookups, expanded hash algorithms) shipped in v1.1 and v1.2 without corresponding reference docs updates
- Users could not discover or configure these features from documentation alone
- FAQ contained a phantom `insert_only` write mode that does not exist in the codebase

## What changed

**YAML Schema Reference** (3 files)
- `weave.md` — added `lookups`, `variables`, `pre_steps`, `post_steps` sections with full field tables, type docs, and examples
- `thread.md` — added `Source.lookup` field, expanded hash algorithms from 2 to 8 values, added `output` field on key configs
- `configuration-keys.md` — fixed D2 diagram field name, added Weave/Loom/Lookup/HookStep/VariableSpec model tables, expanded algorithm and output fields

**API Reference** (5 files)
- `errors.md` — added `HookError` and `LookupResolutionError` to D2 hierarchy and troubleshooting catalog
- `engine.md` / `operations.md` / `model.md` — updated intro text to reflect hooks, lookups, gates
- `context.md` — added `weevr.result` mkdocstrings directive for `RunResult`/`LoadedConfig`/`ExecutionMode`

**Guides & How-tos** (3 files)
- `engine-internals.md` — fixed pipeline step count (11→12), corrected cache lifecycle, added hooks to execution flow and module map, documented loom failure propagation
- `cache-a-lookup.md` — added weave-level lookups and narrow lookup sections
- `config-resolution.md` — reframed `load_config()` as internal detail

**FAQ & Tutorials** (3 files)
- `faq.md` — removed phantom `insert_only` write mode, added hooks and lookups Q&A entries
- `your-first-loom.md` — fixed `Context` init to use `.weevr` suffix
- `thread-weave-loom.md` — standardized `config_version: "1.0"`

**Release Notes & Nav** (5 files)
- Created `release-notes/1.1.md` and `release-notes/1.2.md`
- Updated `release-notes/1.0.md` — removed `insert_only` references, updated "What's Next"
- `compatibility.md` — added version validation note
- `mkdocs.yml` — added v1.1 and v1.2 to nav

## How to test

- [x] uv sync --dev
- [x] uv run ruff check .
- [x] uv run ruff format .
- [x] uv run pyright .
- [x] uv run pytest
- [x] uv run mkdocs build --strict (passes with no warnings or errors)

## Release / Versioning

- [x] PR title follows Conventional Commit format (feat:, fix:, chore:, docs:, ci:, etc.)
- [ ] Breaking change indicated (feat!: / fix!: or BREAKING CHANGE in body)

## Notes

- Uses `docs` type to avoid triggering a version bump — these are documentation-only changes with no source code modifications
- 19 files changed, 872 insertions, 76 deletions