### PR TITLE
chore(docs): complete v1.10 release notes with missing features

### DIFF
--- a/docs/release-notes/1.10.md
+++ b/docs/release-notes/1.10.md
@@ -2,17 +2,387 @@
 
 **Release date:** March 2026
 
-This release adds the **resolve step** for declarative FK
-resolution, the **fk_sentinel_rate assertion** for FK quality
-gates, and a broad set of **codebase quality improvements**
-spanning model validation, error handling, security hardening,
-and telemetry reliability.
+This release adds four new pipeline steps (**concat**, **map**,
+**format**, **fill_null type defaults**), two **analytical
+target modes** (dimension and fact), **audit column templates**
+with built-in presets, **shared resource universality** across
+loom/weave/thread levels, the **resolve step** for declarative
+FK resolution, the **fk_sentinel_rate assertion**, and a broad
+set of **codebase quality improvements** spanning model
+validation, error handling, security hardening, and telemetry
+reliability.
+
+---
+
+## Concat Step
+
+Concatenates multiple columns into a single string column with
+configurable null handling, separators, and trimming.
+
+```yaml
+steps:
+  - concat:
+      target: full_address
+      columns: [street, city, state, zip]
+      separator: ", "
+      null_mode: skip
+      trim: true
+      collapse_separators: true
+```
+
+Key features:
+
++ **null_mode** — `skip` (omit nulls and collapse their
+  separator), `empty` (convert nulls to empty strings), or
+  `literal` (replace with a custom string)
++ **null_literal** — replacement string when `null_mode` is
+  `literal` (default `<NULL>`)
++ **trim** — strip leading/trailing whitespace from source
+  columns before joining
++ **collapse_separators** — when nulls are skipped, collapse
+  adjacent separators into one (default `true`)
++ When all source values are null in `skip` mode, the result
+  is NULL rather than an empty string
+
+---
+
+## Map Step
+
+Maps discrete values in a column to new values using a lookup
+dictionary. Handles nulls and unmapped values independently.
+
+```yaml
+steps:
+  - map:
+      column: status_code
+      target: status_label
+      values:
+        A: "Active"
+        B: "Blocked"
+        C: "Closed"
+      default: "Unknown"
+      on_null: "Missing"
+      case_sensitive: false
+```
+
+Key features:
+
++ **target** — optional output column; when omitted, the
+  source column is overwritten in place
++ **default** — fallback value for unmapped inputs (mutually
+  exclusive with `unmapped: null` and `unmapped: validate`)
++ **on_null** — specific replacement for null inputs
++ **unmapped** — `keep` (retain original), `null` (set NULL),
+  or `validate` (keep and add a boolean flag column
+  `__map_unmapped_{column}`)
++ **case_sensitive** — set `false` for case-insensitive
+  matching (default `true`)
+
+---
+
+## Format Step
+
+Formats columns using pattern, number, or date rules. Each
+column specifies exactly one format type.
+
+```yaml
+steps:
+  - format:
+      columns:
+        phone:
+          source: raw_phone
+          pattern: "({1:3}){4:3}-{7:4}"
+        amount_display:
+          source: amount
+          number: "#,##0.00"
+        event_date:
+          date: "yyyy-MM-dd"
+```
+
+Three format types:
+
++ **pattern** — positional extraction with `{position:length}`
+  syntax (e.g., phone number formatting). `on_short` controls
+  behavior when input is shorter than the pattern: `null`
+  (default) or `partial` (best effort)
++ **number** — DecimalFormat pattern for numeric display
+  (e.g., `#,##0.00` → `1,234,567.89`). `strict_types: false`
+  auto-casts non-numeric sources
++ **date** — SimpleDateFormat pattern for date display
+  (e.g., `yyyy-MM-dd`)
+
+---
+
+## Type-Aware fill_null
+
+The `fill_null` step gains a new `type_defaults` mode that
+assigns semantically appropriate defaults based on each
+column's data type.
+
+```yaml
+steps:
+  - fill_null:
+      mode: type_defaults
+      code: unknown
+      include: ["amount_*"]
+      exclude: ["id"]
+      overrides:
+        region: "Unspecified"
+```
+
+Semantic codes and their defaults:
+
+| Code | String | Integer | Boolean | Date |
+|------|--------|---------|---------|------|
+| `unknown` | Unknown | 0 | false | 1970-01-01 |
+| `not_applicable` | Not Applicable | 0 | false | 1970-01-01 |
+| `invalid` | Invalid | 0 | false | 1970-01-01 |
+
+Key features:
+
++ **include/exclude** — glob patterns to restrict which
+  columns receive defaults (e.g., `include: ["addr_*"]`)
++ **overrides** — per-column replacements applied on top of
+  type-based defaults
++ **where** — conditional predicate to fill only matching rows
++ **Composable** — `mode: type_defaults` and explicit
+  `columns` can coexist in the same step; type defaults apply
+  first, then explicit columns override
+
+---
+
+## Analytical Target Modes
+
+### Dimension Mode
+
+Declares a dimension table with surrogate key generation,
+business key identification, SCD Type 2 history tracking,
+change detection groups, and system member rows.
+
+```yaml
+target:
+  alias: gold.dim_customer
+  dimension:
+    business_key: [customer_id]
+    surrogate_key:
+      name: sk_customer_id
+      algorithm: sha256
+      columns: [customer_id]
+      output: native
+    track_history: true
+    change_detection:
+      attrs:
+        columns: [customer_name, address]
+        on_change: version
+      static:
+        columns: [region_code]
+        on_change: static
+    columns:
+      valid_from: _valid_from
+      valid_to: _valid_to
+      is_current: _is_current
+    system_members:
+      - sk: -1
+        code: UNKNOWN
+        label: Unknown
+      - sk: -4
+        code: INVALID
+        label: Invalid Data
+```
+
+Key features:
+
++ **surrogate_key** — hash-based key generation with
+  configurable algorithm (`sha256`, `xxhash64`, `md5`,
+  `murmur3`, etc.) and output type (`native` or `string`)
++ **business_key** — one or more columns forming the natural
+  key
++ **track_history** — enables SCD Type 2 with `valid_from`,
+  `valid_to`, and `is_current` tracking columns
++ **change_detection** — named groups with independent
+  `on_change` behavior: `version` (new SCD row), `overwrite`
+  (update in place), or `static` (non-versioned metadata).
+  `columns: auto` captures remaining unclaimed columns
++ **previous_columns** — capture prior values before an update
+  (e.g., `previous_name: customer_name`)
++ **additional_keys** — extra hash keys beyond the primary
+  surrogate
++ **system_members** — sentinel rows with negative SK values
+  for Unknown, Invalid, etc. `seed_system_members: true`
+  inserts them on first load
++ **history_filter** — expose a filtered view of current rows
+  only (default `true`)
++ **dates** — configurable SCD boundary dates (`min` default
+  `1970-01-01`, `max` default `9999-12-31`)
+
+### Fact Mode
+
+Declares a fact table with foreign key columns and sentinel
+value conventions for data quality enforcement.
+
+```yaml
+target:
+  alias: gold.fact_sales
+  fact:
+    foreign_keys:
+      - customer_sk
+      - product_sk
+      - region_sk
+    sentinel_values:
+      invalid: -4
+      missing: -1
+```
+
+Key features:
+
++ **foreign_keys** — required non-empty list of FK columns
+  referencing dimensions
++ **sentinel_values** — conventions for missing and invalid
+  data (defaults: `invalid: -4`, `missing: -1`). Values must
+  be distinct to prevent stats double-counting
++ Pairs naturally with the **resolve step** and
+  **fk_sentinel_rate assertion** for end-to-end FK resolution
+  and quality gates
+
+---
+
+## Audit Column Templates
+
+### Background
+
+v1.6 introduced audit column injection via inline
+`audit_columns` dicts at the thread target level. v1.10 adds
+**named templates** — reusable sets of audit columns that can
+be defined at any level and referenced by name, with two
+built-in presets.
+
+### Built-in Presets
+
+| Preset | Cols | Description |
+|--------|------|-------------|
+| `fabric` | 9 | Fabric pipeline metadata — batch, pipeline, workspace, Spark app |
+| `minimal` | 3 | Lightweight — loaded_at, run_id, thread name |
+
+### Configuration
+
+Define custom templates and reference them by name:
+
+```yaml
+# Define at loom, weave, or thread level
+audit_templates:
+  my_standard:
+    columns:
+      _loaded_at: "current_timestamp()"
+      _run_id: "${param.run_id}"
+      _environment: "'${param.env}'"
+
+target:
+  alias: gold.customers
+  audit_template: minimal
+```
+
+Multiple templates can be referenced and merged in order:
+
+```yaml
+target:
+  alias: gold.orders
+  audit_template:
+    - minimal
+    - my_standard
+  audit_columns:
+    _custom_col: "custom_value()"
+  audit_columns_exclude:
+    - "_batch_*"
+```
+
+### Inheritance
+
+Templates cascade from loom → weave → thread:
+
++ Templates defined at the loom level are inherited by all
+  weaves and threads
++ Weave-level templates extend or override loom-level ones
++ Thread-level templates extend or override weave-level ones
++ Set `audit_template_inherit: false` on a thread to block
+  inheritance from parent levels
++ Inline `audit_columns` merge additively on top of resolved
+  templates (same-named columns override)
++ `audit_columns_exclude` applies glob patterns last to remove
+  unwanted columns
+
+### Context Variables
+
+Templates support runtime substitution:
+
++ `${thread.name}`, `${thread.qualified_key}`,
+  `${thread.source}`, `${thread.sources}`
++ `${weave.name}`, `${loom.name}`
++ `${run.timestamp}`, `${run.id}`
++ `${param.*}` (runtime parameters)
+
+---
+
+## Shared Resource Universality
+
+Prior to v1.10, shared resources like lookups, column sets,
+and variables could only be defined at the thread level. This
+release promotes resource definitions to the loom and weave
+levels, enabling centralized configuration that cascades down
+the hierarchy.
+
+### Resources at Every Level
+
+The following resources can now be defined at loom, weave,
+or thread levels:
+
++ `lookups` — named lookup source definitions
++ `column_sets` — named column rename mappings
++ `variables` — named variable specs
++ `pre_steps` / `post_steps` — named hook steps
++ `params` — parameter definitions
++ `execution` — execution config (log level, tracing)
++ `naming` — column naming conventions
++ `audit_templates` — audit column template definitions
+
+### Cascading Rules
+
+Resources merge from loom → weave → thread, with the most
+specific level winning on conflicts:
+
+```yaml
+# loom.yaml — shared across all weaves
+lookups:
+  dim_customer:
+    source:
+      type: delta
+      alias: staging.dim_customer
+
+# weave.yaml — adds weave-specific lookups
+lookups:
+  ref_status:
+    source:
+      type: delta
+      alias: reference.status_codes
+
+# thread.yaml — overrides loom-level customer lookup
+lookups:
+  dim_customer:
+    source:
+      type: delta
+      alias: dev.dim_customer_test
+```
+
+Merge semantics:
+
++ **Additive merge** — `lookups`, `column_sets`, `variables`,
+  `pre_steps`, `post_steps` merge by name across levels;
+  same-named entries at a lower level override the parent
++ **Replacement** — `execution`, `naming`, `params` at a
+  lower level replace the parent entirely
 
 ---
 
 ## Resolve Step
-
-### Background
 
 Foreign key resolution is a universal pattern in dimensional
 modeling. Every fact table requires resolving business keys from


### PR DESCRIPTION
## Summary

- Complete the v1.10 release notes to cover all five features shipped in the release

## Why

- The original release notes only documented the resolve step and fk_sentinel_rate assertion, omitting four of the five features bundled in v1.10

## What changed

Added release notes sections for:

- **Concat step** — column concatenation with null_mode, trim, separator collapse
- **Map step** — value mapping with unmapped/null handling, case sensitivity
- **Format step** — pattern, number, and date formatting
- **Type-aware fill_null** — type_defaults mode with semantic codes, include/exclude globs, overrides
- **Analytical target modes** — dimension (surrogate keys, SCD2, change detection, system members) and fact (FK columns, sentinel conventions)
- **Audit column templates** — named presets (fabric, minimal) with loom→weave→thread inheritance
- **Shared resource universality** — lookups, column_sets, variables, etc. at all hierarchy levels

Updated the intro paragraph to reflect the full scope of the release.

## How to test

- [x] uv sync --dev
- [x] uv run ruff check .
- [x] uv run ruff format .
- [x] uv run pyright .
- [x] uv run pytest

## Release / Versioning

- [x] PR title follows Conventional Commit format (chore(docs):)
- [x] Not a breaking change

## Notes

- Docs-only change — no code modifications
- All YAML examples verified against actual model definitions and test cases