### PR TITLE
fix(engine): rewrite Sankey waterfall with proper visualization

### DIFF
--- a/src/weevr/engine/display.py
+++ b/src/weevr/engine/display.py
@@ -1702,13 +1702,13 @@ def render_waterfall_svg(
 
     # --- Compute band heights ---
     clean_rows = max(rows_after - rows_quarantined, 0) if mode == "execute" else 0
-    output_dests: list[tuple[str, int, str]] = []
+    output_dests: list[tuple[str, int]] = []
     if mode == "execute":
-        output_dests.append(("Target", rows_written, "#bee3f8"))
+        output_dests.append(("Target", rows_written))
         for er in export_results:
             er_name = getattr(er, "name", "export")
             er_rows = getattr(er, "rows_written", 0)
-            output_dests.append((er_name, er_rows, "#bbf7d0"))
+            output_dests.append((er_name, er_rows))
 
     has_quarantine = mode == "execute" and rows_quarantined > 0
     n_cols = 2 if mode == "preview" else (4 if has_quarantine else 3)
@@ -1717,7 +1717,7 @@ def render_waterfall_svg(
     h_after = _bh(rows_after)
     h_clean = _bh(clean_rows) if has_quarantine else _bh(rows_after)
     h_quar = _bh(rows_quarantined) if has_quarantine else 0.0
-    h_outputs = [_bh(c) for _, c, _ in output_dests]
+    h_outputs = [_bh(c) for _, c in output_dests]
 
     # Canvas sizing
     max_stack = max(
@@ -1937,7 +1937,7 @@ def render_waterfall_svg(
         total_out = sum(h_outputs) + band_gap * max(len(h_outputs) - 1, 0)
         y_out = cy - total_out / 2
         n_out = len(output_dests)
-        for oi, (olabel, ocount, _ocolor) in enumerate(output_dests):
+        for oi, (olabel, ocount) in enumerate(output_dests):
             oh = h_outputs[oi]
             role = "target" if oi == 0 else "export"
             _draw_band(cx3, y_out, col_w, oh, olabel, ocount, role)
@@ -1960,7 +1960,7 @@ def render_waterfall_svg(
         total_out = sum(h_outputs) + band_gap * max(len(h_outputs) - 1, 0)
         y_out = cy - total_out / 2
         n_out = len(output_dests)
-        for oi, (olabel, ocount, _ocolor) in enumerate(output_dests):
+        for oi, (olabel, ocount) in enumerate(output_dests):
             oh = h_outputs[oi]
             role = "target" if oi == 0 else "export"
             _draw_band(cx2, y_out, col_w, oh, olabel, ocount, role)


### PR DESCRIPTION
## Summary

- Rewrite Sankey waterfall SVG with smooth Bezier curves, correct
  data flow topology, and theme-aligned colors
- Fix quarantine flowing into target (now terminal — quarantine
  rows go to quarantine table, not target)
- Add full dark mode support and visual contrast between bands and
  flow paths

## Why

The original Sankey implementation had three visual bugs: overlapping
angular trapezoid paths instead of smooth curves, quarantine label
overlapping clean rows, and quarantine incorrectly connecting forward
to target. Light mode also lacked contrast between bands and flows,
and dark mode was not supported for the waterfall SVG.

## What changed

- `src/weevr/engine/display.py` — `render_waterfall_svg()` rewritten:
  - Cubic Bezier curves (`C` paths) replace straight-line trapezoids
  - Quarantine is a terminal node with no forward flow
  - Band min height 34px with labels inside bands (not below)
  - 24px gap between stacked bands prevents label overlap
  - Contrasting stroke borders on band rects for light mode clarity
  - Colors pulled from shared `_FLOW_LIGHT`/`_FLOW_DARK` palettes
    so Sankey bands match flow SVG node colors exactly
  - Full `@media(prefers-color-scheme:dark)` CSS overrides for all
    band roles (fill + stroke) and flow opacity
  - Removed unused color field from output_dests tuples

## How to test

- [x] uv sync --dev
- [x] uv run ruff check .
- [x] uv run ruff format .
- [x] uv run pyright .
- [x] uv run pytest
- [x] Tested in live Microsoft Fabric notebook (light + dark mode)

## Release / Versioning

- [x] PR title follows Conventional Commit format
- [ ] Breaking change indicated

## Notes

- Verified in Fabric Runtime 1.3 notebook across multiple iterations
- Function signature unchanged — backward compatible