### PR TITLE
chore(build): add gtr to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,7 +29,7 @@
         "source=${localEnv:USERPROFILE}/.codex,target=/home/vscode/.codex,type=bind,consistency=cached"
     ],
 
-    "postCreateCommand": "git config --global --add safe.directory /workspaces/weevr && curl -fsSL https://claude.ai/install.sh | bash && uv sync --dev",
+    "postCreateCommand": "git config --global --add safe.directory /workspaces/weevr && curl -fsSL https://claude.ai/install.sh | bash && git clone https://github.com/coderabbitai/git-worktree-runner.git /home/vscode/.gtr && ln -sf /home/vscode/.gtr/bin/git-gtr /usr/local/bin/git-gtr && uv sync --dev",
 
     // Keep the venv current on every container start (not just first create).
     "postStartCommand": "uv sync",


### PR DESCRIPTION
## Summary

- Install git-worktree-runner (gtr) in the devcontainer so worktree-based workflows work out of the box

## Why

- gtr is used by the `using-worktrees` skill to create isolated worktrees with `.claude/` symlinked for sub-agent dispatch
- Without it installed, `git gtr` commands fail in the devcontainer

## What changed

- Added `git clone` + `ln -sf` for gtr to `postCreateCommand` in `.devcontainer/devcontainer.json`
- gtr is cloned to `/home/vscode/.gtr` and symlinked to `/usr/local/bin/git-gtr`

## How to test

- [ ] Rebuild the devcontainer
- [ ] Run `git gtr --help` and verify it responds
- [ ] Run `git gtr run echo hello` to verify worktree creation works

## Release / Versioning

- [ ] PR title follows Conventional Commit format (feat:, fix:, chore:, docs:, ci:, etc.)
- [ ] Breaking change indicated (feat!: / fix!: or BREAKING CHANGE in body)

## Notes

- No version bump — `chore` type is not release-triggering