### PR TITLE
chore(meta): expand issue templates and add tech-debt form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,7 +1,6 @@
 name: Bug report
 description: Report a defect or unexpected behavior
-title: "bug: "
-labels: ["bug"]
+labels: ["bug", "status:triage"]
 body:
   - type: textarea
     id: description
@@ -23,11 +22,40 @@ body:
     validations:
       required: true
 
+  - type: textarea
+    id: config
+    attributes:
+      label: Minimal config snippet
+      description: Smallest YAML that reproduces the issue. Sanitize any secrets or paths.
+      render: yaml
+    validations:
+      required: false
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - Blocks me — no workaround
+        - Workaround exists but painful
+        - Nuisance — easy to work around
+    validations:
+      required: false
+
   - type: input
     id: version
     attributes:
       label: weevr version
-      placeholder: "0.1.0"
+      placeholder: "1.16.3"
+    validations:
+      required: false
+
+  - type: input
+    id: runtime
+    attributes:
+      label: Spark / Fabric runtime
+      description: Fabric runtime version, or local Spark version if not on Fabric.
+      placeholder: "Fabric Runtime 1.3 (Spark 3.5)"
     validations:
       required: false
 

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,7 +1,6 @@
 name: Feature request
 description: Propose an enhancement or new capability
-title: "feat: "
-labels: ["enhancement"]
+labels: ["enhancement", "status:triage"]
 body:
   - type: textarea
     id: problem
@@ -18,6 +17,14 @@ body:
       description: What do you want to happen?
     validations:
       required: true
+
+  - type: textarea
+    id: workload
+    attributes:
+      label: Workload context
+      description: What kind of pipeline are you building? (e.g., bronze→silver incremental, CDC into curated, dimension modelling)
+    validations:
+      required: false
 
   - type: textarea
     id: alternatives

--- a/.github/ISSUE_TEMPLATE/tech-debt.yml
+++ b/.github/ISSUE_TEMPLATE/tech-debt.yml
@@ -1,0 +1,44 @@
+name: Technical debt
+description: Internal cleanup, refactor, or known weakness in the codebase
+labels: ["tech-debt", "status:accepted"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What's wrong
+      description: What's suboptimal about the current state? Defect, fragility, or missing capability that isn't user-facing yet.
+    validations:
+      required: true
+
+  - type: input
+    id: location
+    attributes:
+      label: Where
+      description: File path(s), module, or subsystem.
+      placeholder: "src/weevr/operations/joins.py:85"
+    validations:
+      required: false
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why it matters
+      description: Impact today, and risk if left unaddressed. Reference any incident or user report that surfaced it.
+    validations:
+      required: true
+
+  - type: textarea
+    id: fix
+    attributes:
+      label: Proposed fix sketch
+      description: Rough direction. Doesn't need to be a full design — just enough that future-you can pick it up.
+    validations:
+      required: false
+
+  - type: textarea
+    id: workaround
+    attributes:
+      label: Current workaround
+      description: How users (or internal code) work around it today, if applicable.
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

- New `tech-debt.yml` issue template for tracking internal cleanup, separate from bugs and enhancements
- Bug template gains a config snippet field, severity dropdown, and Spark/Fabric runtime field
- Feature template gains a workload context field
- Drop the `bug:` / `feat:` title prefixes so the title field starts empty
- Templates auto-apply a `status:` label so new issues land in triage by default

## Why

The project is starting to pick up outside contributors and the existing templates were thin. Triage needs more context up front (severity, runtime, config), and the label set needed area / status / priority axes to make the issue tracker actually usable as the backlog grows.

## What changed

- `.github/ISSUE_TEMPLATE/bug.yml` — config snippet, severity, runtime fields; default labels `["bug", "status:triage"]`
- `.github/ISSUE_TEMPLATE/feature.yml` — workload context field; default labels `["enhancement", "status:triage"]`
- `.github/ISSUE_TEMPLATE/tech-debt.yml` — new (what / where / why / fix sketch / workaround); default labels `["tech-debt", "status:accepted"]`

Labels were created out-of-band via `gh label` since they aren't repo files:

- Added: `tech-debt`; `area:{engine,config,io,telemetry,cli,ci,tooling}`; `status:{triage,accepted,in-design,scheduled,blocked,needs-info}`; `priority:{p0,p1,p2}`
- Removed: `invalid`, `wontfix`, `duplicate` — closing with a comment is clearer
- GitHub defaults kept as-is

## How to test

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`

Open a new issue against the default branch after merge to confirm the templates render and apply the right labels.

## Release / Versioning

- [x] PR title follows Conventional Commit format
- [x] Not a breaking change