### PR TITLE
chore(docs): add v1.9 release notes and docs drift fixes

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -45,7 +45,8 @@
     "markdownlint",
     "cspell",
     "powerbi",
-    "tsql"
+    "tsql",
+    "dataflows"
   ],
   "ignorePaths": [
     "**/*.py",

--- a/docs/release-notes/1.9.md
+++ b/docs/release-notes/1.9.md
@@ -1,0 +1,100 @@
+# Release Notes — v1.9
+
+**Release date:** March 2026
+
+This release adds **reserved word presets** — named, curated word
+lists for DAX, M language (Power Query), and T-SQL that protect
+column and table names from conflicts when Delta tables are
+consumed by Power BI semantic models, Power Query dataflows, or
+Fabric SQL analytics endpoints.
+
+---
+
+## Reserved Word Presets
+
+### Background
+
+v1.8 introduced reserved word protection with a single ANSI SQL
+word list. v1.9 extends this into a **preset system** where each
+query language context has its own curated word set. Presets are
+self-contained and combinable.
+
+### Configuration
+
+Select presets with the new `preset` field on `reserved_words`:
+
+```yaml
+naming:
+  columns: snake_case
+  reserved_words:
+    preset: powerbi
+    strategy: prefix
+    prefix: "_"
+```
+
+A single string or a list is accepted:
+
+```yaml
+# Multi-engine protection:
+reserved_words:
+  preset: [ansi, dax, tsql]
+  strategy: prefix
+  extend: [fiscal_year]
+  exclude: [by]
+```
+
+### Built-in Presets
+
+| Preset | Words | Description |
+|--------|-------|-------------|
+| `ansi` | ~80 | ANSI SQL reserved keywords (existing default) |
+| `dax` | ~28 | DAX reserved words for Power BI semantic models |
+| `m` | ~21 | M language (Power Query) reserved words |
+| `powerbi` | ~45 | Convenience alias — expands to `dax` + `m` |
+| `tsql` | ~156 | T-SQL reserved keywords for SQL endpoints |
+
+### Composition Rules
+
+- **Default when omitted:** `ansi` (backwards compatible with v1.8)
+- **Explicit replaces default:** specifying any preset replaces
+  the implicit ANSI default. To include ANSI alongside others,
+  list it explicitly: `preset: [ansi, dax]`
+- **Self-contained:** each preset includes all words needed for
+  that language context, including any ANSI overlaps.
+  `preset: [tsql]` alone gives full T-SQL protection.
+- **Union composition:** multiple presets are merged via set union
+- **extend/exclude compose on top:** project-specific words add to
+  or remove from the resolved preset union
+
+### Table Name Protection
+
+Reserved word protection now applies to **both column names and
+the target table name**. Previously, only column names were
+checked. Table names matching a reserved word are handled per
+the configured strategy (prefix, quote, or error).
+
+---
+
+## Observability
+
+- DEBUG log: resolved preset names and effective word count
+- DEBUG log: individual table name reserved word matches
+
+## New Public Exports
+
+From `weevr.model`:
+
+- `ReservedWordPreset` — StrEnum of built-in preset names
+
+## Compatibility
+
+No breaking changes. The `preset` field defaults to `None`,
+preserving the existing ANSI SQL behavior for all configurations
+that do not specify a preset.
+
+| Component | Version |
+|-----------|---------|
+| Python | 3.11 |
+| PySpark | 3.5.x |
+| Delta Lake | 3.2.x |
+| Microsoft Fabric Runtime | 1.3 |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,7 @@ nav:
   - FAQ: faq.md
   - Contributing: contributing.md
   - Release Notes:
+      - "1.9": release-notes/1.9.md
       - "1.8": release-notes/1.8.md
       - "1.7": release-notes/1.7.md
       - "1.6": release-notes/1.6.md


### PR DESCRIPTION
## Summary

- Add v1.9 release notes page documenting the reserved word preset
  system shipped in PR #101
- Add `1.9` entry to mkdocs.yml navigation
- Add `dataflows` to cspell dictionary

## Why

v1.9.0 has been released to PyPI. Release notes document the new
preset system for users upgrading from v1.8.

## What changed

- `docs/release-notes/1.9.md` — new page covering presets, composition
  rules, table name protection, and new exports
- `mkdocs.yml` — nav entry for v1.9 release notes
- `.cspell.json` — `dataflows` added to dictionary

## How to test

- [x] uv run mkdocs build --strict
- [x] npx markdownlint-cli2 "docs/release-notes/1.9.md"
- [x] npx cspell "docs/release-notes/1.9.md"

## Release / Versioning

- [x] PR title follows Conventional Commit format (chore:)
- [ ] Breaking change indicated — not applicable

## Notes

- Docs-only change, no version bump