### PR TITLE
chore(docs): add v1.10 release notes

### DIFF
--- a/docs/release-notes/1.10.md
+++ b/docs/release-notes/1.10.md
@@ -1,0 +1,224 @@
+# Release Notes — v1.10
+
+**Release date:** March 2026
+
+This release adds the **resolve step** for declarative FK
+resolution, the **fk_sentinel_rate assertion** for FK quality
+gates, and a broad set of **codebase quality improvements**
+spanning model validation, error handling, security hardening,
+and telemetry reliability.
+
+---
+
+## Resolve Step
+
+### Background
+
+Foreign key resolution is a universal pattern in dimensional
+modeling. Every fact table requires resolving business keys from
+source systems into surrogate keys from dimension tables.
+Previously, this required chaining `join`, `derive`, `filter`,
+and `coalesce` steps — verbose, error-prone, and lacking
+standardized sentinel handling.
+
+### Single FK Resolve
+
+The `resolve` step encapsulates the complete FK resolution
+pattern in one declarative block:
+
+```yaml
+steps:
+  - resolve:
+      name: plant_id
+      lookup: dim_plant
+      match: plant_code
+      pk: id
+      on_invalid: -4
+      on_unknown: -1
+```
+
+Key features:
+
++ **BK completeness check** — null/blank source columns
+  automatically receive the `on_invalid` sentinel
++ **Sentinel assignment** — aligned with system member codes
+  (`on_invalid` default `-4`, `on_unknown` default `-1`)
++ **Match sugar** — string, list, or dict forms for column
+  mapping
++ **Normalization** — `trim_lower`, `trim_upper`, `trim`
+  presets applied symmetrically to both sides
++ **Include columns** — bring additional lookup columns into
+  the fact with optional rename dict and prefix
++ **on_duplicate** — `warn` (default), `error`, or `first`
+  for multi-match scenarios
++ **Resolution stats** — per-FK metadata (total, matched,
+  unknown, invalid, duplicates, match_rate)
+
+### SCD2 Narrowing
+
+The `effective` block supports two sub-modes for point-in-time
+dimension resolution:
+
+```yaml
+# Current flag (string sugar or dict form)
+effective:
+  current: is_current
+
+# Date range (half-open interval [from, to))
+effective:
+  date_column: order_date
+  from: effective_from
+  to: effective_to
+```
+
+A general `where` predicate can compose with `effective` using
+AND semantics for custom narrowing.
+
+### Batch Mode
+
+Resolve multiple FKs in one step with shared defaults:
+
+```yaml
+- resolve:
+    pk: id
+    on_invalid: -4
+    on_unknown: -1
+    batch:
+      - name: plant_id
+        lookup: dim_plant
+        match: plant_code
+      - name: customer_id
+        lookup: dim_customer
+        match:
+          customer_code: natural_id
+        normalize: trim_lower
+```
+
+Item-level values override shared defaults. Source columns are
+dropped only after all FKs complete, preventing mid-batch
+failures when columns are shared across resolutions.
+
+### Pipeline Integration
+
+The resolve step is dispatched via special handling in
+`run_pipeline()`, which now accepts an optional `lookups`
+parameter. The executor passes the effective cached lookups
+(merged from loom, weave, and thread levels) through to the
+pipeline.
+
+`on_failure: warn` assigns the `on_unknown` sentinel to all
+rows and logs a warning instead of aborting the thread when a
+lookup cannot be found (single mode only).
+
+---
+
+## fk_sentinel_rate Assertion
+
+A new post-write assertion type for checking FK sentinel value
+rates:
+
+```yaml
+assertions:
+  - type: fk_sentinel_rate
+    column: plant_id
+    sentinel: -4
+    max_rate: 0.05
+    message: "plant FK invalid rate exceeded"
+```
+
+Supports:
+
++ **Single column or columns list** — each checked
+  independently
++ **Named sentinel groups** — dict-of-int (shared max_rate)
+  or dict-of-dict (per-group rates)
++ **System member codes** — string values resolved at
+  evaluation time
+
+---
+
+## Config Validation
+
+`validate_resolve_lookups()` checks at config time that all
+resolve steps reference defined lookup names, catching
+configuration errors before execution.
+
+---
+
+## Codebase Quality Improvements
+
+### Model Validation
+
++ **Step discriminator fix** — multi-word step types
+  (`case_when`, `fill_null`, `string_ops`, `date_ops`) now
+  round-trip correctly through the discriminated union when
+  passed as model instances
++ **Empty collection guards** — `SelectParams`, `DropParams`,
+  `CastParams`, `DeriveParams`, `SortParams`, `UnionParams`
+  now reject empty column/source lists at parse time
++ **Target requires alias or path** — at least one must be
+  set
++ **Thread requires non-empty sources** — empty sources dict
+  rejected at parse time
++ **ColumnSetSource type validation** — `delta` requires
+  `alias`, `yaml` requires `path`
++ **fk_sentinel_rate presence validation** — requires at least
+  one of `column`/`columns` and `sentinel`/`sentinels`
++ **on_invalid/on_unknown uniqueness** — equal sentinel values
+  rejected to prevent stats double-counting
++ **DimensionSurrogateKeyConfig** — renamed from
+  `SurrogateKeyConfig` in the dimension module to resolve
+  namespace collision with `keys.SurrogateKeyConfig`
+
+### Public API
+
++ `STEP_TYPES` — renamed from `_STEP_TYPES` (now public)
++ New exports from `weevr.model`: `ConcatStep`, `ConcatParams`,
+  `MapStep`, `MapParams`, `FormatStep`, `FormatSpec`,
+  `FormatParams`, `ResolveStep`, `ResolveParams`,
+  `ResolveBatchItem`, `EffectiveConfig`, `CurrentConfig`,
+  `DimensionSurrogateKeyConfig`
++ `quote_identifier` — renamed from `_quote_identifier`
++ `CONTEXT_VAR_PATTERN` — renamed from `_CONTEXT_VAR_PATTERN`
+
+### Security and Reliability
+
++ **SQL injection guard** — table aliases in quality gate SQL
+  queries are now backtick-escaped via `_quote_table_ref()`
++ **Path traversal guard** — `resolve_ref_path` rejects refs
+  that escape the project root
++ **Thread name sanitization** — single quotes escaped in
+  table property keys
++ **Assert replacement** — all `assert` statements in
+  production code replaced with explicit if-raise guards that
+  survive Python `-O` optimization
++ **Error type normalization** — `ValueError` replaced with
+  `ExecutionError` in resolve and formatting handlers for
+  consistent error taxonomy
+
+### Telemetry and Observability
+
++ **Span finalization** — weave and loom telemetry spans are
+  now finalized in `finally` blocks, producing complete traces
+  even on failure paths
++ **Weave status fix** — a weave where all threads succeeded
+  or were conditionally skipped now correctly returns
+  `"success"` (was `"partial"`)
++ **CDC count consolidation** — three separate `.count()`
+  calls in `execute_cdc_merge` consolidated into a single
+  `groupBy` aggregation
+
+### Minor Improvements
+
++ `__dedup_rn__` temp column name prevents collision with user
+  columns named `_rn`
++ `FormatSpec` rejects empty pattern strings
++ `ConcatParams` rejects empty `null_literal` with literal
+  mode
++ `Export` treats empty-string path/alias same as `None`
++ `fact.py` logs exceptions at DEBUG level instead of
+  silently swallowing them in the FK sentinel advisory check
++ `WeaveTelemetry.column_set_results` typed as
+  `list[ColumnSetResult]` (was `list[Any]`)
++ Internal planning IDs stripped from all source and test
+  files

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,7 @@ nav:
   - FAQ: faq.md
   - Contributing: contributing.md
   - Release Notes:
+      - "1.10": release-notes/1.10.md
       - "1.9": release-notes/1.9.md
       - "1.8": release-notes/1.8.md
       - "1.7": release-notes/1.7.md


### PR DESCRIPTION
## Summary

+ Add v1.10 release notes documenting the resolve step, fk_sentinel_rate
  assertion, and codebase quality improvements

## Why

+ v1.10.0 has been released — release notes page needed

## What changed

+ New `docs/release-notes/1.10.md` covering:
  + Resolve step (single FK, SCD2, batch mode, pipeline integration)
  + fk_sentinel_rate assertion (sentinel groups, per-group rates)
  + Config validation (lookup reference checking)
  + Model validation hardening (15 new validators)
  + Security fixes (SQL injection, path traversal, thread name)
  + Telemetry reliability (span finalization, weave status)
  + Public API changes (new exports, renamed symbols)
  + Minor improvements
+ Nav entry added to `mkdocs.yml`

## How to test

+ [x] `npx markdownlint-cli2 "docs/release-notes/1.10.md"` — 0 errors
+ [x] `uv run mkdocs build --strict` — clean

## Release / Versioning

+ [x] PR title follows Conventional Commit format
+ [ ] Breaking change — none

## Notes

+ Docs-only change, no source code modified