### PR TITLE
chore(docs): fix docs drift across schema, guides, and API reference

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -68,10 +68,10 @@ Configuration cascades through three levels: **Loom** > **Weave** >
 A loom can define default write modes, execution settings, and audit
 columns. A weave can override any of those. A thread can override
 anything the weave set. Scalar values are replaced outright; collections
-(lists, maps) are also replaced entirely, not merged. The exception is
-`audit_columns`, which uses **additive merge** -- each level extends the
-column set, and same-named columns at a lower level override the
-expression from the higher level.
+(lists, maps) are also replaced entirely, not merged. The exceptions are
+`audit_columns` and `exports`, which use **additive merge** -- each
+level extends the set, and same-named entries at a lower level override
+those from the higher level.
 
 ```text
 Loom default:   write.mode = overwrite
@@ -232,9 +232,9 @@ Yes. There are two approaches:
 
 **Thread-level auto-caching** — The `CacheManager` analyzes the thread
 dependency DAG within a weave. When it detects that a thread's output
-feeds multiple downstream consumers, it persists the output at
-`MEMORY_AND_DISK` level automatically. You can force caching on a
-specific thread with `cache: true` or disable it with `cache: false`.
+feeds two or more downstream consumers, it persists the output at
+`MEMORY_AND_DISK` level automatically. You can disable auto-caching on
+a specific thread with `cache: false`.
 
 **Weave-level lookups** — Define named lookups in the weave's `lookups`
 block. Lookups can be pre-materialized (read once, cached or broadcast

--- a/docs/guides/engine-internals.md
+++ b/docs/guides/engine-internals.md
@@ -78,6 +78,9 @@ The planner builds a DAG from thread configurations:
    concurrently.
 5. **Analyze cache targets** — Threads with two or more downstream dependents
    are flagged for caching, unless the thread explicitly sets `cache: false`.
+   Setting `cache: true` is a no-op — it only prevents `cache: false`
+   suppression but does not force caching for threads with fewer than two
+   dependents.
 
 The result is an immutable `ExecutionPlan` that the executor consumes without
 modification.
@@ -94,19 +97,22 @@ skipped.
 
 **Weave level** (`execute_weave`) — Orchestrates the full weave lifecycle:
 
-1. **Pre-steps** — If the weave defines `pre_steps`, hook steps run before
+1. **Initialize variables** — A `VariableContext` is created from the
+   weave's `variables` block. Variables are available to hook steps via
+   `${var.name}` placeholders.
+2. **Lookup materialization (external)** — External lookups (those not
+   produced by a thread in the weave) are materialized before any thread
+   or hook step runs. Internal lookups whose source is produced by a
+   thread in group N are deferred and materialized at the group N+1
+   boundary — after their producer completes.
+3. **Pre-steps** — If the weave defines `pre_steps`, hook steps run before
    any thread executes. Failures with `on_failure: abort` stop the weave.
-2. **Lookup materialization** — Named lookups are materialized according to
-   the planner's lookup schedule. External lookups (those not produced by a
-   thread in the weave) are pre-read before the first group. Internal lookups
-   whose source is produced by a thread in group N are deferred and
-   materialized at the group N+1 boundary — after their producer completes.
-   Threads reference lookups via `source.lookup` and receive the cached
-   DataFrame.
-3. **Thread execution** — Parallel groups are processed sequentially. Within
+   Pre-steps can read from lookups materialized in the previous step.
+4. **Thread execution** — Parallel groups are processed sequentially. Within
    each group, threads are submitted to a `ThreadPoolExecutor` for concurrent
-   execution.
-4. **Post-steps** — After all threads complete, `post_steps` hook steps run.
+   execution. Threads reference lookups via `source.lookup` and receive
+   the cached DataFrame.
+5. **Post-steps** — After all threads complete, `post_steps` hook steps run.
    Failures with `on_failure: abort` mark the weave as failed.
 
 After each thread completes:
@@ -116,7 +122,7 @@ After each thread completes:
   consumers remain.
 - Thread-level telemetry collectors are merged into the weave collector.
 
-**Thread level** (`execute_thread`) — A single thread runs through a 14-step
+**Thread level** (`execute_thread`) — A single thread runs through a 15-step
 pipeline:
 
 ```d2
@@ -152,8 +158,9 @@ finalize: Finalize {
   style.fill: "#F3E5F5"
   s10: "12. Persist watermark/CDC state"
   s11: "13. Post-write assertions"
-  s12: "14. Build telemetry\n→ ThreadResult"
-  s10 -> s11 -> s12
+  s11b: "14. Write exports\n(secondary outputs)"
+  s12: "15. Build telemetry\n→ ThreadResult"
+  s10 -> s11 -> s11b -> s12
 }
 
 sources -> transforms
@@ -174,7 +181,8 @@ write -> finalize
 11. Write to the Delta target (standard write or CDC merge routing)
 12. Persist watermark or CDC state
 13. Run post-write assertions
-14. Build telemetry and return `ThreadResult`
+14. Write exports (secondary outputs, if configured)
+15. Build telemetry and return `ThreadResult`
 
 ### Failure handling
 

--- a/docs/how-to/cache-a-lookup.md
+++ b/docs/how-to/cache-a-lookup.md
@@ -34,39 +34,15 @@ dim_product  -->  fact_orders
 Because `dim_product` feeds two consumers, weevr auto-caches its output after
 it finishes writing.
 
-## Step 2 -- Force-cache a thread
+## Step 2 -- Prevent cache suppression
 
-If the engine does not auto-detect a caching opportunity (for example, the
-thread is not part of a multi-consumer DAG but you know it will be read
-repeatedly), you can force caching with the `cache` flag on the thread:
+By default, threads with two or more downstream dependents are auto-cached.
+Setting `cache: true` on a thread is a no-op in the current engine — it
+only prevents `cache: false` suppression. It does **not** force caching for
+threads with fewer than two dependents.
 
-```yaml
-# lookups/dim_product.thread
-config_version: "1.0"
-
-sources:
-  products:
-    type: delta
-    alias: bronze.products
-
-steps:
-  - select:
-      columns:
-        - product_id
-        - product_name
-        - category
-
-target:
-  path: Tables/dim_product
-
-write:
-  mode: overwrite
-
-cache: true
-```
-
-Setting `cache: true` instructs the engine to persist this thread's output
-regardless of the DAG analysis.
+If you need a thread's output to be shared across multiple consumers, use
+[weave-level lookups](#step-4----use-weave-level-lookups) instead.
 
 ## Step 3 -- Disable caching for a thread
 

--- a/docs/reference/api/model.md
+++ b/docs/reference/api/model.md
@@ -2,7 +2,8 @@
 
 The `weevr.model` package contains all Pydantic domain models that represent
 the configuration structure -- threads, weaves, looms, pipeline steps, sources,
-targets, hooks, lookups, and supporting types.
+targets, hooks, lookups, exports, variables, failure configuration, and
+supporting types.
 
 ::: weevr.model
     options:

--- a/docs/reference/api/operations.md
+++ b/docs/reference/api/operations.md
@@ -1,8 +1,9 @@
 # Operations API
 
 The `weevr.operations` module implements the concrete readers, transformation
-steps, writers, and quality gates that the engine dispatches to. Each pipeline
-step type maps to an operation function.
+steps, writers, audit column injection, export writers, quarantine handling,
+and quality gates that the engine dispatches to. Each pipeline step type
+maps to an operation function.
 
 ::: weevr.operations
     options:

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -3,7 +3,7 @@
 weevr is designed to run within the Microsoft Fabric runtime. The table below
 lists the tested and supported versions for each dependency.
 
-Last validated against weevr **1.6.0**.
+Last validated against weevr **1.7.1**.
 
 ## Runtime matrix
 

--- a/docs/reference/configuration-keys.md
+++ b/docs/reference/configuration-keys.md
@@ -14,7 +14,7 @@ data_flow: Data Flow {
     shape: class
     config_version: str
     sources: "dict[str, Source]"
-    step_list: "list[Step]"
+    "steps": "list[Step]"
     target: Target
   }
   Source: Source {
@@ -208,7 +208,7 @@ Write mode and merge behavior for the target.
 | `on_no_match_target` | `"insert" \| "ignore"` | `"insert"` | Action for new source rows |
 | `on_no_match_source` | `"delete" \| "soft_delete" \| "ignore"` | `"ignore"` | Action for missing source rows |
 | `soft_delete_column` | `str` | `None` | Column for soft delete flag (required for `soft_delete`) |
-| `soft_delete_value` | `str` | `"true"` | Value written to the soft delete column |
+| `soft_delete_value` | `bool` | `True` | Value written to the soft delete column |
 
 ---
 

--- a/docs/reference/yaml-schema/thread.md
+++ b/docs/reference/yaml-schema/thread.md
@@ -476,7 +476,7 @@ Controls how data is written to the target.
 | `on_no_match_target` | `string` | no | `"insert"` | Merge behavior for new source rows: `"insert"` or `"ignore"` |
 | `on_no_match_source` | `string` | no | `"ignore"` | Merge behavior for missing source rows: `"delete"`, `"soft_delete"`, `"ignore"` |
 | `soft_delete_column` | `string` | no | `null` | Column to flag soft deletes. Required when `on_no_match_source` is `"soft_delete"`. |
-| `soft_delete_value` | `string` | no | `"true"` | Value written to the soft delete column |
+| `soft_delete_value` | `bool` | no | `true` | Value written to the soft delete column |
 
 ```yaml
 write:
@@ -486,7 +486,7 @@ write:
   on_no_match_target: insert
   on_no_match_source: soft_delete
   soft_delete_column: is_deleted
-  soft_delete_value: "true"
+  soft_delete_value: true
 ```
 
 ---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,7 +58,7 @@ nav:
           - Weave: reference/yaml-schema/weave.md
           - Loom: reference/yaml-schema/loom.md
       - API:
-          - Context: reference/api/context.md
+          - Context & Results: reference/api/context.md
           - Config: reference/api/config.md
           - Model: reference/api/model.md
           - Engine: reference/api/engine.md


### PR DESCRIPTION
## Summary

- Fix 11 documentation drift findings (4 high, 3 medium, 4 low) identified by a full docs-review audit at v1.7.1
- Correct inaccuracies in YAML schema types, engine internals lifecycle, cache behavior, and API reference intros

## Why

- Docs-review audit found incorrect information that could mislead users (wrong types, wrong pipeline step counts, wrong execution order)
- Several v1.6/v1.7 features (exports, audit columns) were missing from API intros and FAQ

## What changed

- `docs/reference/yaml-schema/thread.md` — fix `soft_delete_value` type from `string` to `bool`
- `docs/reference/configuration-keys.md` — fix `soft_delete_value` type; fix D2 diagram field `step_list` → `steps`
- `docs/guides/engine-internals.md` — update thread pipeline from 14→15 steps (add exports write); fix weave lifecycle order (variables → lookups → pre-steps); clarify `cache: true` behavior
- `docs/how-to/cache-a-lookup.md` — rewrite "force-cache" section to accurately describe `cache: true` as no-op
- `docs/faq.md` — remove `cache: true` force-cache claim; add `exports` to additive merge inheritance
- `docs/reference/compatibility.md` — update version stamp from 1.6.0 to 1.7.1
- `docs/reference/api/operations.md` — add audit columns, exports, quarantine to intro
- `docs/reference/api/model.md` — add exports, variables, failure config to intro
- `mkdocs.yml` — rename nav entry "Context" → "Context & Results" for discoverability

## How to test

- [x] uv sync --dev
- [x] uv run ruff check .
- [x] uv run ruff format .
- [x] uv run pyright .
- [x] uv run pytest
- [x] uv run mkdocs build --strict
- [x] npx markdownlint-cli2 "docs/**/*.md"

## Release / Versioning

- [x] PR title follows Conventional Commit format (feat:, fix:, chore:, docs:, ci:, etc.)
- [ ] Breaking change indicated (feat!: / fix!: or BREAKING CHANGE in body)

## Notes

- The `cache: true` finding revealed a code/docs discrepancy — confirmed as a docs bug (the planner intentionally only uses `cache: false` for suppression)
- Patch release notes (e.g., 1.7.1) are folded into the existing minor release page per project convention