### PR TITLE
ci(docs): add standalone docs deploy workflow

### DIFF
--- a/.github/workflows/docs-deploy.yaml
+++ b/.github/workflows/docs-deploy.yaml
@@ -1,0 +1,58 @@
+name: Deploy Docs
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "src/weevr/**"
+      - "CONTRIBUTING.md"
+
+permissions:
+  contents: write
+
+jobs:
+  deploy-docs:
+    # Skip release-please commits — the release workflow handles those
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      !startsWith(github.event.head_commit.message, 'chore(main): release')
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: ".python-version"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.9.28"
+          enable-cache: true
+
+      - name: Sync (locked)
+        run: uv sync --locked --dev
+
+      - name: Install D2
+        run: curl -fsSL https://d2lang.com/install.sh | sh -s --
+        env:
+          D2_VERSION: "0.6.9"
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Deploy docs
+        run: |
+          TAG=$(git describe --tags --abbrev=0)
+          VERSION=$(echo "$TAG" | sed -E 's/^(weevr-)?v([0-9]+\.[0-9]+).*/\2/')
+          uv run mike deploy "$VERSION" latest --update-aliases --push
+          uv run mike set-default latest --push


### PR DESCRIPTION
## Summary

- Add a standalone workflow that deploys docs to GitHub Pages on push to main when docs-related files change
- Support manual dispatch via workflow_dispatch for on-demand docs deployment

## Why

- Docs deployment was previously gated on Release Please creating a release, meaning docs-only changes (merged as `chore` or `docs` types) never got published
- PR #71 fixed 27 docs drift items but the published site didn't update because no release was triggered
- This decouples docs deployment from the release cycle so content fixes land immediately

## What changed

- Added `.github/workflows/docs-deploy.yaml` — triggers on push to main (scoped to `docs/**`, `mkdocs.yml`, `src/weevr/**`, `CONTRIBUTING.md`) and on `workflow_dispatch`
- Skips release-please commits (`chore(main): release ...`) to avoid double-deploying with the existing `deploy-docs` job in `release.yaml`
- Derives the mike version from the latest git tag rather than a release output

## How to test

- [x] uv sync --dev
- [x] uv run ruff check .
- [x] uv run ruff format .
- [x] uv run pyright .
- [x] uv run pytest
- After merge, trigger manually from Actions tab to verify docs deploy

## Release / Versioning

- [x] PR title follows Conventional Commit format (feat:, fix:, chore:, docs:, ci:, etc.)
- [ ] Breaking change indicated (feat!: / fix!: or BREAKING CHANGE in body)

## Notes

- The existing `deploy-docs` job in `release.yaml` remains unchanged — it still runs on releases
- After merging this PR, use "Run workflow" from the Actions tab to publish the docs from PR #71