### PR TITLE
chore(docs): fix relative SVG paths in v1.5 release notes

### DIFF
--- a/docs/release-notes/1.5.md
+++ b/docs/release-notes/1.5.md
@@ -34,7 +34,7 @@ arrows through the transform chain.
 return `None`.
 
 <figure>
-  <img src="../assets/svg/flow-example.svg"
+  <img src="../../assets/svg/flow-example.svg"
     alt="Thread flow diagram showing sources, joins,
     transforms, and target">
   <figcaption>Example flow diagram for a
@@ -61,7 +61,7 @@ thread execution groups, and post-hooks as sequential phases with
 wall-clock duration bars.
 
 <figure>
-  <img src="../assets/svg/timeline-example.svg"
+  <img src="../../assets/svg/timeline-example.svg"
     alt="Execution timeline Gantt chart showing
     phased execution">
   <figcaption>Timeline for a weave with a lookup
@@ -76,7 +76,7 @@ each processing stage: rows read, after transforms, quarantined, and
 rows written. Preview mode shows the first two stages only.
 
 <figure>
-  <img src="../assets/svg/waterfall-example.svg"
+  <img src="../../assets/svg/waterfall-example.svg"
     alt="Data waterfall chart showing row counts
     through processing stages">
   <figcaption>Waterfall for <code>fact_orders</code>:
@@ -90,7 +90,7 @@ Execute mode results include an annotated DAG with colored status badges
 (success/failure/skipped) and duration annotations on each thread node.
 
 <figure>
-  <img src="../assets/svg/annotated-dag-example.svg"
+  <img src="../../assets/svg/annotated-dag-example.svg"
     alt="Annotated DAG with status badges and
     duration labels">
   <figcaption>Post-execution DAG for a loom with six


### PR DESCRIPTION
## Summary

- Fix broken SVG images on the v1.5 release notes page by correcting relative paths in HTML img tags

## Why

- Raw HTML `<img>` tags use browser-relative path resolution, not MkDocs source-relative resolution
- With `use_directory_urls`, the page is served at `/{version}/release-notes/1.5/index.html`, so `../assets/svg/` resolves one level too shallow
- SVGs were returning 404 on the published docs site

## What changed

- `docs/release-notes/1.5.md` — changed `../assets/svg/` to `../../assets/svg/` in all four `<figure>` img tags
- The extra `../` accounts for the `use_directory_urls` path structure and works across all mike version prefixes (`/latest/`, `/1.5/`, etc.)

## How to test

- [x] uv sync --dev
- [x] uv run ruff check .
- [x] uv run ruff format .
- [x] uv run pyright .
- [x] uv run pytest
- [x] uv run mkdocs build --strict
- After deploy, verify SVGs load at `/{version}/release-notes/1.5/`

## Release / Versioning

- [x] PR title follows Conventional Commit format (feat:, fix:, chore:, docs:, ci:, etc.)
- [ ] Breaking change indicated (feat!: / fix!: or BREAKING CHANGE in body)

## Notes

- MkDocs resolves markdown image syntax (`![](...)`) relative to the source file, but raw HTML `<img src="">` is resolved by the browser relative to the served URL — this distinction caused the breakage