### PR TITLE
chore(docs): add v1.7 release notes and fix docs drift

### DIFF
--- a/docs/release-notes/1.7.md
+++ b/docs/release-notes/1.7.md
@@ -1,0 +1,177 @@
+# Release Notes — v1.7
+
+**Release date:** March 2026
+
+This release adds **exports** — declarative secondary output
+destinations that write thread data to additional locations in
+configurable formats, without duplicating pipeline logic.
+
+Also includes enhanced **flow SVG** visualization with validation,
+quarantine, assertions, and export nodes, plus a new **Sankey-style
+waterfall** replacing the horizontal bar chart.
+
+---
+
+## Exports (Secondary Outputs)
+
+### Configuration
+
+Declare `exports` at the thread, weave, or loom level. Each export
+writes the same post-mapping, audit-injected DataFrame as the
+primary target.
+
+```yaml
+exports:
+  - name: parquet_archive
+    description: "Daily archive for external consumers"
+    type: parquet
+    path: /lakehouse/archive/orders/${run.timestamp}/
+    partition_by: [region]
+    on_failure: warn
+
+  - name: csv_extract
+    type: csv
+    path: /lakehouse/exports/orders_latest/
+    options:
+      header: "true"
+      delimiter: "|"
+```
+
+### Supported Formats
+
+Five Fabric-native Spark formats are supported:
+
+| Format | Path | Alias | Notes |
+|--------|------|-------|-------|
+| `delta` | yes | yes | Metastore or OneLake path |
+| `parquet` | yes | no | Compression via `options` |
+| `csv` | yes | no | Header, delimiter via `options` |
+| `json` | yes | no | One object per line |
+| `orc` | yes | no | Hive-compatible columnar |
+
+### Cascade Inheritance
+
+Exports cascade additively through loom → weave → thread,
+following the same pattern as `audit_columns`:
+
+- All levels contribute exports; collected by name
+- Same-named exports at a lower level override the definition
+- `enabled: false` suppresses an inherited export
+
+```yaml
+# loom defaults — archive for every thread
+defaults:
+  exports:
+    - name: audit_archive
+      type: parquet
+      path: /archive/${thread.name}/${run.timestamp}/
+
+# thread level — suppress for this thread
+exports:
+  - name: audit_archive
+    enabled: false
+```
+
+### Dynamic Path Naming
+
+Export paths support context variables for unique-per-run outputs:
+
+| Variable | Description |
+|----------|-------------|
+| `${run.timestamp}` | ISO 8601 UTC timestamp of execution start |
+| `${run.id}` | UUID4 unique per execution |
+| `${thread.name}` | Thread name |
+| `${weave.name}` | Weave name |
+| `${loom.name}` | Loom name |
+
+These are resolved at execution time, not config load time.
+
+### Error Handling
+
+Each export has an `on_failure` setting (default: `warn`):
+
+- **`warn`** — log warning, continue to next export, thread
+  succeeds
+- **`abort`** — raise `ExportError`, thread fails, remaining
+  exports skipped
+
+Exports only execute after a successful primary write, watermark
+persistence, and assertions. Export failures never corrupt the
+primary target or watermark state.
+
+## Run Context Variables
+
+Two new system-wide context variables are available in audit
+column expressions and export path templates:
+
+- `${run.timestamp}` — ISO 8601 UTC timestamp
+- `${run.id}` — UUID4 identifier
+
+These are generated once per `execute_thread()` call, ensuring
+consistent values across audit columns and export paths within a
+single execution.
+
+## Enhanced Flow SVG
+
+The thread flow diagram now shows the complete data pipeline:
+
+- **Validation gate** — appears after transforms when validations
+  are configured
+- **Quarantine destination** — branches down from validation
+- **Assertions checkpoint** — appears after the target node
+- **Export destinations** — fan out from the preparation stage as
+  siblings of the target (not downstream of target)
+
+When no validations, assertions, or exports are configured, the
+flow remains unchanged.
+
+## Sankey-Style Waterfall
+
+The horizontal bar chart waterfall has been replaced with a
+proportional band-width Sankey flow:
+
+- Rows read → after transforms → validation split → target +
+  exports
+- Quarantine branch shown with proportional band width
+- Export bands shown alongside the target band
+- Row counts labeled on each band
+
+## Observability
+
+- `explain()` lists exports with name, type, and target path
+- `summary()` shows per-export results (rows, status, errors)
+- `ThreadTelemetry.export_results` captures `ExportResult` for
+  each export (name, type, target, rows_written, duration_ms,
+  status, error)
+
+## New Public Exports
+
+From `weevr.operations`:
+
+- `write_export` — write a DataFrame to an export target
+- `resolve_exports` — resolve context variables in export paths
+- `resolve_export_path` — substitute variables in a single path
+
+From `weevr.telemetry`:
+
+- `ExportResult` — per-export write result model
+
+From `weevr.model`:
+
+- `Export` — export domain model
+
+From `weevr.errors`:
+
+- `ExportError` — raised on `on_failure: abort` export failure
+
+## Compatibility
+
+No breaking changes. All new fields default to `None` or empty —
+existing configurations work without modification.
+
+| Component | Version |
+|-----------|---------|
+| Python | 3.11 |
+| PySpark | 3.5.x |
+| Delta Lake | 3.2.x |
+| Microsoft Fabric Runtime | 1.3 |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,7 @@ nav:
   - FAQ: faq.md
   - Contributing: contributing.md
   - Release Notes:
+      - "1.7": release-notes/1.7.md
       - "1.6": release-notes/1.6.md
       - "1.5": release-notes/1.5.md
       - "1.4": release-notes/1.4.md

--- a/src/weevr/telemetry/results.py
+++ b/src/weevr/telemetry/results.py
@@ -95,6 +95,8 @@ class ThreadTelemetry(FrozenBase):
             Populated on the outermost telemetry object only (thread-level runs).
         audit_columns_applied: Names of audit columns injected into the output
             DataFrame for this thread.
+        export_results: Per-export write results, one per export configured
+            on the thread.
     """
 
     span: ExecutionSpan


### PR DESCRIPTION
## Summary

- Add v1.7 release notes documenting exports feature
- Fix ThreadTelemetry docstring drift (missing export_results)

## Why

v1.7.0 shipped without release notes in the docs site. The
ThreadTelemetry docstring was also missing the new export_results
attribute, causing it to be absent from the auto-generated API
reference.

## What changed

- `docs/release-notes/1.7.md` — new file covering exports, run
  context variables, enhanced flow SVG, Sankey waterfall, public
  API exports, and compatibility
- `mkdocs.yml` — added 1.7 nav entry under Release Notes
- `src/weevr/telemetry/results.py` — added export_results to
  ThreadTelemetry Attributes docstring

## How to test

- [x] uv sync --dev
- [x] uv run ruff check .
- [x] uv run ruff format .
- [x] uv run pyright .
- [x] uv run pytest
- [x] uv run mkdocs build --strict
- [x] npx markdownlint-cli2 "docs/**/*.md" (0 errors)

## Release / Versioning

- [x] PR title follows Conventional Commit format
- [ ] Breaking change indicated

## Notes

- Non-releasing change (chore type)