### PR TITLE
fix(examples): create schemas before staging demo tables

### DIFF
--- a/examples/fabcon/demo_setup.py
+++ b/examples/fabcon/demo_setup.py
@@ -21,6 +21,9 @@ Usage::
 # Adjust this path to match where the fabcon data directory is uploaded.
 DATA_DIR = "Files/fabcon.weevr/data"
 
+# Schemas used by the demo tables.
+_SCHEMAS = ["raw", "staging", "silver"]
+
 
 def _load_csv(spark, csv_name, table_name, mode="overwrite"):
     """Read a CSV file and write it as a Delta table.
@@ -38,6 +41,16 @@ def _load_csv(spark, csv_name, table_name, mode="overwrite"):
     print(f"  {table_name}: {count} rows ({mode})")
 
 
+def _ensure_schemas(spark):
+    """Create demo schemas if they don't already exist.
+
+    Args:
+        spark: Active SparkSession.
+    """
+    for schema in _SCHEMAS:
+        spark.sql(f"CREATE SCHEMA IF NOT EXISTS {schema}")  # noqa: S608
+
+
 def stage_all(spark):
     """Load all base CSVs into Delta tables for the demo sequence.
 
@@ -52,6 +65,7 @@ def stage_all(spark):
         spark: Active SparkSession.
     """
     print("Staging base data...")
+    _ensure_schemas(spark)
     _load_csv(spark, "customers.csv", "raw.customers")
     _load_csv(spark, "orders.csv", "raw.orders")
     _load_csv(spark, "transactions.csv", "raw.transactions")


### PR DESCRIPTION
## Summary

- Add `_ensure_schemas()` to `demo_setup.py` that creates `raw`, `staging`, and `silver` schemas before loading Delta tables

## Why

- Fabric lakehouses require explicit schema creation before writing tables with dotted names (e.g., `raw.customers`). Without this, `saveAsTable` fails with `SCHEMA_NOT_FOUND`.

## What changed

- `examples/fabcon/demo_setup.py`: Added `_SCHEMAS` list and `_ensure_schemas()` helper, called at the start of `stage_all()`
- `reset()` inherits the fix transitively since it calls `stage_all()` after dropping tables

## How to test

- [x] uv sync --dev
- [x] uv run ruff check .
- [x] uv run ruff format .
- [x] uv run pyright .
- [x] uv run pytest

Manual validation: run `stage_all(spark)` in a Fabric notebook against a lakehouse that does not have pre-existing `raw`/`staging`/`silver` schemas.

## Release / Versioning

- [x] PR title follows Conventional Commit format (feat:, fix:, chore:, docs:, ci:, etc.)
- [ ] Breaking change indicated (feat!: / fix!: or BREAKING CHANGE in body)

## Notes

- This only affects the demo setup utility, not the weevr library itself