### PR TITLE
fix(config): resolve relative source paths against project root

### DIFF
--- a/src/weevr/context.py
+++ b/src/weevr/context.py
@@ -723,6 +723,10 @@ class Context:
         except ValueError:
             resolved_with_refs["qualified_key"] = str(file_path)
 
+        # Step 8c: Resolve relative source paths against project root
+        if config_type == "thread":
+            self._resolve_source_paths(resolved_with_refs, self._project_root)
+
         # Step 9: Hydrate top-level model
         model = self._hydrate_model(resolved_with_refs, config_type, file_path)
 
@@ -736,6 +740,7 @@ class Context:
                 resolved_with_refs.get("threads", []),
                 resolved_with_refs.get("_resolved_threads", []),
                 file_path,
+                project_root=self._project_root,
             )
             threads[weave_name] = thread_map
 
@@ -764,6 +769,7 @@ class Context:
                     weave_dict.get("threads", []),
                     weave_dict.get("_resolved_threads", []),
                     file_path,
+                    project_root=self._project_root,
                 )
                 threads[weave_name] = thread_map
 
@@ -800,6 +806,7 @@ class Context:
         thread_entries: list[Any],
         resolved_dicts: list[dict[str, Any]],
         source_path: Path,
+        project_root: Path | str | None = None,
     ) -> dict[str, Thread]:
         """Hydrate resolved thread dicts into a name->Thread mapping."""
         result: dict[str, Thread] = {}
@@ -814,6 +821,10 @@ class Context:
 
             if not thread_dict.get("name"):
                 thread_dict["name"] = name
+
+            if project_root is not None:
+                Context._resolve_source_paths(thread_dict, project_root)
+
             try:
                 result[name] = Thread.model_validate(thread_dict)
             except ValidationError as exc:
@@ -823,3 +834,32 @@ class Context:
                     file_path=str(source_path),
                 ) from exc
         return result
+
+    @staticmethod
+    def _resolve_source_paths(thread_dict: dict[str, Any], project_root: Path | str) -> None:
+        """Resolve relative source file paths against the project root.
+
+        Modifies the thread config dict in place, prepending the project root
+        to any relative ``path`` values in file-based sources (csv, json,
+        parquet, excel).
+
+        Args:
+            thread_dict: Thread configuration dict (pre-hydration).
+            project_root: Resolved project root (Path for local, str for ABFS).
+        """
+        sources = thread_dict.get("sources")
+        if not sources or not isinstance(sources, dict):
+            return
+        for source_cfg in sources.values():
+            if not isinstance(source_cfg, dict):
+                continue
+            path = source_cfg.get("path")
+            if path is None:
+                continue
+            # Skip already-absolute paths and URIs
+            if os.path.isabs(path) or "://" in path:
+                continue
+            if isinstance(project_root, Path):
+                source_cfg["path"] = str(project_root / path)
+            else:
+                source_cfg["path"] = f"{project_root.rstrip('/')}/{path}"

--- a/tests/weevr/test_context.py
+++ b/tests/weevr/test_context.py
@@ -102,6 +102,57 @@ class TestContextValidation:
             Context(spark=mock_spark, project="/path/without/extension")
 
 
+class TestResolveSourcePaths:
+    """Unit tests for Context._resolve_source_paths (no Spark required)."""
+
+    def test_relative_path_resolved_with_local_root(self, tmp_path: Path) -> None:
+        thread_dict: dict = {
+            "sources": {"customers": {"type": "csv", "path": "data/customers.csv"}}
+        }
+        Context._resolve_source_paths(thread_dict, tmp_path)
+        assert thread_dict["sources"]["customers"]["path"] == str(tmp_path / "data/customers.csv")
+
+    def test_relative_path_resolved_with_abfs_root(self) -> None:
+        root = "abfss://ws@onelake.dfs.fabric.microsoft.com/lh/Files/project.weevr"
+        thread_dict: dict = {
+            "sources": {"customers": {"type": "csv", "path": "data/customers.csv"}}
+        }
+        Context._resolve_source_paths(thread_dict, root)
+        assert thread_dict["sources"]["customers"]["path"] == f"{root}/data/customers.csv"
+
+    def test_absolute_path_unchanged(self) -> None:
+        thread_dict: dict = {
+            "sources": {"main": {"type": "csv", "path": "/absolute/path/data.csv"}}
+        }
+        Context._resolve_source_paths(thread_dict, Path("/project.weevr"))
+        assert thread_dict["sources"]["main"]["path"] == "/absolute/path/data.csv"
+
+    def test_uri_path_unchanged(self) -> None:
+        uri = "abfss://ws@onelake.dfs.fabric.microsoft.com/lh/Files/data.csv"
+        thread_dict: dict = {"sources": {"main": {"type": "csv", "path": uri}}}
+        Context._resolve_source_paths(thread_dict, Path("/project.weevr"))
+        assert thread_dict["sources"]["main"]["path"] == uri
+
+    def test_delta_source_skipped(self) -> None:
+        thread_dict: dict = {"sources": {"main": {"type": "delta", "alias": "raw.customers"}}}
+        Context._resolve_source_paths(thread_dict, Path("/project.weevr"))
+        assert "path" not in thread_dict["sources"]["main"]
+
+    def test_no_sources_is_noop(self) -> None:
+        thread_dict: dict = {"name": "test"}
+        Context._resolve_source_paths(thread_dict, Path("/project.weevr"))
+        assert thread_dict == {"name": "test"}
+
+    def test_abfs_root_trailing_slash_normalized(self) -> None:
+        root = "abfss://ws@onelake.dfs.fabric.microsoft.com/lh/Files/project.weevr/"
+        thread_dict: dict = {"sources": {"main": {"type": "json", "path": "data/events.json"}}}
+        Context._resolve_source_paths(thread_dict, root)
+        expected = (
+            "abfss://ws@onelake.dfs.fabric.microsoft.com/lh/Files/project.weevr/data/events.json"
+        )
+        assert thread_dict["sources"]["main"]["path"] == expected
+
+
 class TestRunValidation:
     def test_invalid_mode(self, tmp_path: Path) -> None:
         mock_spark = MagicMock(spec=SparkSession)


### PR DESCRIPTION
## Summary

- Resolve relative file-based source paths (csv, json, parquet) against the project root during config assembly
- Fixes 400 errors on OneLake when threads reference relative paths like `data/customers.csv`

## Why

- File-based sources with relative paths were passed directly to `spark.read.load()` without the project root prefix. On Fabric, Spark resolved these against the lakehouse root instead of the project directory, causing `SCHEMA_NOT_FOUND` / 400 errors from OneLake.

## What changed

- `src/weevr/context.py`: Added `_resolve_source_paths()` static method that prepends the project root to relative source paths in the thread config dict before model hydration. Called for standalone threads, weave children, and loom children.
- `tests/weevr/test_context.py`: Added `TestResolveSourcePaths` with 7 unit tests covering local paths, ABFS paths, absolute paths, URIs, delta sources, empty sources, and trailing slash normalization.

## How to test

- [x] uv sync --dev
- [x] uv run ruff check .
- [x] uv run ruff format .
- [x] uv run pyright .
- [x] uv run pytest

Manual validation: run a thread with a relative CSV source path in a Fabric notebook — the path should resolve to `<project_root>/data/customers.csv` instead of just `data/customers.csv`.

## Release / Versioning

- [x] PR title follows Conventional Commit format (feat:, fix:, chore:, docs:, ci:, etc.)
- [ ] Breaking change indicated (feat!: / fix!: or BREAKING CHANGE in body)

## Notes

- Path resolution happens before Pydantic model hydration, so the Source model (which is frozen) already contains the resolved absolute path by the time the executor, reader, validator, and preview mode access it