### PR TITLE
chore(build): fix gtr symlinks in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,7 +29,7 @@
         "source=${localEnv:USERPROFILE}/.codex,target=/home/vscode/.codex,type=bind,consistency=cached"
     ],
 
-    "postCreateCommand": "git config --global --add safe.directory /workspaces/weevr && curl -fsSL https://claude.ai/install.sh | bash && git clone https://github.com/coderabbitai/git-worktree-runner.git /home/vscode/.gtr && ln -sf /home/vscode/.gtr/bin/git-gtr /usr/local/bin/git-gtr && uv sync --dev",
+    "postCreateCommand": "git config --global --add safe.directory /workspaces/weevr && curl -fsSL https://claude.ai/install.sh | bash && git clone https://github.com/coderabbitai/git-worktree-runner.git /home/vscode/.gtr && sudo ln -sf /home/vscode/.gtr/bin/git-gtr /usr/local/bin/git-gtr && sudo ln -sf /home/vscode/.gtr/bin/gtr /usr/local/bin/gtr && uv sync --dev",
 
     // Keep the venv current on every container start (not just first create).
     "postStartCommand": "uv sync",


### PR DESCRIPTION
## Summary

- Add `sudo` to gtr symlink commands in `postCreateCommand`
- Add missing `gtr` shorthand symlink alongside `git-gtr`

## Why

The `postCreateCommand` runs as `vscode` user, but `/usr/local/bin`
is owned by `root`. The existing `ln -sf` for `git-gtr` was silently
failing, leaving the tool unavailable after container creation. The
`gtr` shorthand was also never symlinked.

## What changed

`.devcontainer/devcontainer.json` `postCreateCommand`:
- `ln -sf` → `sudo ln -sf` for the existing `git-gtr` symlink
- Added `sudo ln -sf .../bin/gtr /usr/local/bin/gtr`

## How to test

- Rebuild the devcontainer
- Verify `gtr --help` and `git gtr --help` both work

## Release / Versioning

- [x] PR title follows Conventional Commit format
- [ ] Breaking change indicated — **not applicable**

## Notes

- No version bump — `chore` type