### PR TITLE
chore(ci): restore release-please labeling on release PRs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,17 +33,6 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          # The labeling step is racy against GitHub's API: when
-          # release-please-action creates a PR and immediately tries to
-          # label it, the PR's GraphQL node ID can fail to resolve, the
-          # label call returns "Could not resolve to a node with the global
-          # id", and the action exits with failure. The release PR itself
-          # is created successfully, but without its `autorelease: pending`
-          # label release-please cannot recognize the eventual merged
-          # commit as a release commit and downstream tagging silently
-          # fails. Skip the racy step entirely; the workflow does not
-          # depend on these labels.
-          skip-labeling: true
 
   build:
     needs: release


### PR DESCRIPTION
## Summary

- Remove `skip-labeling: true` from the `release-please-action@v4` step in `.github/workflows/release.yaml`
- Delete the incorrect comment block explaining the "racy labeling" theory that was added with it
- Release PRs opened by release-please will once again receive the `autorelease: pending` label on creation, so post-merge detection can recognize them as release commits and trigger the tag/build/publish chain automatically

## Why

The `skip-labeling: true` setting was added during the v1.16.1 recovery under the incorrect assumption that release-please's release-detection state machine read the manifest rather than the label on the release PR. Verifying against the release-please source (`manifest.ts: findMergedReleasePullRequests`), the `autorelease: pending` label is the **only** mechanism release-please uses to detect merged release PRs and trigger tag/release creation.

With `skip-labeling: true` in place, every release PR was created without the label. On merge, release-please's post-merge detection returned `releases_created=false`, and the build/publish chain was silently skipped because of the `if:` gate on the `build` job.

This bit the v1.16.2 release cycle: PR #147 (`chore(main): release weevr 1.16.2`) was created by release-please without the label. The label was added manually with `gh pr edit 147 --add-label "autorelease: pending"` before merging, which allowed the tagging step to run. Without that manual intervention, v1.16.2 would have silently failed to ship.

## What changed

Single change in `.github/workflows/release.yaml`:

```diff
         uses: googleapis/release-please-action@v4
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          # The labeling step is racy against GitHub's API: when
-          # release-please-action creates a PR and immediately tries to
-          # label it, the PR's GraphQL node ID can fail to resolve, the
-          # label call returns "Could not resolve to a node with the global
-          # id", and the action exits with failure. The release PR itself
-          # is created successfully, but without its ` + "`autorelease: pending`" + `
-          # label release-please cannot recognize the eventual merged
-          # commit as a release commit and downstream tagging silently
-          # fails. Skip the racy step entirely; the workflow does not
-          # depend on these labels.
-          skip-labeling: true
```

Eleven-line deletion. Nothing else touched.

## How to test

- [x] YAML syntax preserved (diff shows clean deletion only)
- [x] `workflow_dispatch` + `force_release` escape hatch remains in place for manual recovery of the rare original labeling race
- [x] Commit scoped as `chore(ci)` so release-please does not produce a version bump on this fix

End-to-end validation will come with the next `feat`/`fix` that triggers a release. Release-please will open the release PR and label it automatically on creation, and the tag/build/publish chain will run without any manual intervention.

## Release / Versioning

- [x] PR title follows Conventional Commit format (`chore(ci):`)
- [x] Not a breaking change — workflow change only, does not affect library users
- [x] Does not trigger a release-please version bump (`chore` type is non-releaseable by default)

## Notes

- A `gh-CLI` labeling fallback step was deliberately **not** added. The original labeling race that motivated `skip-labeling: true` was rare (1 occurrence in 16+ releases) and the existing recovery procedure (`gh workflow run release.yaml --ref main -f force_release=true` after manually creating the tag/release and labeling the merged release PR) takes approximately 5 minutes when needed. The cost of adding and maintaining CI complexity for an infrequent transient failure outweighs the benefit.
- The original labeling race (GraphQL node ID not resolving immediately after PR creation) has been observed once. If it recurs, the `workflow_dispatch` + `force_release=true` recovery path is still the correct response — not reintroducing `skip-labeling`.