### PR TITLE
chore(docs): add v1.8 release notes and fix docs drift

### DIFF
--- a/docs/guides/engine-internals.md
+++ b/docs/guides/engine-internals.md
@@ -100,20 +100,29 @@ skipped.
 1. **Initialize variables** — A `VariableContext` is created from the
    weave's `variables` block. Variables are available to hook steps via
    `${var.name}` placeholders.
-2. **Lookup materialization (external)** — External lookups (those not
-   produced by a thread in the weave) are materialized before any thread
-   or hook step runs. Internal lookups whose source is produced by a
-   thread in group N are deferred and materialized at the group N+1
-   boundary — after their producer completes.
-3. **Pre-steps** — If the weave defines `pre_steps`, hook steps run before
-   any thread executes. Failures with `on_failure: abort` stop the weave.
-   Pre-steps can read from lookups materialized in the previous step.
-4. **Thread execution** — Parallel groups are processed sequentially. Within
-   each group, threads are submitted to a `ThreadPoolExecutor` for concurrent
-   execution. Threads reference lookups via `source.lookup` and receive
-   the cached DataFrame.
-5. **Post-steps** — After all threads complete, `post_steps` hook steps run.
-   Failures with `on_failure: abort` mark the weave as failed.
+2. **Lookup materialization (external)** — External lookups
+   (those not produced by a thread in the weave) are materialized
+   before any thread or hook step runs. Internal lookups whose
+   source is produced by a thread in group N are deferred and
+   materialized at the group N+1 boundary — after their producer
+   completes.
+3. **Column set materialization** — If the weave (or loom) defines
+   `column_sets`, all sets are resolved to from→to mapping dicts.
+   Delta/YAML sources are read via `read_source()`; param sources
+   resolve from runtime parameters. Results are captured in
+   `WeaveTelemetry.column_set_results`.
+4. **Pre-steps** — If the weave defines `pre_steps`, hook steps
+   run before any thread executes. Failures with
+   `on_failure: abort` stop the weave. Pre-steps can read from
+   lookups materialized in step 2.
+5. **Thread execution** — Parallel groups are processed
+   sequentially. Within each group, threads are submitted to a
+   `ThreadPoolExecutor` for concurrent execution. Threads
+   reference lookups via `source.lookup` and receive the cached
+   DataFrame.
+6. **Post-steps** — After all threads complete, `post_steps` hook
+   steps run. Failures with `on_failure: abort` mark the weave
+   as failed.
 
 After each thread completes:
 

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -265,10 +265,17 @@ depends on what was executed:
   **watermark_new_value** -- Watermark state for incremental loads
 - **cdc_inserts**, **cdc_updates**, **cdc_deletes** -- CDC operation
   counts
-- **audit_columns_applied** -- Names of audit columns injected into the
-  output
-- **export_results** -- Per-export write results (`ExportResult` list with
-  name, type, target, rows_written, duration_ms, status, error)
+- **rows_after_transforms** -- Row count after pipeline transforms,
+  before validation
+- **audit_columns_applied** -- Names of audit columns injected
+  into the output
+- **export_results** -- Per-export write results (`ExportResult`
+  list with name, type, target, rows_written, duration_ms,
+  status, error)
+- **watermark_persisted** -- Whether the watermark was
+  successfully persisted after write
+- **watermark_first_run** -- Whether this is the first run with
+  no prior watermark state
 
 ### Weave telemetry fields
 

--- a/docs/release-notes/1.8.md
+++ b/docs/release-notes/1.8.md
@@ -1,0 +1,165 @@
+# Release Notes — v1.8
+
+**Release date:** March 2026
+
+This release adds **dictionary rename** — named column sets that
+source bulk column mappings from Delta tables, YAML files, or
+runtime parameters — and **naming enhancements** including
+kebab-case, collision dedup, and reserved word protection.
+
+---
+
+## Dictionary Rename (Column Sets)
+
+### Configuration
+
+Declare `column_sets` at the weave or loom level. Each column set
+maps raw column names to friendly names from an external source.
+
+```yaml
+column_sets:
+  sap_dictionary:
+    source:
+      type: delta
+      alias: ref.column_dictionary
+      from_column: raw_name
+      to_column: friendly_name
+      filter: "system = 'SAP'"
+    on_unmapped: pass_through
+    on_extra: ignore
+    on_failure: abort
+
+  runtime_overrides:
+    param: column_overrides
+```
+
+Reference a column set in a rename step:
+
+```yaml
+steps:
+  - rename:
+      column_set: sap_dictionary
+      columns:
+        MANUAL_COL: manual_override  # static wins
+```
+
+### Source Types
+
+| Source | Configuration | Use case |
+|--------|--------------|----------|
+| Delta table | `type: delta`, `alias` or `path` | Shared dictionary in lakehouse |
+| YAML file | `type: yaml`, `path` | Version-controlled mappings |
+| Runtime parameter | `param: <name>` | Orchestration-driven mappings |
+
+### Behavior Controls
+
+| Setting | Values | Default | Description |
+|---------|--------|---------|-------------|
+| `on_unmapped` | `pass_through`, `error` | `pass_through` | DataFrame columns with no mapping entry |
+| `on_extra` | `ignore`, `warn`, `error` | `ignore` | Mapping entries for non-existent columns |
+| `on_failure` | `abort`, `warn`, `skip` | `abort` | Source read failure or empty result |
+
+### Cascade
+
+Column sets cascade from loom → weave. Weave-level definitions
+with the same name override loom-level definitions.
+
+---
+
+## Naming Enhancements
+
+### kebab-case Pattern
+
+`kebab-case` is now a supported naming pattern:
+
+```yaml
+naming:
+  columns: kebab-case
+```
+
+!!! warning "Backtick-quoting required"
+    Hyphenated column names require backtick-quoting in Spark SQL
+    expressions. A validation warning is emitted when selected.
+
+### Collision Dedup
+
+When normalization produces duplicate column names, the new
+`on_collision` setting controls the behavior:
+
+```yaml
+naming:
+  columns: snake_case
+  on_collision: suffix  # _2, _3 suffixes in source order
+```
+
+| Value | Behavior |
+|-------|----------|
+| `error` (default) | Raise `ConfigError` listing collisions |
+| `suffix` | Append `_2`, `_3` in source column order |
+
+### Reserved Word Protection
+
+Prevent SQL-reserved column names from breaking downstream queries:
+
+```yaml
+naming:
+  columns: snake_case
+  reserved_words:
+    strategy: prefix
+    prefix: "_"
+    extend: [timestamp, value]
+    exclude: [to, by]
+```
+
+| Strategy | Behavior |
+|----------|----------|
+| `quote` (default) | No-op — Spark backtick-quotes automatically |
+| `prefix` | Prepend configured prefix string |
+| `error` | Raise `ConfigError` listing conflicts |
+
+The default reserved word list contains 82 ANSI SQL:2016 keywords.
+Use `extend` and `exclude` to customize.
+
+### Pipeline Order
+
+The full naming pipeline executes in a fixed order:
+
+1. **Rename** — column set + static mappings applied
+2. **Normalize** — pattern transformation (snake_case, etc.)
+3. **Dedup** — collision resolution (suffix or error)
+4. **Reserved words** — protection applied (prefix, quote, error)
+
+---
+
+## Observability
+
+- `ColumnSetResult` captures per-column-set resolution outcome
+  (name, source_type, mappings_loaded, skipped)
+- `WeaveTelemetry.column_set_results` populates structured
+  results from materialization
+- DEBUG-level per-mapping logs for rename, normalize, and
+  reserved word operations
+
+## New Public Exports
+
+From `weevr.model`:
+
+- `ColumnSet` — column set domain model
+- `ColumnSetSource` — source configuration for column sets
+- `ReservedWordConfig` — reserved word protection settings
+
+From `weevr.telemetry`:
+
+- `ColumnSetResult` — per-column-set resolution result
+
+## Compatibility
+
+No breaking changes. All new fields default to `None` or safe
+defaults — existing configurations work without modification.
+
+| Component | Version |
+|-----------|---------|
+| Python | 3.11 |
+| PySpark | 3.5.x |
+| Delta Lake | 3.2.x |
+| Microsoft Fabric Runtime | 1.3 |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,7 @@ nav:
   - FAQ: faq.md
   - Contributing: contributing.md
   - Release Notes:
+      - "1.8": release-notes/1.8.md
       - "1.7": release-notes/1.7.md
       - "1.6": release-notes/1.6.md
       - "1.5": release-notes/1.5.md

--- a/src/weevr/model/__init__.py
+++ b/src/weevr/model/__init__.py
@@ -14,6 +14,7 @@ from weevr.model.keys import ChangeDetectionConfig, KeyConfig, SurrogateKeyConfi
 from weevr.model.load import LoadConfig
 from weevr.model.lookup import Lookup
 from weevr.model.loom import Loom, WeaveEntry
+from weevr.model.naming import NamingConfig, NamingPattern
 from weevr.model.params import ParamsConfig, ParamSpec
 from weevr.model.pipeline import (
     AggregateStep,
@@ -117,6 +118,9 @@ __all__ = [
     "ColumnSet",
     "ColumnSetSource",
     "ReservedWordConfig",
+    # Naming
+    "NamingConfig",
+    "NamingPattern",
     # Variable
     "VariableSpec",
 ]


### PR DESCRIPTION
## Summary

- Add v1.8 release notes page covering dictionary rename and naming
  enhancements
- Fix four documentation drift issues found in post-release review

## Why

v1.8.0 shipped without a release notes page (required for minor
versions per project policy). Post-release docs check also found
three additional drift issues across guides and API reference.

## What changed

- **New:** `docs/release-notes/1.8.md` — covers column sets,
  kebab-case, collision dedup, reserved word protection, telemetry
- **New nav entry** in `mkdocs.yml` for v1.8 release notes
- **Fix:** Export `NamingConfig` and `NamingPattern` from
  `weevr.model.__init__` so mkdocstrings renders them in the API
  reference
- **Fix:** Add column set materialization step (step 3) to the
  weave execution lifecycle in `docs/guides/engine-internals.md`
- **Fix:** Add missing `rows_after_transforms`,
  `watermark_persisted`, `watermark_first_run` fields to the
  Thread telemetry section in `docs/guides/observability.md`
- **Fix:** Broken anchor in `docs/how-to/cache-a-lookup.md`
  resolved with explicit `{#weave-level-lookups}` attribute

## How to test

- [x] uv run mkdocs build --strict (0 warnings)
- [x] npx markdownlint-cli2 'docs/**/*.md' (0 errors)
- [x] uv run ruff check . (clean)
- [x] uv run pyright (0 errors)
- [x] uv run pytest tests/weevr/model/ -x (all pass)

## Release / Versioning

- [x] PR title follows Conventional Commit format
- [ ] Breaking change indicated — **not applicable**

## Notes

- `chore(docs)` type used intentionally to avoid triggering a
  Release Please patch bump for doc-only changes
- The three pre-existing drift items (ThreadTelemetry fields,
  engine internals lifecycle, broken anchor) predate v1.8 but
  are fixed here as part of the same sweep