### PR TITLE
feat(engine): defer lookup materialization to schedule-aware group boundaries

### DIFF
--- a/src/weevr/context.py
+++ b/src/weevr/context.py
@@ -308,10 +308,12 @@ class Context:
                 )
 
             filtered_entries = [e for e in model.threads if e.name in weave_threads]
+            weave_lookups = dict(model.lookups) if model.lookups else None
             plan = build_plan(
                 weave_name=resolved.config_name,
                 threads=weave_threads,
                 thread_entries=filtered_entries,
+                lookups=weave_lookups,
             )
             # Build thread condition map from ThreadEntry conditions
             thread_conditions: dict[str, ConditionSpec] = {}
@@ -433,6 +435,7 @@ class Context:
                     weave_name=resolved.config_name,
                     threads=wt,
                     thread_entries=list(model.threads),
+                    lookups=dict(model.lookups) if model.lookups else None,
                 )
             except Exception as exc:
                 validation_errors.append(f"DAG validation failed: {exc}")
@@ -454,6 +457,7 @@ class Context:
                         weave_name=weave_name,
                         threads=wt,
                         thread_entries=list(weave.threads),
+                        lookups=dict(weave.lookups) if weave.lookups else None,
                     )
                 except Exception as exc:
                     validation_errors.append(
@@ -550,6 +554,7 @@ class Context:
                         weave_name=resolved.config_name,
                         threads=wt,
                         thread_entries=filtered_entries,
+                        lookups=dict(model.lookups) if model.lookups else None,
                     )
                 )
 
@@ -573,6 +578,7 @@ class Context:
                             weave_name=weave_name,
                             threads=wt,
                             thread_entries=filtered_entries,
+                            lookups=dict(weave.lookups) if weave.lookups else None,
                         )
                     )
 

--- a/src/weevr/engine/planner.py
+++ b/src/weevr/engine/planner.py
@@ -1,9 +1,12 @@
 """Execution planner — builds a DAG-based execution plan from a weave's thread config."""
 
+from __future__ import annotations
+
 from collections import deque
 
 from weevr.errors.exceptions import ConfigError
 from weevr.model.base import FrozenBase
+from weevr.model.lookup import Lookup
 from weevr.model.thread import Thread
 from weevr.model.weave import ThreadEntry
 
@@ -24,6 +27,10 @@ class ExecutionPlan(FrozenBase):
             determined by matching target paths to source paths across threads.
         explicit_dependencies: The explicitly declared subset of ``dependencies``,
             sourced from ``ThreadEntry.dependencies`` in the weave config.
+        lookup_schedule: Maps execution group indices to lookups that should
+            be materialized at that boundary. Key 0 means before the first
+            group; key N (N > 0) means after group N-1 finishes. ``None``
+            when ``build_plan`` was called without lookups.
     """
 
     weave_name: str
@@ -34,6 +41,7 @@ class ExecutionPlan(FrozenBase):
     cache_targets: list[str]
     inferred_dependencies: dict[str, list[str]]
     explicit_dependencies: dict[str, list[str]]
+    lookup_schedule: dict[int, list[str]] | None = None
 
 
 def _normalize_path(path: str) -> str:
@@ -67,15 +75,41 @@ def _extract_source_paths(thread: Thread) -> set[str]:
     return paths
 
 
+def _build_target_index(threads: dict[str, Thread]) -> dict[str, str]:
+    """Build a mapping of normalized target path to thread name.
+
+    Used by the dependency graph builder and lookup dependency inference to
+    identify which thread produces a given data path.
+
+    Args:
+        threads: Mapping of thread name to Thread config.
+
+    Returns:
+        A dict mapping normalized target path to the producing thread's name.
+    """
+    target_index: dict[str, str] = {}
+    for name, thread in threads.items():
+        path = _extract_target_path(thread)
+        if path is not None:
+            target_index[path] = name
+    return target_index
+
+
 def _build_dependency_graph(
     threads: dict[str, Thread],
     thread_entries: list[ThreadEntry],
+    target_index: dict[str, str] | None = None,
 ) -> tuple[dict[str, list[str]], dict[str, list[str]]]:
     """Build inferred and explicit dependency dicts.
 
     For each thread, auto-infers an edge when another thread's target path
     appears in this thread's source paths. Also merges explicit dependencies
     declared on ThreadEntry objects.
+
+    Args:
+        threads: Mapping of thread name to Thread config.
+        thread_entries: Ordered thread entries from the weave config.
+        target_index: Pre-built target path index. Built internally when ``None``.
 
     Returns:
         A ``(inferred_deps, explicit_deps)`` tuple where each is a
@@ -85,12 +119,8 @@ def _build_dependency_graph(
         ConfigError: If a thread referenced in explicit dependencies does not
             exist in the ``threads`` dict.
     """
-    # Build index: target_path → thread_name for fast lookup
-    target_index: dict[str, str] = {}
-    for name, thread in threads.items():
-        path = _extract_target_path(thread)
-        if path is not None:
-            target_index[path] = name
+    if target_index is None:
+        target_index = _build_target_index(threads)
 
     # Build explicit deps index from ThreadEntry list
     explicit_index: dict[str, list[str]] = {name: [] for name in threads}
@@ -251,21 +281,130 @@ def _analyze_cache_targets(
     return sorted(targets)
 
 
+def _infer_lookup_dependencies(
+    threads: dict[str, Thread],
+    lookups: dict[str, Lookup],
+    target_index: dict[str, str],
+) -> tuple[dict[str, list[str]], dict[str, str | None]]:
+    """Infer implicit thread dependencies mediated by lookups.
+
+    When a lookup's source reads from a table produced by thread A, and
+    thread B consumes that lookup, then B implicitly depends on A.
+
+    Args:
+        threads: Mapping of thread name to Thread config.
+        lookups: Mapping of lookup name to Lookup config.
+        target_index: Pre-built target path to thread name index.
+
+    Returns:
+        A tuple of ``(lookup_deps, lookup_producer)`` where:
+        - ``lookup_deps`` maps consumer thread names to the list of producer
+          thread names they implicitly depend on (via lookups).
+        - ``lookup_producer`` maps lookup names to the producing thread name,
+          or ``None`` for external lookups.
+    """
+    # Find the producer thread for each lookup
+    lookup_producer: dict[str, str | None] = {}
+    for lk_name, lk in lookups.items():
+        src = lk.source
+        raw = src.alias or src.path
+        if raw is not None:
+            normalized = _normalize_path(raw)
+            lookup_producer[lk_name] = target_index.get(normalized)
+        else:
+            lookup_producer[lk_name] = None
+
+    # Find which threads consume each lookup
+    lookup_consumers: dict[str, list[str]] = {lk: [] for lk in lookups}
+    for thread_name, thread in threads.items():
+        for source in thread.sources.values():
+            if (
+                source.lookup is not None
+                and source.lookup in lookup_consumers
+                and thread_name not in lookup_consumers[source.lookup]
+            ):
+                lookup_consumers[source.lookup].append(thread_name)
+
+    # Build implicit deps: consumer depends on producer
+    lookup_deps: dict[str, list[str]] = {name: [] for name in threads}
+    for lk_name, producer in lookup_producer.items():
+        if producer is None:
+            continue
+        for consumer in lookup_consumers.get(lk_name, []):
+            if consumer != producer and producer not in lookup_deps[consumer]:
+                lookup_deps[consumer].append(producer)
+
+    return lookup_deps, lookup_producer
+
+
+def _compute_lookup_schedule(
+    lookups: dict[str, Lookup],
+    lookup_producer: dict[str, str | None],
+    execution_order: list[list[str]],
+) -> dict[int, list[str]]:
+    """Compute when each materialized lookup should be read.
+
+    Lookups with no producer (external data) are scheduled at group 0 (before
+    the first execution group). Lookups whose source is produced by a thread
+    in group N are scheduled at group N+1 (after the producer completes).
+
+    Args:
+        lookups: Mapping of lookup name to Lookup config.
+        lookup_producer: Maps lookup name to its producer thread, or ``None``.
+        execution_order: Parallel execution groups from topological sort.
+
+    Returns:
+        A dict mapping group index to the list of lookup names that should
+        be materialized before that group executes.
+    """
+    # Build thread → group index mapping
+    thread_group_index: dict[str, int] = {}
+    for idx, group in enumerate(execution_order):
+        for name in group:
+            thread_group_index[name] = idx
+
+    schedule: dict[int, list[str]] = {}
+    for lk_name, lk in lookups.items():
+        if not lk.materialize:
+            continue
+        producer = lookup_producer.get(lk_name)
+        group_idx = 0 if producer is None else thread_group_index[producer] + 1
+        schedule.setdefault(group_idx, []).append(lk_name)
+
+    # Sort lookup names within each group for determinism
+    for group_idx in schedule:
+        schedule[group_idx] = sorted(schedule[group_idx])
+
+    return schedule
+
+
 def build_plan(
     weave_name: str,
     threads: dict[str, Thread],
     thread_entries: list[ThreadEntry],
+    lookups: dict[str, Lookup] | None = None,
 ) -> ExecutionPlan:
     """Build an execution plan from a weave's threads and declared/inferred dependencies.
 
     Performs DAG construction, cycle detection, topological sort, and cache analysis
     to produce an immutable :class:`ExecutionPlan`.
 
+    When ``lookups`` are provided, the planner also:
+
+    - Infers implicit dependencies between threads mediated by lookups (a
+      thread consuming a lookup whose source is produced by another thread
+      depends on that producer).
+    - Computes a **lookup schedule** mapping each execution group boundary to
+      the lookups that should be materialized before that group runs.
+
     Args:
         weave_name: Name of the weave being planned.
         threads: Mapping of thread name to :class:`Thread` config.
         thread_entries: Ordered thread entries from the weave config, which may
             carry explicit dependency declarations.
+        lookups: Optional weave-level lookup definitions. When provided, lookup-
+            mediated dependencies are inferred and a materialization schedule is
+            computed.
 
     Returns:
         An immutable :class:`ExecutionPlan`.
@@ -277,8 +416,22 @@ def build_plan(
     """
     thread_names = list(threads.keys())
 
+    # 0. Build shared target index
+    target_index = _build_target_index(threads)
+
     # 1. Build inferred and explicit dependency graphs
-    inferred, explicit = _build_dependency_graph(threads, thread_entries)
+    inferred, explicit = _build_dependency_graph(threads, thread_entries, target_index)
+
+    # 1b. Infer lookup-mediated dependencies when lookups are provided
+    lookup_deps: dict[str, list[str]] | None = None
+    lookup_producer: dict[str, str | None] | None = None
+    if lookups:
+        lookup_deps, lookup_producer = _infer_lookup_dependencies(threads, lookups, target_index)
+        # Merge lookup deps into inferred deps
+        for name, deps in lookup_deps.items():
+            for dep in deps:
+                if dep not in inferred[name]:
+                    inferred[name].append(dep)
 
     # 2. Merge into unified dependency graph
     dependencies = _merge_dependencies(inferred, explicit)
@@ -298,6 +451,11 @@ def build_plan(
     # 6. Identify cache targets
     cache_targets = _analyze_cache_targets(thread_names, threads, dependents)
 
+    # 7. Compute lookup materialization schedule
+    lookup_schedule: dict[int, list[str]] | None = None
+    if lookups and lookup_producer is not None:
+        lookup_schedule = _compute_lookup_schedule(lookups, lookup_producer, execution_order)
+
     return ExecutionPlan(
         weave_name=weave_name,
         threads=thread_names,
@@ -307,4 +465,5 @@ def build_plan(
         cache_targets=cache_targets,
         inferred_dependencies=inferred,
         explicit_dependencies=explicit,
+        lookup_schedule=lookup_schedule,
     )

--- a/src/weevr/engine/runner.py
+++ b/src/weevr/engine/runner.py
@@ -135,9 +135,27 @@ def execute_weave(
     all_hook_results: list[HookResult] = []
     all_lookup_results: list[LookupResult] = []
 
+    def _materialize_scheduled(sched_key: int) -> None:
+        """Materialize lookups assigned to ``sched_key`` in the lookup schedule."""
+        if not lookups or plan.lookup_schedule is None or sched_key not in plan.lookup_schedule:
+            return
+        subset = {k: v for k, v in lookups.items() if k in plan.lookup_schedule[sched_key]}
+        if not subset:
+            return
+        new_cached, new_results = materialize_lookups(
+            spark, subset, collector=collector, parent_span_id=weave_span_id
+        )
+        cached_lookup_dfs.update(new_cached)
+        all_lookup_results.extend(new_results)
+
     try:
-        # Materialize lookups before any hook or thread execution
-        if lookups:
+        # Materialize lookups: when a lookup schedule is available, defer
+        # internal lookups to the correct group boundary. Otherwise (backward
+        # compat) materialize everything upfront.
+        if lookups and plan.lookup_schedule is not None:
+            # Materialize only lookups scheduled at group 0 (external / pre-thread)
+            _materialize_scheduled(0)
+        elif lookups:
             cached_lookup_dfs, all_lookup_results = materialize_lookups(
                 spark, lookups, collector=collector, parent_span_id=weave_span_id
             )
@@ -159,7 +177,14 @@ def execute_weave(
                 cleanup_lookups(cached_lookup_dfs)
                 raise
 
-        for group in plan.execution_order:
+        for group_idx, group in enumerate(plan.execution_order):
+            # Materialize lookups whose producers completed in prior groups.
+            # Schedule key N (N>=1) means "after group N-1 finishes" — at the
+            # top of group N's iteration all prior groups have already executed.
+            # Key 0 is handled before the loop (pre-thread external lookups).
+            if group_idx > 0:
+                _materialize_scheduled(group_idx)
+
             if aborted:
                 for name in group:
                     if thread_states[name] == "pending":
@@ -482,10 +507,12 @@ def execute_loom(
         weave = weaves[weave_name]
         weave_threads = threads[weave_name]
 
+        weave_lookups = dict(weave.lookups) if weave.lookups else None
         plan = build_plan(
             weave_name=weave_name,
             threads=weave_threads,
             thread_entries=list(weave.threads),
+            lookups=weave_lookups,
         )
 
         # Build thread condition map from ThreadEntry conditions

--- a/src/weevr/result.py
+++ b/src/weevr/result.py
@@ -325,11 +325,13 @@ class LoadedConfig:
             typed_threads: dict[str, Thread] = {}
             for name, t in thread_map.items():
                 typed_threads[name] = t if isinstance(t, Thread) else Thread.model_validate(t)
+            weave_lookups = dict(weave.lookups) if weave.lookups else None
             plans.append(
                 build_plan(
                     weave_name=weave_name,
                     threads=typed_threads,
                     thread_entries=list(weave.threads),
+                    lookups=weave_lookups,
                 )
             )
 
@@ -348,11 +350,13 @@ class LoadedConfig:
                 typed_threads = {}
                 for name, t in thread_map.items():
                     typed_threads[name] = t if isinstance(t, Thread) else Thread.model_validate(t)
+                lk = dict(weave_obj.lookups) if weave_obj.lookups else None
                 plans.append(
                     build_plan(
                         weave_name=weave_name,
                         threads=typed_threads,
                         thread_entries=list(weave_obj.threads),
+                        lookups=lk,
                     )
                 )
 

--- a/tests/weevr/engine/test_planner.py
+++ b/tests/weevr/engine/test_planner.py
@@ -8,6 +8,8 @@ import pytest
 
 from weevr.engine.planner import build_plan
 from weevr.errors.exceptions import ConfigError
+from weevr.model.lookup import Lookup
+from weevr.model.source import Source
 from weevr.model.thread import Thread
 from weevr.model.weave import ThreadEntry
 
@@ -387,3 +389,150 @@ class TestExecutionPlanInspectability:
         }
         plan = build_plan("w", threads, _entries("A", "B"))
         assert "A" in plan.dependencies["B"]
+
+
+# ---------------------------------------------------------------------------
+# Helpers — lookups
+# ---------------------------------------------------------------------------
+
+
+def _make_lookup(alias: str, materialize: bool = True) -> Lookup:
+    """Create a minimal Lookup pointing at the given source alias."""
+    return Lookup(source=Source(type="delta", alias=alias), materialize=materialize)
+
+
+def _make_thread_with_lookup(
+    name: str,
+    lookup_name: str,
+    target_alias: str | None = None,
+    source_aliases: list[str] | None = None,
+) -> Thread:
+    """Create a Thread with a lookup-based source."""
+    sources: dict = {}
+    if source_aliases:
+        for alias in source_aliases:
+            sources[alias] = {"type": "delta", "alias": alias}
+    sources[f"lk_{lookup_name}"] = {"lookup": lookup_name}
+
+    target: dict = {}
+    if target_alias:
+        target["alias"] = target_alias
+
+    return Thread.model_validate(
+        {
+            "name": name,
+            "config_version": "1.0",
+            "sources": sources,
+            "target": target,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lookup dependency inference tests
+# ---------------------------------------------------------------------------
+
+
+class TestLookupDependencyInference:
+    def test_lookup_creates_implicit_dependency(self):
+        """Thread A produces data → lookup reads it → Thread B consumes lookup → B depends on A."""
+        threads = {
+            "A": _make_thread("A", target_alias="silver.dim_customer"),
+            "B": _make_thread_with_lookup("B", "cust_lookup"),
+        }
+        lookups = {"cust_lookup": _make_lookup("silver.dim_customer")}
+        plan = build_plan("w", threads, _entries("A", "B"), lookups=lookups)
+        assert "A" in plan.dependencies["B"]
+
+    def test_consumer_moves_to_later_group(self):
+        """Lookup-mediated dep forces consumer into a later group than producer."""
+        threads = {
+            "A": _make_thread("A", target_alias="silver.dim_customer"),
+            "B": _make_thread_with_lookup("B", "cust_lookup"),
+        }
+        lookups = {"cust_lookup": _make_lookup("silver.dim_customer")}
+        plan = build_plan("w", threads, _entries("A", "B"), lookups=lookups)
+        assert plan.execution_order == [["A"], ["B"]]
+
+    def test_external_lookup_scheduled_at_group_0(self):
+        """Lookup with no producer thread is scheduled at group 0."""
+        threads = {"A": _make_thread_with_lookup("A", "ext_lookup")}
+        lookups = {"ext_lookup": _make_lookup("external.ref_table")}
+        plan = build_plan("w", threads, _entries("A"), lookups=lookups)
+        assert plan.lookup_schedule is not None
+        assert 0 in plan.lookup_schedule
+        assert "ext_lookup" in plan.lookup_schedule[0]
+
+    def test_internal_lookup_scheduled_after_producer(self):
+        """Lookup whose source is produced by thread in group 0 → scheduled at group 1."""
+        threads = {
+            "A": _make_thread("A", target_alias="silver.dim_customer"),
+            "B": _make_thread_with_lookup("B", "cust_lookup"),
+        }
+        lookups = {"cust_lookup": _make_lookup("silver.dim_customer")}
+        plan = build_plan("w", threads, _entries("A", "B"), lookups=lookups)
+        assert plan.lookup_schedule is not None
+        assert 1 in plan.lookup_schedule
+        assert "cust_lookup" in plan.lookup_schedule[1]
+        # Should not be at group 0
+        assert "cust_lookup" not in plan.lookup_schedule.get(0, [])
+
+    def test_mixed_external_and_internal_lookups(self):
+        """External lookup at group 0, internal lookup at producer_group + 1."""
+        threads = {
+            "A": _make_thread("A", target_alias="silver.dim_customer"),
+            "B": _make_thread_with_lookup("B", "cust_lookup"),
+        }
+        lookups = {
+            "cust_lookup": _make_lookup("silver.dim_customer"),
+            "ext_ref": _make_lookup("external.codes"),
+        }
+        # B also has a normal source for ext_ref — but the lookup schedule is about lookups
+        plan = build_plan("w", threads, _entries("A", "B"), lookups=lookups)
+        assert plan.lookup_schedule is not None
+        assert "ext_ref" in plan.lookup_schedule.get(0, [])
+        assert "cust_lookup" in plan.lookup_schedule.get(1, [])
+
+    def test_cycle_through_lookup_raises(self):
+        """Circular dependency through a lookup is caught."""
+        # A produces silver.dim → lookup reads silver.dim → B consumes lookup
+        # B produces silver.fact → A reads silver.fact
+        # This creates: A → B (via lookup) and B → A (via source) = cycle
+        threads = {
+            "A": _make_thread("A", target_alias="silver.dim", source_aliases=["silver.fact"]),
+            "B": _make_thread_with_lookup("B", "dim_lk", target_alias="silver.fact"),
+        }
+        lookups = {"dim_lk": _make_lookup("silver.dim")}
+        with pytest.raises(ConfigError, match="Circular dependency"):
+            build_plan("w", threads, _entries("A", "B"), lookups=lookups)
+
+    def test_no_lookups_schedule_is_none(self):
+        """Without lookups, lookup_schedule is None."""
+        threads = {"A": _make_thread("A")}
+        plan = build_plan("w", threads, _entries("A"))
+        assert plan.lookup_schedule is None
+
+    def test_non_materialized_lookup_excluded_from_schedule(self):
+        """Lookup with materialize=False is not in the schedule."""
+        threads = {
+            "A": _make_thread("A", target_alias="silver.dim"),
+            "B": _make_thread_with_lookup("B", "dim_lk"),
+        }
+        lookups = {"dim_lk": _make_lookup("silver.dim", materialize=False)}
+        plan = build_plan("w", threads, _entries("A", "B"), lookups=lookups)
+        assert plan.lookup_schedule is not None
+        # Schedule should be empty (no materialized lookups)
+        all_scheduled = [lk for lks in plan.lookup_schedule.values() for lk in lks]
+        assert "dim_lk" not in all_scheduled
+
+    def test_lookup_dep_still_inferred_when_not_materialized(self):
+        """Even non-materialized lookups create implicit dependencies for ordering."""
+        threads = {
+            "A": _make_thread("A", target_alias="silver.dim"),
+            "B": _make_thread_with_lookup("B", "dim_lk"),
+        }
+        lookups = {"dim_lk": _make_lookup("silver.dim", materialize=False)}
+        plan = build_plan("w", threads, _entries("A", "B"), lookups=lookups)
+        # B still depends on A via the lookup
+        assert "A" in plan.dependencies["B"]
+        assert plan.execution_order == [["A"], ["B"]]

--- a/tests/weevr/engine/test_runner.py
+++ b/tests/weevr/engine/test_runner.py
@@ -959,6 +959,229 @@ class TestWeaveLookupIntegration:
         mock_cleanup.assert_called_once_with({"ref": mock_df})
 
 
+class TestDeferredLookupMaterialization:
+    """Test schedule-aware lookup materialization in execute_weave."""
+
+    @patch("weevr.engine.runner.execute_thread")
+    @patch("weevr.engine.runner.materialize_lookups")
+    def test_deferred_lookup_materialized_at_scheduled_group(self, mock_mat, mock_exec):
+        """Internal lookup is materialized after its producer group, not upfront."""
+        from weevr.engine.lookups import LookupResult
+        from weevr.model.lookup import Lookup
+        from weevr.model.source import Source
+
+        # Track call ordering to verify materialization happens after producer
+        call_order: list[str] = []
+
+        mock_df = MagicMock()
+        mock_mat.side_effect = lambda spark, lk_dict, **kwargs: (
+            call_order.append(f"materialize:{','.join(lk_dict.keys())}"),
+            (
+                {n: mock_df for n in lk_dict},
+                [LookupResult(name=n, materialized=True, row_count=10) for n in lk_dict],
+            ),
+        )[1]
+
+        def exec_side_effect(spark, thread, **kwargs):
+            call_order.append(f"execute:{thread.name}")
+            return _make_result(thread.name)
+
+        mock_exec.side_effect = exec_side_effect
+
+        # A produces silver.dim_customer; lookup reads it; B consumes lookup
+        lookups = {
+            "cust": Lookup(
+                source=Source(type="delta", alias="silver.dim_customer"),
+                materialize=True,
+            )
+        }
+        threads = {
+            "A": _make_thread("A", target_alias="silver.dim_customer"),
+            "B": Thread.model_validate(
+                {
+                    "name": "B",
+                    "config_version": "1.0",
+                    "sources": {"lk_cust": {"lookup": "cust"}},
+                    "target": {},
+                }
+            ),
+        }
+        plan = build_plan("test_weave", threads, _entries("A", "B"), lookups=lookups)
+        assert plan.lookup_schedule is not None
+        assert 1 in plan.lookup_schedule
+        assert "cust" in plan.lookup_schedule[1]
+
+        result = execute_weave(_MOCK_SPARK, plan, threads, lookups=lookups)
+        assert result.status == "success"
+        # materialize_lookups should be called once (deferred to after group 0)
+        assert mock_mat.call_count == 1
+        # The call should be for the "cust" lookup only
+        call_lookups = mock_mat.call_args[0][1]
+        assert "cust" in call_lookups
+        # Producer must execute BEFORE the lookup is materialized
+        assert call_order.index("execute:A") < call_order.index("materialize:cust")
+
+    @patch("weevr.engine.runner.execute_thread")
+    @patch("weevr.engine.runner.materialize_lookups")
+    def test_no_schedule_falls_back_to_upfront(self, mock_mat, mock_exec):
+        """Without lookup_schedule, all lookups are materialized upfront."""
+        from weevr.engine.lookups import LookupResult
+        from weevr.model.lookup import Lookup
+        from weevr.model.source import Source
+
+        mock_df = MagicMock()
+        mock_mat.return_value = (
+            {"ref": mock_df},
+            [LookupResult(name="ref", materialized=True, row_count=5)],
+        )
+        mock_exec.return_value = _make_result("A")
+
+        lookups = {
+            "ref": Lookup(
+                source=Source(type="delta", alias="ext.table"),
+                materialize=True,
+            )
+        }
+        threads = {"A": _make_thread("A")}
+        # Build plan without lookups → no schedule
+        plan = build_plan("test_weave", threads, _entries("A"))
+        assert plan.lookup_schedule is None
+
+        result = execute_weave(_MOCK_SPARK, plan, threads, lookups=lookups)
+        assert result.status == "success"
+        # Upfront materialization should be called once with all lookups
+        mock_mat.assert_called_once()
+
+    @patch("weevr.engine.runner.execute_thread")
+    @patch("weevr.engine.runner.materialize_lookups")
+    def test_external_lookup_materialized_at_group_0(self, mock_mat, mock_exec):
+        """External lookup (no producer) is materialized before first group."""
+        from weevr.engine.lookups import LookupResult
+        from weevr.model.lookup import Lookup
+        from weevr.model.source import Source
+
+        mock_df = MagicMock()
+        mock_mat.return_value = (
+            {"ext": mock_df},
+            [LookupResult(name="ext", materialized=True, row_count=3)],
+        )
+        mock_exec.return_value = _make_result("A")
+
+        lookups = {
+            "ext": Lookup(
+                source=Source(type="delta", alias="external.codes"),
+                materialize=True,
+            )
+        }
+        threads = {
+            "A": Thread.model_validate(
+                {
+                    "name": "A",
+                    "config_version": "1.0",
+                    "sources": {"lk_ext": {"lookup": "ext"}},
+                    "target": {},
+                }
+            )
+        }
+        plan = build_plan("test_weave", threads, _entries("A"), lookups=lookups)
+        assert plan.lookup_schedule is not None
+        assert 0 in plan.lookup_schedule
+
+        result = execute_weave(_MOCK_SPARK, plan, threads, lookups=lookups)
+        assert result.status == "success"
+        mock_mat.assert_called_once()
+
+    @patch("weevr.engine.runner.execute_thread")
+    @patch("weevr.engine.runner.cleanup_lookups")
+    @patch("weevr.engine.runner.materialize_lookups")
+    def test_cleanup_handles_deferred_lookups(self, mock_mat, mock_cleanup, mock_exec):
+        """Cleanup receives all cached lookups regardless of materialization timing."""
+        from weevr.engine.lookups import LookupResult
+        from weevr.model.lookup import Lookup
+        from weevr.model.source import Source
+
+        mock_df = MagicMock()
+        mock_mat.return_value = (
+            {"cust": mock_df},
+            [LookupResult(name="cust", materialized=True, row_count=5)],
+        )
+        mock_exec.side_effect = lambda spark, thread, **kwargs: _make_result(thread.name)
+
+        lookups = {
+            "cust": Lookup(
+                source=Source(type="delta", alias="silver.dim"),
+                materialize=True,
+            )
+        }
+        threads = {
+            "A": _make_thread("A", target_alias="silver.dim"),
+            "B": Thread.model_validate(
+                {
+                    "name": "B",
+                    "config_version": "1.0",
+                    "sources": {"lk_cust": {"lookup": "cust"}},
+                    "target": {},
+                }
+            ),
+        }
+        plan = build_plan("test_weave", threads, _entries("A", "B"), lookups=lookups)
+        execute_weave(_MOCK_SPARK, plan, threads, lookups=lookups)
+
+        mock_cleanup.assert_called_once()
+        cleaned = mock_cleanup.call_args[0][0]
+        assert "cust" in cleaned
+
+    @patch("weevr.engine.runner.execute_thread")
+    @patch("weevr.engine.runner.materialize_lookups")
+    def test_mixed_lookups_materialized_at_different_groups(self, mock_mat, mock_exec):
+        """External lookup at group 0, internal lookup deferred to after producer."""
+        from weevr.engine.lookups import LookupResult
+        from weevr.model.lookup import Lookup
+        from weevr.model.source import Source
+
+        call_log: list[dict] = []
+
+        def mat_side_effect(spark, lk_dict, **kwargs):
+            names = list(lk_dict.keys())
+            call_log.append({"lookups": names})
+            result_dfs = {n: MagicMock() for n in names}
+            results = [LookupResult(name=n, materialized=True, row_count=1) for n in names]
+            return result_dfs, results
+
+        mock_mat.side_effect = mat_side_effect
+        mock_exec.side_effect = lambda spark, thread, **kwargs: _make_result(thread.name)
+
+        lookups = {
+            "ext_codes": Lookup(
+                source=Source(type="delta", alias="external.codes"),
+                materialize=True,
+            ),
+            "cust": Lookup(
+                source=Source(type="delta", alias="silver.dim"),
+                materialize=True,
+            ),
+        }
+        threads = {
+            "A": _make_thread("A", target_alias="silver.dim"),
+            "B": Thread.model_validate(
+                {
+                    "name": "B",
+                    "config_version": "1.0",
+                    "sources": {"lk_cust": {"lookup": "cust"}, "lk_ext": {"lookup": "ext_codes"}},
+                    "target": {},
+                }
+            ),
+        }
+        plan = build_plan("test_weave", threads, _entries("A", "B"), lookups=lookups)
+        result = execute_weave(_MOCK_SPARK, plan, threads, lookups=lookups)
+
+        assert result.status == "success"
+        # Two separate calls: ext_codes at group 0, cust after group 0
+        assert len(call_log) == 2
+        assert "ext_codes" in call_log[0]["lookups"]
+        assert "cust" in call_log[1]["lookups"]
+
+
 class TestWeaveVariableIntegration:
     """Test variable context in execute_weave."""
 


### PR DESCRIPTION
## Summary

- Planner infers implicit thread dependencies mediated by lookups and computes a materialization schedule
- Runner defers internal lookup materialization to after the producer group completes, fixing first-run failures
- External lookups (no producer in the weave) are materialized before the first group, preserving existing behavior

## Why

When a lookup's source table is produced by a thread in the same weave, the previous upfront materialization caused first-run failures (table doesn't exist yet) and stale-cache reads on subsequent runs. This is the Fabcon Demo 4 scenario where `silver.dim_customer` is written by a thread but the lookup tries to read it before any threads run.

## What changed

- **`src/weevr/engine/planner.py`** — Extracted `_build_target_index()` for reuse. Added `_infer_lookup_dependencies()` and `_compute_lookup_schedule()`. Extended `ExecutionPlan` with `lookup_schedule` field. `build_plan()` accepts optional `lookups` parameter.
- **`src/weevr/engine/runner.py`** — `execute_weave()` uses the schedule to materialize lookups at group boundaries. Extracted `_materialize_scheduled()` helper to eliminate duplication. Falls back to upfront materialization when no schedule (backward compat).
- **`src/weevr/context.py`** — Passes lookups to `build_plan()` at all 5 call sites (execute, validate, plan modes).
- **`src/weevr/result.py`** — Passes lookups to `build_plan()` in `LoadedConfig.execution_plan`.
- **`tests/weevr/engine/test_planner.py`** — 9 new tests: implicit deps, group ordering, external/internal/mixed, cycles, non-materialized, None default.
- **`tests/weevr/engine/test_runner.py`** — 5 new tests: deferred materialization ordering, upfront fallback, external at group 0, cleanup, mixed scheduling. Key test verifies producer executes before lookup materializes.

## How to test

- [x] uv sync --dev
- [x] uv run ruff check .
- [x] uv run ruff format .
- [x] uv run pyright .
- [x] uv run pytest

## Release / Versioning

- [x] PR title follows Conventional Commit format (feat:, fix:, chore:, docs:, ci:, etc.)
- [ ] Breaking change indicated (feat!: / fix!: or BREAKING CHANGE in body)

## Notes

- No YAML schema changes — inference is automatic from existing config
- `build_plan()` without lookups returns `lookup_schedule=None`, preserving full backward compatibility