### PR TITLE
fix(engine): propagate connections to lookup materialization and fix join dup-key-drop

### DIFF
--- a/src/weevr/context.py
+++ b/src/weevr/context.py
@@ -693,7 +693,11 @@ class Context:
 
         for thread_name, thread in all_threads.items():
             try:
-                sources_map = read_sources(self._spark, thread.sources)
+                sources_map = read_sources(
+                    self._spark,
+                    thread.sources,
+                    connections=thread.connections,
+                )
                 for key in sources_map:
                     sources_map[key] = sources_map[key].limit(sample_rows)
 

--- a/src/weevr/engine/runner.py
+++ b/src/weevr/engine/runner.py
@@ -170,7 +170,11 @@ def execute_weave(
         if not subset:
             return
         new_cached, new_results = materialize_lookups(
-            spark, subset, collector=collector, parent_span_id=weave_span_id
+            spark,
+            subset,
+            collector=collector,
+            parent_span_id=weave_span_id,
+            connections=connections,
         )
         cached_lookup_dfs.update(new_cached)
         all_lookup_results.extend(new_results)
@@ -200,7 +204,11 @@ def execute_weave(
             _materialize_scheduled(0)
         elif lookups:
             cached_lookup_dfs, all_lookup_results = materialize_lookups(
-                spark, lookups, collector=collector, parent_span_id=weave_span_id
+                spark,
+                lookups,
+                collector=collector,
+                parent_span_id=weave_span_id,
+                connections=connections,
             )
 
         # Materialize column sets — resolve all defs into name→mapping dicts
@@ -560,12 +568,14 @@ def execute_loom(
             )
 
         # Materialize loom-level lookups (shared across all weaves)
+        loom_connections = dict(loom.connections) if loom.connections else None
         if loom.lookups:
             loom_cached_lookup_dfs, _ = materialize_lookups(
                 spark,
                 dict(loom.lookups),
                 collector=collector,
                 parent_span_id=loom_span_id,
+                connections=loom_connections,
             )
 
         for weave_entry in loom.weaves:

--- a/src/weevr/model/thread.py
+++ b/src/weevr/model/thread.py
@@ -195,7 +195,11 @@ class Thread(FrozenBase):
             available.add(cte_name)
 
         # 3. Unused CTE warning: collect all source references from join/union steps
+        #    AND sibling CTE from: references (CTE-to-CTE chaining).
         referenced: set[str] = set()
+        for sub_pipeline in self.with_.values():
+            if sub_pipeline.from_ in cte_names:
+                referenced.add(sub_pipeline.from_)
         all_step_lists = list(self.with_.values()) + [self]
         for container in all_step_lists:
             steps_list = container.steps if hasattr(container, "steps") else []

--- a/src/weevr/operations/pipeline/joins.py
+++ b/src/weevr/operations/pipeline/joins.py
@@ -46,6 +46,7 @@ def apply_join(
 
     # Capture left-side columns before join so source columns can be identified afterward.
     left_cols: set[str] = set(df.columns)
+    left_col_count = len(df.columns)
 
     if params.type == "cross":
         result = df.crossJoin(right_df)
@@ -56,11 +57,36 @@ def apply_join(
         # Column-expression joins keep both sides of matching key columns,
         # causing ambiguous references downstream. Drop the right-side
         # duplicates when the left and right key names are the same.
-        for pair in params.on:
-            if pair.left == pair.right:
-                result = result.drop(right_df[pair.right])
+        same_name_keys = {pair.right for pair in params.on if pair.left == pair.right}
+        if same_name_keys:
+            if params.alias:
+                # When alias is set, Spark's internal column IDs change so
+                # right_df[col] no longer targets the right-side column
+                # reliably. Rename all columns to unique temp names, drop
+                # the duplicates by temp name, then rename back.
+                drop_indices: set[int] = set()
+                seen: dict[str, int] = {}
+                for i, col_name in enumerate(result.columns):
+                    if col_name in same_name_keys:
+                        if col_name in seen:
+                            drop_indices.add(i)
+                        else:
+                            seen[col_name] = i
+                if drop_indices:
+                    orig_cols = result.columns
+                    temp_names = [f"__dedup_{i}__" for i in range(len(orig_cols))]
+                    result = result.toDF(*temp_names)
+                    for idx in sorted(drop_indices, reverse=True):
+                        result = result.drop(temp_names[idx])
+                    final_names = [c for i, c in enumerate(orig_cols) if i not in drop_indices]
+                    result = result.toDF(*final_names)
+            else:
+                # Without alias, DataFrame-qualified drop works correctly.
+                for pair in params.on:
+                    if pair.left == pair.right:
+                        result = result.drop(right_df[pair.right])
 
-    result = _apply_column_control(result, params, left_cols)
+    result = _apply_column_control(result, params, left_cols, left_col_count)
     return result
 
 
@@ -68,14 +94,11 @@ def _apply_column_control(
     result: DataFrame,
     params: JoinParams,
     left_cols: set[str],
+    left_col_count: int = 0,
 ) -> DataFrame:
     """Apply include/exclude/prefix/rename column control to joined source columns.
 
     Processing order (per DEC-017): dup-key-drop → include → exclude → prefix → rename.
-
-    Note: when a non-key column name exists on both sides of the join, the
-    source-column detection cannot distinguish left from right copies. Use
-    ``alias`` + ``prefix`` to disambiguate before column control in that case.
     """
     no_control = (
         params.include is None
@@ -86,8 +109,13 @@ def _apply_column_control(
     if no_control:
         return result
 
-    # Identify source (right-side) columns as those not present in the left DataFrame.
-    source_cols = [c for c in result.columns if c not in left_cols]
+    # Identify source (right-side) columns. Use the left-side column count
+    # as a positional boundary so that same-name columns surviving after
+    # dup-key-drop are correctly classified as right-side (source) columns.
+    if left_col_count > 0:
+        source_cols = list(result.columns[left_col_count:])
+    else:
+        source_cols = [c for c in result.columns if c not in left_cols]
 
     # --- include ---
     if params.include is not None:

--- a/tests/weevr/engine/test_runner.py
+++ b/tests/weevr/engine/test_runner.py
@@ -1979,3 +1979,102 @@ class TestLoomResourceLifecycle:
         weave_idx = call_order.index("execute_weave")
         post_idx = call_order.index("hooks:post")
         assert weave_idx < post_idx
+
+
+class TestConnectionPropagation:
+    """Verify connections are forwarded to materialize_lookups."""
+
+    @patch("weevr.engine.runner.execute_thread")
+    @patch("weevr.engine.runner.materialize_lookups")
+    def test_weave_upfront_lookups_receive_connections(self, mock_mat, mock_exec):
+        """Upfront materialize_lookups receives connections from execute_weave."""
+        from weevr.engine.lookups import LookupResult
+        from weevr.model.lookup import Lookup
+        from weevr.model.source import Source
+
+        mock_df = MagicMock()
+        mock_mat.return_value = (
+            {"ref": mock_df},
+            [LookupResult(name="ref", materialized=True, row_count=5)],
+        )
+        mock_exec.return_value = _make_result("A")
+
+        lookups = {
+            "ref": Lookup(
+                source=Source(type="delta", alias="ext.table"),
+                materialize=True,
+            )
+        }
+        threads = {"A": _make_thread("A")}
+        plan = build_plan("test_weave", threads, _entries("A"))
+
+        fake_conn = MagicMock()
+        execute_weave(
+            _MOCK_SPARK,
+            plan,
+            threads,
+            lookups=lookups,
+            connections={"gold": fake_conn},
+        )
+
+        mock_mat.assert_called_once()
+        call_kwargs = mock_mat.call_args[1]
+        assert "connections" in call_kwargs
+        assert call_kwargs["connections"]["gold"] is fake_conn
+
+    @patch("weevr.engine.runner.execute_thread")
+    @patch("weevr.engine.runner.materialize_lookups")
+    def test_weave_scheduled_lookups_receive_connections(self, mock_mat, mock_exec):
+        """Scheduled materialize_lookups receives connections from execute_weave."""
+        from weevr.engine.lookups import LookupResult
+        from weevr.model.lookup import Lookup
+        from weevr.model.source import Source
+
+        call_order: list[str] = []
+        mock_df = MagicMock()
+        mock_mat.side_effect = lambda spark, lk_dict, **kwargs: (
+            call_order.append(f"materialize:{','.join(lk_dict.keys())}"),
+            (
+                {n: mock_df for n in lk_dict},
+                [LookupResult(name=n, materialized=True, row_count=10) for n in lk_dict],
+            ),
+        )[1]
+
+        def exec_side_effect(spark, thread, **kwargs):
+            call_order.append(f"execute:{thread.name}")
+            return _make_result(thread.name)
+
+        mock_exec.side_effect = exec_side_effect
+
+        lookups = {
+            "cust": Lookup(
+                source=Source(type="delta", alias="silver.dim_customer"),
+                materialize=True,
+            )
+        }
+        threads = {
+            "A": _make_thread("A", target_alias="silver.dim_customer"),
+            "B": Thread.model_validate(
+                {
+                    "name": "B",
+                    "config_version": "1.0",
+                    "sources": {"lk_cust": {"lookup": "cust"}},
+                    "target": {"alias": "test"},
+                }
+            ),
+        }
+        plan = build_plan("test_weave", threads, _entries("A", "B"), lookups=lookups)
+
+        fake_conn = MagicMock()
+        execute_weave(
+            _MOCK_SPARK,
+            plan,
+            threads,
+            lookups=lookups,
+            connections={"gold": fake_conn},
+        )
+
+        for call in mock_mat.call_args_list:
+            call_kwargs = call[1]
+            assert "connections" in call_kwargs
+            assert call_kwargs["connections"]["gold"] is fake_conn

--- a/tests/weevr/model/test_thread.py
+++ b/tests/weevr/model/test_thread.py
@@ -658,6 +658,34 @@ class TestThreadWithBlock:
             Thread.model_validate(data)
         assert "active_customers" not in caplog.text or "unused" not in caplog.text.lower()
 
+    def test_sibling_cte_from_reference_no_warning(self, caplog):
+        """CTE consumed by a sibling CTE via from: does not produce an unused warning."""
+        data = {
+            **_MINIMAL_WITH_SOURCES,
+            "with": {
+                "base_customers": {
+                    "from": "customers",
+                    "steps": [{"filter": {"expr": "active = true"}}],
+                },
+                "vip_customers": {
+                    "from": "base_customers",
+                    "steps": [{"filter": {"expr": "tier = 'VIP'"}}],
+                },
+            },
+            "steps": [
+                {
+                    "join": {
+                        "source": "vip_customers",
+                        "type": "inner",
+                        "on": ["id"],
+                    }
+                }
+            ],
+        }
+        with caplog.at_level(logging.WARNING):
+            Thread.model_validate(data)
+        assert "base_customers" not in caplog.text
+
     def test_join_alias_collides_with_source_raises(self):
         """Join step alias matching a source name raises ValidationError."""
         data = {

--- a/tests/weevr/operations/pipeline/test_joins.py
+++ b/tests/weevr/operations/pipeline/test_joins.py
@@ -462,6 +462,72 @@ class TestApplyJoinColumnControl:
         assert set(result.columns) == {"id", "left_val", "right_val"}
 
 
+class TestJoinDupKeyDropWithAlias:
+    """Regression tests for alias + same-name key dup-key-drop (TD-009)."""
+
+    def test_alias_same_name_key_produces_single_column(self, spark: SparkSession) -> None:
+        """Alias with same-name key pair drops the right-side duplicate."""
+        left = spark.createDataFrame([{"id": 1, "lv": "a"}])
+        right = spark.createDataFrame([{"id": 1, "rv": "x"}])
+        params = JoinParams(
+            source="r",
+            type="inner",
+            on=[JoinKeyPair(left="id", right="id")],
+            alias="r",
+        )
+        result = apply_join(left, params, {"r": right})
+        assert result.columns.count("id") == 1
+        assert result.count() == 1
+
+    def test_alias_same_name_key_with_include_exclude(self, spark: SparkSession) -> None:
+        """Include/exclude correctly filter right-side columns when alias is set."""
+        left = spark.createDataFrame([{"id": 1, "client": "A", "lv": "a"}])
+        right = spark.createDataFrame([{"id": 1, "client": "A", "rv": "x", "extra": "y"}])
+        params = JoinParams(
+            source="r",
+            type="left",
+            on=[JoinKeyPair(left="id", right="id"), JoinKeyPair(left="client", right="client")],
+            alias="r",
+            include=["rv"],
+            exclude=["id", "client"],
+        )
+        result = apply_join(left, params, {"r": right})
+        assert result.columns.count("id") == 1
+        assert result.columns.count("client") == 1
+        assert "rv" in result.columns
+        assert "extra" not in result.columns
+
+    def test_alias_same_name_key_with_rename(self, spark: SparkSession) -> None:
+        """Rename works correctly after alias dup-key-drop."""
+        left = spark.createDataFrame([{"id": 1, "lv": "a"}])
+        right = spark.createDataFrame([{"id": 1, "rv": "x"}])
+        params = JoinParams(
+            source="r",
+            type="inner",
+            on=[JoinKeyPair(left="id", right="id")],
+            alias="r",
+            include=["rv"],
+            rename={"rv": "right_value"},
+        )
+        result = apply_join(left, params, {"r": right})
+        assert "right_value" in result.columns
+        assert "rv" not in result.columns
+        assert result.columns.count("id") == 1
+
+    def test_no_alias_same_name_key_still_works(self, spark: SparkSession) -> None:
+        """Without alias, same-name key dup-key-drop still works (regression guard)."""
+        left = spark.createDataFrame([{"id": 1, "lv": "a"}])
+        right = spark.createDataFrame([{"id": 1, "rv": "x"}])
+        params = JoinParams(
+            source="r",
+            type="inner",
+            on=[JoinKeyPair(left="id", right="id")],
+        )
+        result = apply_join(left, params, {"r": right})
+        assert result.columns.count("id") == 1
+        assert set(result.columns) == {"id", "lv", "rv"}
+
+
 class TestApplyUnion:
     """Tests for the union step handler."""
 


### PR DESCRIPTION
## Summary

- Fix connection parameter not being forwarded to lookup materialization in weave and loom execution
- Fix join alias breaking same-name key column deduplication
- Fix false-positive CTE unused warnings for sibling `from:` references

## Why

- Weave-level lookups referencing named connections (e.g., `connection: gold`) fail with "Source references undefined connection" because `materialize_lookups` is called without the `connections` parameter
- Join steps with `alias` set and same-name key pairs (e.g., `left: customer, right: customer`) leave duplicate columns that cause `AMBIGUOUS_REFERENCE` errors downstream
- CTEs consumed by sibling CTEs via `from:` incorrectly trigger "declared but never referenced" warnings

## What changed

**Connection propagation (runner.py, context.py):**
- Forward `connections=connections` to `materialize_lookups` in `execute_weave` (both scheduled and upfront paths)
- Build and forward `loom_connections` to `materialize_lookups` in `execute_loom`
- Pass `connections=thread.connections` to `read_sources` in preview mode

**Join dup-key-drop (joins.py):**
- When alias is set, use `toDF`-based positional rename+drop to remove right-side duplicate key columns (alias changes Spark's internal column IDs, making `right_df[col]` drop silently fail)
- Pass `left_col_count` to `_apply_column_control` and use positional boundary for source column classification instead of set membership, so same-name surviving duplicates are correctly identified as right-side columns

**CTE warning (thread.py):**
- Include sibling CTE `from_` references in the `referenced` set before checking for unused CTEs

## How to test

- [x] uv run ruff check .
- [x] uv run ruff format --check .
- [x] uv run pyright
- [x] uv run pytest (all existing + 7 new regression tests pass)

## Release / Versioning

- [x] PR title follows Conventional Commit format (fix:)
- [ ] Breaking change indicated — N/A, no breaking changes

## Notes

- Connection propagation gaps tracked as part of broader TD-014 (connection registry architecture) for v2 planning
- Join fix preserves existing non-alias behavior; alias path uses toDF rename which is slightly heavier but necessary for correctness
- New tests: 4 join regression, 2 connection propagation, 1 CTE sibling reference