### PR TITLE
fix: forward loom/weave connections to materialize_lookups at all call sites

### DIFF
--- a/src/weevr/engine/runner.py
+++ b/src/weevr/engine/runner.py
@@ -574,6 +574,7 @@ def execute_loom(
                 dict(loom.lookups),
                 collector=collector,
                 parent_span_id=loom_span_id,
+                connections=loom.connections if loom.connections else None,
             )
 
         for weave_entry in loom.weaves:

--- a/src/weevr/engine/runner.py
+++ b/src/weevr/engine/runner.py
@@ -170,7 +170,11 @@ def execute_weave(
         if not subset:
             return
         new_cached, new_results = materialize_lookups(
-            spark, subset, collector=collector, parent_span_id=weave_span_id
+            spark,
+            subset,
+            collector=collector,
+            parent_span_id=weave_span_id,
+            connections=connections,
         )
         cached_lookup_dfs.update(new_cached)
         all_lookup_results.extend(new_results)
@@ -200,7 +204,11 @@ def execute_weave(
             _materialize_scheduled(0)
         elif lookups:
             cached_lookup_dfs, all_lookup_results = materialize_lookups(
-                spark, lookups, collector=collector, parent_span_id=weave_span_id
+                spark,
+                lookups,
+                collector=collector,
+                parent_span_id=weave_span_id,
+                connections=connections,
             )
 
         # Materialize column sets — resolve all defs into name→mapping dicts

--- a/tests/weevr/engine/test_runner.py
+++ b/tests/weevr/engine/test_runner.py
@@ -1574,6 +1574,191 @@ class TestExecuteWeaveConnectionsForwarding:
         assert call_kwargs.get("connections") is connections
 
 
+class TestExecuteWeaveConnectionsToLookups:
+    """Test that execute_weave forwards its connections kwarg to materialize_lookups.
+
+    Regression tests for the bug where loom-level connections were not forwarded
+    to materialize_lookups, causing LookupResolutionError for any lookup whose
+    source referenced a connection defined only at the loom level.
+    """
+
+    @patch("weevr.engine.runner.execute_thread")
+    @patch("weevr.engine.runner.materialize_lookups")
+    def test_connections_forwarded_to_materialize_lookups_fallback_path(self, mock_mat, mock_exec):
+        """connections is forwarded to materialize_lookups on the fallback
+        (no lookup_schedule) upfront-materialization path."""
+        from weevr.engine.lookups import LookupResult
+        from weevr.model.connection import OneLakeConnection
+        from weevr.model.lookup import Lookup
+        from weevr.model.source import Source
+
+        mock_df = MagicMock()
+        mock_mat.return_value = (
+            {"my_lookup": mock_df},
+            [LookupResult(name="my_lookup", materialized=True, row_count=5)],
+        )
+        mock_exec.return_value = _make_result("t1")
+
+        lookups = {
+            "my_lookup": Lookup(
+                source=Source(type="delta", connection="silver", table="customers"),
+                materialize=True,
+            )
+        }
+        connections = {
+            "silver": OneLakeConnection(type="onelake", workspace="ws-1", lakehouse="silver-lh"),
+        }
+        threads = {"t1": _make_thread("t1")}
+        # Build plan *without* passing lookups so lookup_schedule is None,
+        # forcing the fallback upfront-materialization branch.
+        plan = build_plan("test_weave", threads, _entries("t1"))
+        assert plan.lookup_schedule is None
+
+        result = execute_weave(_MOCK_SPARK, plan, threads, lookups=lookups, connections=connections)
+
+        assert result.status == "success"
+        mock_mat.assert_called_once()
+        call_kwargs = mock_mat.call_args.kwargs
+        assert call_kwargs.get("connections") is connections, (
+            "connections must be forwarded to materialize_lookups on the fallback path"
+        )
+
+    @patch("weevr.engine.runner.execute_thread")
+    @patch("weevr.engine.runner.materialize_lookups")
+    def test_connections_forwarded_to_materialize_lookups_scheduled_path(self, mock_mat, mock_exec):
+        """connections is forwarded to materialize_lookups on the scheduled
+        (_materialize_scheduled) path used when plan.lookup_schedule is set."""
+        from weevr.engine.lookups import LookupResult
+        from weevr.model.connection import OneLakeConnection
+        from weevr.model.lookup import Lookup
+        from weevr.model.source import Source
+
+        mock_df = MagicMock()
+        mock_mat.return_value = (
+            {"my_lookup": mock_df},
+            [LookupResult(name="my_lookup", materialized=True, row_count=3)],
+        )
+        mock_exec.side_effect = lambda spark, thread, **kw: _make_result(thread.name)
+
+        lookups = {
+            "my_lookup": Lookup(
+                source=Source(type="delta", connection="silver", table="customers"),
+                materialize=True,
+            )
+        }
+        connections = {
+            "silver": OneLakeConnection(type="onelake", workspace="ws-1", lakehouse="silver-lh"),
+        }
+        # Thread references the lookup — plan will build a lookup_schedule
+        threads = {
+            "t1": Thread.model_validate(
+                {
+                    "name": "t1",
+                    "config_version": "1.0",
+                    "sources": {"lk": {"lookup": "my_lookup"}},
+                    "target": {"alias": "test.out"},
+                }
+            )
+        }
+        plan = build_plan("test_weave", threads, _entries("t1"), lookups=lookups)
+        assert plan.lookup_schedule is not None
+
+        result = execute_weave(_MOCK_SPARK, plan, threads, lookups=lookups, connections=connections)
+
+        assert result.status == "success"
+        mock_mat.assert_called_once()
+        call_kwargs = mock_mat.call_args.kwargs
+        assert call_kwargs.get("connections") is connections, (
+            "connections must be forwarded to materialize_lookups on the scheduled path"
+        )
+
+    @patch("weevr.engine.runner.execute_thread")
+    @patch("weevr.engine.runner.materialize_lookups")
+    def test_loom_connections_cascade_to_materialize_lookups_via_execute_loom(
+        self, mock_mat, mock_exec
+    ):
+        """End-to-end: loom-level connections are merged and forwarded through
+        execute_loom → execute_weave → materialize_lookups so that lookups
+        referencing a loom-only connection can resolve without error.
+
+        This is the exact failure scenario reported in the bug ticket.
+        """
+        from weevr.engine.lookups import LookupResult
+        from weevr.model.connection import OneLakeConnection
+        from weevr.model.lookup import Lookup
+        from weevr.model.source import Source
+
+        mock_df = MagicMock()
+        mock_mat.return_value = (
+            {"my_lookup": mock_df},
+            [LookupResult(name="my_lookup", materialized=True, row_count=7)],
+        )
+        mock_exec.side_effect = lambda spark, thread, **kw: _make_result(thread.name)
+
+        # Loom declares the 'silver' connection; neither the weave nor threads do.
+        loom = Loom.model_validate(
+            {
+                "config_version": "1.0",
+                "weaves": ["pipeline"],
+                "connections": {
+                    "silver": {
+                        "type": "onelake",
+                        "workspace": "ws-prod",
+                        "lakehouse": "silver-lh",
+                    },
+                },
+            }
+        )
+
+        # Weave declares a lookup that references the loom-level connection.
+        weave_lookup = Lookup(
+            source=Source(type="delta", connection="silver", table="customers"),
+            materialize=True,
+        )
+        weave = Weave.model_validate(
+            {
+                "config_version": "1.0",
+                "name": "pipeline",
+                "lookups": {"my_lookup": weave_lookup.model_dump()},
+                "threads": ["t1"],
+            }
+        )
+        t1 = Thread.model_validate(
+            {
+                "name": "t1",
+                "config_version": "1.0",
+                "sources": {"lk": {"lookup": "my_lookup"}},
+                "target": {"alias": "gold.out"},
+            }
+        )
+
+        result = execute_loom(
+            _MOCK_SPARK,
+            loom,
+            {"pipeline": weave},
+            {"pipeline": {"t1": t1}},
+        )
+
+        assert result.status == "success"
+        # materialize_lookups must have been called with the loom-level connection
+        assert mock_mat.call_count >= 1
+        # Find the call that materialized weave-level lookups (not loom-level)
+        weave_mat_call = None
+        for call in mock_mat.call_args_list:
+            if "my_lookup" in call[0][1]:
+                weave_mat_call = call
+                break
+        assert weave_mat_call is not None, "materialize_lookups not called for weave lookup"
+        forwarded_connections = weave_mat_call.kwargs.get("connections")
+        assert forwarded_connections is not None, (
+            "connections must be forwarded to materialize_lookups — "
+            "loom-level connections were not reaching the lookup materializer"
+        )
+        assert "silver" in forwarded_connections
+        assert isinstance(forwarded_connections["silver"], OneLakeConnection)
+        assert forwarded_connections["silver"].lakehouse == "silver-lh"
+
+
 # ---------------------------------------------------------------------------
 # Lifecycle order tests
 # ---------------------------------------------------------------------------

--- a/tests/weevr/engine/test_runner.py
+++ b/tests/weevr/engine/test_runner.py
@@ -2131,6 +2131,56 @@ class TestLoomResourceLifecycle:
         assert "extra" in merged
 
     @patch("weevr.engine.runner.execute_weave")
+    @patch("weevr.engine.runner.materialize_lookups")
+    def test_loom_connections_forwarded_to_loom_level_materialize_lookups(
+        self, mock_mat, mock_weave_exec
+    ):
+        """Loom-level connections are forwarded to materialize_lookups when the
+        loom declares both lookups and connections.
+
+        Regression test for the bug where execute_loom called materialize_lookups
+        for loom-level lookups without passing connections, causing
+        LookupResolutionError even when loom.connections was populated.
+        """
+        from weevr.engine.lookups import LookupResult
+        from weevr.model.connection import OneLakeConnection
+        from weevr.model.lookup import Lookup
+        from weevr.model.source import Source
+
+        mock_df = MagicMock()
+        mock_mat.return_value = (
+            {"ref": mock_df},
+            [LookupResult(name="ref", materialized=True, row_count=5)],
+        )
+        mock_weave_exec.return_value = self._weave_result()
+
+        loom_lookup = Lookup(
+            source=Source(type="delta", alias="silver.ref_table"),
+            materialize=True,
+        )
+        loom = self._make_loom(
+            lookups={"ref": loom_lookup.model_dump()},
+            connections={
+                "silver": {"type": "onelake", "workspace": "ws-1", "lakehouse": "silver-lh"}
+            },
+        )
+        weaves = {"w1": self._make_weave()}
+        threads = {"w1": {"t1": _make_thread("t1")}}
+
+        execute_loom(_MOCK_SPARK, loom, weaves, threads)
+
+        mock_mat.assert_called_once()
+        call_kwargs = mock_mat.call_args.kwargs
+        forwarded = call_kwargs.get("connections")
+        assert forwarded is not None, (
+            "connections must be forwarded to materialize_lookups for loom-level lookups — "
+            "loom.connections was not reaching the lookup materializer"
+        )
+        assert "silver" in forwarded
+        assert isinstance(forwarded["silver"], OneLakeConnection)
+        assert forwarded["silver"].lakehouse == "silver-lh"
+
+    @patch("weevr.engine.runner.execute_weave")
     @patch("weevr.engine.runner.run_hook_steps", return_value=[])
     def test_loom_post_steps_run_after_weave_failure(self, mock_hooks, mock_weave_exec):
         """Loom post_steps execute even when a weave fails."""

--- a/tests/weevr/test_context.py
+++ b/tests/weevr/test_context.py
@@ -350,6 +350,122 @@ class TestFilterThreads:
         assert "No threads matched" in warnings[0]
 
 
+class TestLoadResolvedConnections:
+    """Verify that _load_resolved preserves loom-level connections through the
+    full config pipeline and hydrates them onto the Loom domain model.
+
+    Regression guard for the bug where loom.connections evaluated to None at
+    execute_loom time despite being declared in the loom YAML.  No Spark
+    required — _load_resolved only parses/validates YAML; it does not execute.
+    """
+
+    def _build_project(self, tmp_path: Path) -> Path:
+        """Scaffold a minimal .weevr project tree with loom-level connections."""
+        project = tmp_path / "proj.weevr"
+        project.mkdir()
+
+        # thread
+        (project / "threads").mkdir()
+        (project / "threads" / "dim_test.thread").write_text(
+            """\
+config_version: "1.0"
+sources:
+  main:
+    type: delta
+    alias: silver.raw_data
+target:
+  path: /tmp/output
+"""
+        )
+
+        # weave (no connections)
+        (project / "weaves").mkdir()
+        (project / "weaves" / "gold.weave").write_text(
+            """\
+config_version: "1.0"
+threads:
+  - ref: threads/dim_test.thread
+"""
+        )
+
+        # loom with connections
+        (project / "looms").mkdir()
+        (project / "looms" / "daily.loom").write_text(
+            """\
+config_version: "1.0"
+weaves:
+  - ref: weaves/gold.weave
+connections:
+  silver:
+    type: onelake
+    workspace: ws-123
+    lakehouse: lh-456
+"""
+        )
+
+        return project
+
+    def test_loom_connections_survive_load_resolved(self, tmp_path: Path) -> None:
+        """loom.connections is populated from YAML after the full _load_resolved pipeline.
+
+        Asserts that the Loom domain model returned by _load_resolved carries the
+        connections dict defined at the top of the loom YAML, verifying that no
+        pipeline stage (schema validation, variable resolution, reference resolution,
+        inheritance cascade, or Pydantic hydration) silently drops the field.
+        """
+        from unittest.mock import MagicMock
+
+        from pyspark.sql import SparkSession
+
+        from weevr.model.connection import OneLakeConnection
+
+        project = self._build_project(tmp_path)
+        mock_spark = MagicMock(spec=SparkSession)
+        ctx = Context(spark=mock_spark, project=str(project))
+
+        resolved = ctx._load_resolved("looms/daily.loom")
+
+        from weevr.model.loom import Loom
+
+        assert isinstance(resolved.model, Loom)
+        loom = resolved.model
+
+        assert loom.connections is not None, (
+            "loom.connections must not be None after _load_resolved — "
+            "connections declared in loom YAML were silently dropped"
+        )
+        assert "silver" in loom.connections, (
+            "expected connection named 'silver' to be present in loom.connections"
+        )
+        assert isinstance(loom.connections["silver"], OneLakeConnection)
+        assert loom.connections["silver"].workspace == "ws-123"
+        assert loom.connections["silver"].lakehouse == "lh-456"
+
+    def test_weave_without_connections_has_none(self, tmp_path: Path) -> None:
+        """A weave that declares no connections has weave.connections == None.
+
+        Confirms the complementary half of the merge: the weave in the loom
+        fixture above has no connections block, so weave.connections stays None.
+        The loom connections should NOT be injected into weave.connections — they
+        are merged at execute_loom time, not during config loading.
+        """
+        from unittest.mock import MagicMock
+
+        from pyspark.sql import SparkSession
+
+        project = self._build_project(tmp_path)
+        mock_spark = MagicMock(spec=SparkSession)
+        ctx = Context(spark=mock_spark, project=str(project))
+
+        resolved = ctx._load_resolved("looms/daily.loom")
+
+        weave = resolved.weaves.get("gold")
+        assert weave is not None, "weave 'gold' should be resolved"
+        assert weave.connections is None, (
+            "weave.connections must be None when the weave YAML has no connections block"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Integration tests — require Spark
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fixes #149
- `execute_weave` did not pass `connections` to either `materialize_lookups` call site (scheduled path and fallback path), so loom- and weave-level connections never reached lookup materialisation.
- `execute_loom` did not pass `loom.connections` to the loom-level `materialize_lookups` call, so any loom-level lookup whose source requires a named connection also failed.

## Why

The [Connections guide](https://ardent-data.github.io/weevr/latest/guides/connections/#cascade-and-override) documents that connections cascade loom → weave → thread. The cascade is correctly built into the config-loading pipeline and into the `merged_connections` computation in `execute_loom`, but the resulting dict was never forwarded to `materialize_lookups`, causing `LookupResolutionError: Source references undefined connection '<name>'` for any lookup that resolves its source via a named connection.

## What changed

- `src/weevr/engine/runner.py`
  - `execute_weave._materialize_scheduled`: added `connections=connections` (scheduled lookup path)
  - `execute_weave` fallback `elif lookups:` block: added `connections=connections` (upfront materialisation path)
  - `execute_loom` loom-level `materialize_lookups` call: added `connections=loom.connections if loom.connections else None`
- `tests/weevr/engine/test_runner.py`
  - `TestExecuteWeaveConnectionsToLookups`: three regression tests covering both `execute_weave` call sites and the end-to-end loom → `execute_weave` → `materialize_lookups` path
  - `TestLoomResourceLifecycle::test_loom_connections_forwarded_to_loom_level_materialize_lookups`: regression test for the loom-level call site
- `tests/weevr/test_context.py`
  - `TestLoadResolvedConnections`: two integration tests that run a loom YAML with a `connections:` block through the full `_load_resolved` pipeline, confirming the field survives schema validation, variable resolution, reference resolution, inheritance cascade, and Pydantic hydration to `Loom.connections`.

## How to test

- [x] uv sync --dev
- [x] uv run ruff check .
- [x] uv run ruff format .
- [x] uv run pyright .
- [x] uv run pytest

## Release / Versioning

- [x] PR title follows Conventional Commit format (feat:, fix:, chore:, docs:, ci:, etc.)
- [ ] Breaking change indicated (feat!: / fix!: or BREAKING CHANGE in body)

## Notes

Connections may be defined at the loom level, weave level, or both — the merge in `execute_loom` is additive with weave winning on conflict. No change to that semantic; these fixes only ensure the already-merged dict actually reaches `materialize_lookups`. Thread-level connections are unaffected (they flow via `Thread.connections` directly to `execute_thread`, which was already correct).