### PR TITLE
chore(docs): add v1.4 release notes and fix doc drift

### DIFF
--- a/docs/concepts/execution-modes.md
+++ b/docs/concepts/execution-modes.md
@@ -54,6 +54,8 @@ dag                          # renders inline in a notebook
 ```
 
 For per-weave access in a loom, use `result.execution_plan[0].dag()`.
+Note that `result.dag()` includes full resolved-thread context (sources,
+targets, step counts) while the per-plan accessor does not.
 
 ## Data modes
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -326,7 +326,8 @@ The `summary()` output marks cache targets with an asterisk and includes
 footer counts (threads, cached, lookups). `explain()` provides a
 section-by-section breakdown including dependency provenance (inferred vs
 explicit), cache consumers, lookup schedule, and per-thread source/target
-detail. In notebooks, all result modes render automatically as styled
+detail. For loom-scoped results, `explain()` opens with a loom summary
+line showing the loom name and weave count. In notebooks, all result modes render automatically as styled
 HTML. Plan mode includes an embedded DAG diagram; execute mode shows a
 thread results table with status badges and row counts.
 

--- a/docs/guides/engine-internals.md
+++ b/docs/guides/engine-internals.md
@@ -14,8 +14,9 @@ conditional execution, and structured result collection.
 ## Key concepts
 
 - **ExecutionPlan** — An immutable snapshot of thread ordering, dependency
-  edges, parallel execution groups, cache targets, and lookup dependency
-  mappings (`lookup_producers`, `lookup_consumers`). Produced by the planner
+  edges, parallel execution groups, cache targets, lookup dependency
+  mappings (`lookup_producers`, `lookup_consumers`), and a
+  `lookup_schedule` that assigns each lookup to its materialization point. Produced by the planner
   before any data is read. In notebooks, an `ExecutionPlan` renders
   automatically via `_repr_html_()`. Call `plan.dag()` to get a `DAGDiagram`
   SVG that can be saved with `dag.save("plan.svg")`. For plan mode results,

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -3,7 +3,7 @@
 weevr is designed to run within the Microsoft Fabric runtime. The table below
 lists the tested and supported versions for each dependency.
 
-Last validated against weevr **1.3.0**.
+Last validated against weevr **1.4.0**.
 
 ## Runtime matrix
 

--- a/docs/release-notes/1.4.md
+++ b/docs/release-notes/1.4.md
@@ -1,0 +1,126 @@
+<!-- markdownlint-disable MD033 -->
+
+# Release Notes — v1.4
+
+**Release date:** March 2026
+
+This release adds **plan display, DAG visualization, and rich result
+rendering** — bringing notebook-native display, structured plan
+inspection, and exportable SVG DAGs to the engine.
+
+---
+
+## Plan Mode Enhancements
+
+### `explain()` — Detailed Plan Breakdown
+
+Plan mode results now include an `explain()` method that produces a
+section-by-section breakdown of the execution plan:
+
+```python
+result = ctx.run("nightly.loom", mode="plan")
+print(result.explain())
+```
+
+The output includes:
+
+- **Dependencies** with provenance (inferred vs explicit)
+- **Cache targets** and their downstream consumers
+- **Lookup schedule** with materialization points
+- **Per-thread detail** — sources, targets, write modes, and step counts
+
+For loom-scoped results, the output opens with a loom summary line
+showing the loom name and weave count.
+
+### `summary()` — Compact Plan View
+
+The `summary()` method provides a compact execution group view with
+cache markers (asterisk suffix) and footer counts for threads, cached
+targets, and lookups:
+
+```python
+print(result.summary())
+```
+
+```text
+Group 0: dim_product*
+Group 1: fact_orders, fact_returns
+
+3 threads, 1 cached, 1 lookup
+```
+
+## DAG Visualization
+
+### `result.dag()` — Exportable SVG DAGs
+
+Plan mode results expose a `dag()` method that returns a `DAGDiagram`
+object:
+
+```python
+result = ctx.run("nightly.loom", mode="plan")
+dag = result.dag()
+dag.save("plan.svg")    # export to file
+dag                      # renders inline in a notebook
+```
+
+For multi-weave looms, `dag()` returns a loom-level swimlane diagram
+with weave containers stacked vertically. Single-weave results get a
+standard DAG.
+
+### Lookup Nodes in DAGs
+
+Lookups are rendered as distinct pill-shaped nodes in the DAG with
+directed edges showing producer-to-lookup and lookup-to-consumer
+relationships. Internal lookups (produced by a thread in the weave) show
+the producer edge; external lookups appear as standalone nodes feeding
+into their consumers.
+
+### `ExecutionPlan.dag()`
+
+Individual execution plans also expose a `dag()` method for per-weave
+access:
+
+```python
+plan = result.execution_plan[0]
+dag = plan.dag()
+dag.save("weave.svg")
+```
+
+## Rich Notebook Rendering
+
+All result modes now render automatically as styled HTML when evaluated
+in a notebook cell:
+
+- **Execute** — thread results table with status badges, row counts,
+  write modes, and target paths
+- **Validate** — check/error report with color-coded status
+- **Plan** — summary table with embedded DAG diagram
+- **Preview** — output shape table (columns x rows per thread)
+
+The HTML rendering uses inline styles for compatibility with both light
+and dark Fabric notebook themes.
+
+## Resolved Thread Context
+
+Plan mode results now carry resolved thread metadata (sources, targets,
+step counts) through to display rendering. This enables the `explain()`
+output and the enriched DAG nodes.
+
+## Planner: Lookup Producer/Consumer Tracking
+
+The `ExecutionPlan` model now includes `lookup_producers` and
+`lookup_consumers` mappings that track which threads produce and consume
+each lookup. These fields power the lookup node rendering in DAGs and
+the lookup section in `explain()` output.
+
+## Compatibility
+
+No breaking changes. All existing configurations and API usage continue
+to work without modification.
+
+| Component | Version |
+|-----------|---------|
+| Python | 3.11 |
+| PySpark | 3.5.x |
+| Delta Lake | 3.2.x |
+| Microsoft Fabric Runtime | 1.3 |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,7 @@ nav:
   - FAQ: faq.md
   - Contributing: contributing.md
   - Release Notes:
+      - "1.4": release-notes/1.4.md
       - "1.3": release-notes/1.3.md
       - "1.2.1": release-notes/1.2.1.md
       - "1.2": release-notes/1.2.md


### PR DESCRIPTION
## Summary

- Add v1.4.0 release notes page covering plan display, DAG visualization, and rich result rendering
- Fix documentation drift across compatibility, execution modes, engine internals, and FAQ pages

## Why

v1.4.0 shipped with no narrative release notes page. A post-release docs review also found stale version references and minor accuracy gaps introduced by M102 features.

## What changed

- `docs/release-notes/1.4.md` — new release notes page for v1.4
- `mkdocs.yml` — added 1.4 nav entry under Release Notes
- `docs/reference/compatibility.md` — bumped validated version from 1.3.0 to 1.4.0
- `docs/concepts/execution-modes.md` — clarified that per-plan `dag()` lacks resolved-thread context vs `result.dag()`
- `docs/guides/engine-internals.md` — added `lookup_schedule` to ExecutionPlan attribute listing
- `docs/faq.md` — noted loom-level header in `explain()` output

## How to test

- [x] uv sync --dev
- [x] uv run ruff check .
- [x] uv run ruff format .
- [x] uv run pyright .
- [x] uv run pytest
- [x] uv run mkdocs build --strict

## Release / Versioning

- [x] PR title follows Conventional Commit format (feat:, fix:, chore:, docs:, ci:, etc.)
- [ ] Breaking change indicated (feat!: / fix!: or BREAKING CHANGE in body)

## Notes

- Uses `chore(docs)` type intentionally to avoid triggering a patch release for docs-only changes