### PR TITLE
chore(docs): add v1.6 release notes and fix docs drift

### DIFF
--- a/docs/concepts/thread-weave-loom.md
+++ b/docs/concepts/thread-weave-loom.md
@@ -196,7 +196,7 @@ merged.
 !!! tip "Inheritance reduces repetition"
 
     Define common patterns once at the loom level (write modes, audit
-    templates, execution settings) and override only where a thread differs.
+    columns, execution settings) and override only where a thread differs.
     Most threads need very little thread-level configuration when inheritance
     is used effectively.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -210,18 +210,19 @@ By default, weevr uses null-safe join semantics to prevent the common
 Spark pitfall where `NULL = NULL` evaluates to `NULL` (not `true`),
 silently dropping rows from join results.
 
-If you need to customize this behavior, configure null key handling at the
-thread level:
+Null-safe behavior is configured per join step and is enabled by default:
 
 ```yaml
-keys:
-  null_safe: true
-  null_key_replacement: "__NULL__"
+steps:
+  - join:
+      source: dim_region
+      type: left
+      on: [region_id]
+      null_safe: true   # default — rows with null keys are preserved
 ```
 
-When `null_safe` is enabled, null key values are replaced with a sentinel
-before the join and restored afterward. This ensures rows with null keys
-participate in joins as expected.
+Set `null_safe: false` on a specific join step to use standard Spark join
+semantics where null keys do not match.
 
 ---
 

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -3,7 +3,7 @@
 weevr is designed to run within the Microsoft Fabric runtime. The table below
 lists the tested and supported versions for each dependency.
 
-Last validated against weevr **1.5.0**.
+Last validated against weevr **1.6.0**.
 
 ## Runtime matrix
 

--- a/docs/release-notes/1.6.md
+++ b/docs/release-notes/1.6.md
@@ -1,0 +1,120 @@
+# Release Notes — v1.6
+
+**Release date:** March 2026
+
+This release adds **audit column injection** — automatic governance and
+traceability columns appended to thread outputs via configuration, with
+additive cascade inheritance across loom, weave, and thread levels.
+
+---
+
+## Audit Columns
+
+### Configuration
+
+Define `audit_columns` as name-expression pairs at any config level.
+Expressions use Spark SQL syntax and support context variables.
+
+**Loom level** (applied to all threads):
+
+```yaml
+# my-project.loom
+defaults:
+  audit_columns:
+    _weevr_loaded_at: "current_timestamp()"
+    _weevr_run_id: "'${param.run_id}'"
+    _weevr_loom: "'${loom.name}'"
+```
+
+**Weave level** (extends loom columns):
+
+```yaml
+# staging.weave
+defaults:
+  audit_columns:
+    _weevr_weave: "'${weave.name}'"
+```
+
+**Thread level** (extends loom + weave columns):
+
+```yaml
+# stg_orders.thread
+target:
+  alias: silver.stg_orders
+  audit_columns:
+    _weevr_thread: "'${thread.name}'"
+    _weevr_source: "'${thread.source}'"
+```
+
+### Additive Cascade
+
+Unlike standard config inheritance where child values replace parent
+values entirely, `audit_columns` uses **additive merge**:
+
+- Each level extends the column set from higher levels
+- Same-named columns at a lower level override the expression
+- Columns cannot be removed from the inherited set
+
+In the example above, `stg_orders` would receive all seven audit columns
+from loom + weave + thread.
+
+### Context Variables
+
+Audit column expressions can reference execution context:
+
+| Variable | Description |
+|----------|-------------|
+| `${thread.name}` | Thread name |
+| `${thread.qualified_key}` | Fully qualified key (e.g. `staging.stg_orders`) |
+| `${thread.source}` | Primary source alias |
+| `${thread.sources}` | JSON array of all sources with type metadata |
+| `${weave.name}` | Weave name |
+| `${loom.name}` | Loom name |
+
+Context variables are resolved before Spark SQL evaluation. Parameter
+variables (`${param.*}`) and runtime variables (`${var.*}`) are resolved
+during config loading, before audit column injection.
+
+### Write Mode Support
+
+Audit columns are injected for all write modes: append, overwrite,
+merge, and CDC merge. They bypass target mapping mode — always included
+in the output regardless of whether `mapping_mode` is `auto` or
+`explicit`.
+
+### Column Conflict Validation
+
+If an audit column name conflicts with an existing DataFrame column, the
+engine raises an `ExecutionError` before writing. Rename either the
+audit column or the business column to resolve the conflict.
+
+## Telemetry
+
+`ThreadTelemetry` now includes an `audit_columns_applied` field listing
+the names of audit columns injected during execution.
+
+## New Public Exports
+
+The following are now exported from `weevr.operations`:
+
+- `AuditContext` — execution context for audit column variable resolution
+- `inject_audit_columns` — resolve variables and inject audit columns
+  into a DataFrame
+- `resolve_audit_columns` — merge audit column dicts additively across
+  config levels
+- `build_sources_json` — build the `${thread.sources}` JSON array from
+  thread source definitions
+
+## Compatibility
+
+No breaking changes. The previously unused `Target.audit_template` field
+has been replaced by `Target.audit_columns`. Since `audit_template` was
+never implemented, this is not a breaking change — no existing
+configurations referenced it.
+
+| Component | Version |
+|-----------|---------|
+| Python | 3.11 |
+| PySpark | 3.5.x |
+| Delta Lake | 3.2.x |
+| Microsoft Fabric Runtime | 1.3 |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,7 @@ nav:
   - FAQ: faq.md
   - Contributing: contributing.md
   - Release Notes:
+      - "1.6": release-notes/1.6.md
       - "1.5": release-notes/1.5.md
       - "1.4": release-notes/1.4.md
       - "1.3": release-notes/1.3.md

--- a/src/weevr/engine/executor.py
+++ b/src/weevr/engine/executor.py
@@ -58,14 +58,16 @@ def execute_thread(
     3. Set the primary (first) source as the working DataFrame.
     4. Run pipeline steps against the working DataFrame.
     5. Run validation rules (if configured) — quarantine or abort on failures.
-    6. Compute business keys and hashes if configured.
-    7. Resolve the target write path.
-    8. Apply target column mapping.
-    9. Write to the Delta target.
-       - For ``cdc``: use CDC merge routing instead of standard write.
-    10. Persist watermark state (if applicable).
-    11. Run post-write assertions (if configured).
-    12. Build telemetry and return ThreadResult.
+    6. Apply naming normalization (if configured).
+    7. Compute business keys and hashes if configured.
+    8. Resolve the target write path.
+    9. Apply target column mapping.
+    10. Inject audit columns (if configured; bypasses mapping mode).
+    11. Write to the Delta target.
+        - For ``cdc``: use CDC merge routing instead of standard write.
+    12. Persist watermark state (if applicable).
+    13. Run post-write assertions (if configured).
+    14. Build telemetry and return ThreadResult.
 
     Args:
         spark: Active SparkSession.
@@ -82,7 +84,8 @@ def execute_thread(
             Stored on ThreadTelemetry for thread-level runs.
         loom_name: Loom name for audit column context variables.
         weave_name: Weave name for audit column context variables.
-            Derived from ``thread.qualified_key`` when not provided.
+            Derived from the prefix of ``thread.qualified_key`` when not
+            provided. Falls back to empty string if no dot separator exists.
 
     Returns:
         :class:`ThreadResult` with status, row count, write mode, target path,


### PR DESCRIPTION
## Summary

- Add v1.6 release notes documenting audit column support
- Fix docs drift found during post-release review

## Why

- v1.6.0 shipped without release notes
- Post-release docs review identified 5 issues across FAQ, compatibility, executor docstring, and concepts

## What changed

- **New**: `docs/release-notes/1.6.md` — full release notes for audit columns feature
- **Fix**: `docs/faq.md` — replaced non-existent `keys.null_safe` / `keys.null_key_replacement` with correct `steps[].join.null_safe` configuration
- **Fix**: `docs/reference/compatibility.md` — version stamp 1.5.0 → 1.6.0
- **Fix**: `src/weevr/engine/executor.py` — docstring updated from 12 to 14 pipeline steps (naming normalization + audit injection)
- **Fix**: `docs/concepts/thread-weave-loom.md` — "audit templates" → "audit columns"
- **Nav**: `mkdocs.yml` — added v1.6 release notes entry

## How to test

- [x] uv sync --dev
- [x] uv run ruff check .
- [x] uv run ruff format .
- [x] uv run pyright .
- [x] uv run pytest
- [x] uv run mkdocs build --strict

## Release / Versioning

- [x] PR title follows Conventional Commit format (feat:, fix:, chore:, docs:, ci:, etc.)
- [ ] Breaking change indicated (feat!: / fix!: or BREAKING CHANGE in body)

## Notes

- The FAQ null-safe keys issue predates v1.6 — it documented `keys.null_safe` and `keys.null_key_replacement` fields that never existed in the model