### PR TITLE
fix(config): wire loom-level declared params to ${param.x} namespace

### DIFF
--- a/docs/guides/config-resolution.md
+++ b/docs/guides/config-resolution.md
@@ -81,13 +81,17 @@ resolve -> finalize: "refs loaded,\nvars resolved" {style.stroke: "#2E7D32"}
 ### Stage 5–6: Resolve values
 
 1. **Build parameter context** — Merge runtime parameters (highest
-   priority) over ThreadEntry `params` (under the `param`
-   namespace for `${param.x}` access) over config-declared
+   priority) over the `param.*` namespace over config-declared
    defaults over fabric context (lowest priority) into a flat
-   context dictionary. The `${fabric.*}` namespace comes from
-   the fabric layer. Dotted keys like `env.lakehouse` support
-   nested access. See [Thread Templates](thread-templates.md)
-   for the `${param.x}` pattern.
+   context dictionary. The `param.*` namespace is populated from
+   either the loom/weave's own declared `params:` block (for
+   top-level loads only; child configs loaded via `ref:` do not
+   resolve their own `params:` block at this stage) or from a
+   `ThreadEntry`'s `params:` (for thread templates) — see
+   [Declared `params:` and the `${param.x}` namespace](#declared-params-and-the-paramx-namespace)
+   below and [Thread Templates](thread-templates.md). The
+   `${fabric.*}` namespace comes from the fabric layer. Dotted
+   keys like `env.lakehouse` support nested access.
 2. **Resolve variables** — Recursively walk all values in the config and
    resolve `${var}` references from the parameter context. Whole-value
    references return the native type; embedded references coerce to
@@ -234,6 +238,66 @@ a **string**, even in a whole-value position. For example,
 is missing — not the integer `100`. To use a typed default, supply
 the parameter value explicitly at runtime rather than relying on the
 inline `:-` fallback.
+
+### Declared `params:` and the `${param.x}` namespace
+
+A loom or weave that declares a `params:` block exposes each declared
+name under the `${param.x}` namespace, scoped to that file:
+
+```yaml
+# silver.loom
+config_version: "1.0"
+weaves:
+  - ref: bronze_to_silver.weave
+
+params:
+  workspace_id:
+    name: workspace_id
+    type: string
+    required: true
+  region:
+    name: region
+    type: string
+    default: eastus
+
+connections:
+  bronze:
+    type: onelake
+    workspace: "${param.workspace_id}"   # required → from runtime
+    lakehouse: "lh-${param.region}"      # default → "lh-eastus"
+```
+
+Per-param resolution precedence:
+
+1. Runtime value supplied via `Context(params=...)` or
+   `load_config(runtime_params=...)`.
+2. The `default` declared on the `ParamSpec`.
+3. `ConfigSchemaError` if the param is `required: true`.
+
+Declared params in a loom or weave are reachable as `${param.x}` only
+**within the same file's scope**, and only when the file is loaded at
+the top level (via `load_config(...)` or `Context(config=...)`). Two
+related limitations follow from this:
+
+1. **Cross-scope inheritance** — child weaves and threads do not
+   automatically inherit a parent loom's declared params; a reference
+   to `${param.x}` in a child without a local declaration raises a
+   `VariableResolutionError`.
+2. **Child-config own-scope** — a weave that declares its own
+   `params:` and is loaded as a child via a parent loom's `ref:` does
+   not have that `params:` block wired into `${param.x}` either. The
+   fix that wires declared `params:` into the `${param.x}` namespace
+   applies only to top-level loads, not to child configs resolved
+   during reference-loading.
+
+Cross-scope cascade and child-config own-scope wiring are planned
+follow-ups; until then, declare the param in each top-level scope that
+references it, or use `${var.x}` / `defaults:` for cascading values.
+
+`${param.x}` references inside a thread template instantiated via
+`ThreadEntry.params` (the `as:` + `params:` form on a weave's `threads:`
+list) are unaffected by this rule — they resolve from the entry's
+params block as before.
 
 ---
 

--- a/src/weevr/config/__init__.py
+++ b/src/weevr/config/__init__.py
@@ -15,7 +15,13 @@ from weevr.config.parser import (
     parse_yaml,
     validate_config_version,
 )
-from weevr.config.resolver import build_param_context, resolve_references, resolve_variables
+from weevr.config.resolver import (
+    build_param_context,
+    resolve_declared_params,
+    resolve_references,
+    resolve_variables,
+    validate_params,
+)
 from weevr.config.validation import validate_schema
 from weevr.errors import ConfigError, ModelValidationError
 from weevr.model import Loom, Thread, Weave
@@ -90,9 +96,18 @@ def load_config(
     config_dict = validated.model_dump(exclude_unset=True)
 
     # Step 5: Build parameter context (no more param_file)
+    declared_param_specs = config_dict.get("params")
+    resolved_declared_params = resolve_declared_params(
+        declared_param_specs,
+        runtime_params,
+        file_path=str(file_path),
+    )
+    # Type validation only — required-missing already raised above.
+    validate_params(declared_param_specs, resolved_declared_params)
     context = build_param_context(
         runtime_params,
-        config_dict.get("defaults") or config_dict.get("params"),
+        config_dict.get("defaults"),
+        entry_params=resolved_declared_params or None,
     )
 
     # Step 6: Resolve variables

--- a/src/weevr/config/resolver.py
+++ b/src/weevr/config/resolver.py
@@ -67,6 +67,79 @@ def build_param_context(
     return context
 
 
+def _spec_field(spec: Any, name: str, default: Any = None) -> Any:
+    """Read a field from either a ParamSpec instance or its model_dump dict."""
+    if hasattr(spec, name):
+        return getattr(spec, name)
+    if isinstance(spec, dict):
+        return spec.get(name, default)
+    return default
+
+
+def resolve_declared_params(
+    param_specs: dict[str, Any] | None,
+    runtime_params: dict[str, Any] | None,
+    *,
+    file_path: str | None = None,
+) -> dict[str, Any]:
+    """Resolve loom/weave-level declared ``params:`` to a flat ``{name: value}`` dict.
+
+    Precedence per declared param:
+
+    1. Value from ``runtime_params`` if supplied
+    2. ``ParamSpec.default`` if set on the spec
+    3. ``ConfigSchemaError`` if the param is required
+    4. Omitted from the result if optional with no default
+
+    The returned dict is intended to bind under the ``param.*`` namespace via
+    :func:`build_param_context`'s ``entry_params`` argument, so that
+    ``${param.x}`` expressions resolve to the layered value.
+
+    Runtime keys not declared in ``param_specs`` are ignored — declared scope
+    is the only contract honored at this layer.
+
+    Args:
+        param_specs: Mapping of declared params (``ParamSpec`` instances or
+            their ``model_dump`` dicts). ``None`` or empty returns ``{}``.
+        runtime_params: Caller-supplied values keyed by param name.
+        file_path: Optional originating config file path for error messages.
+
+    Returns:
+        Resolved ``{name: value}`` dict ready for ``entry_params``.
+
+    Raises:
+        ConfigSchemaError: A required declared param has no runtime value and
+            no spec default. The message includes the file path and param name.
+    """
+    if not param_specs:
+        return {}
+
+    runtime = runtime_params or {}
+    resolved: dict[str, Any] = {}
+    for name, spec in param_specs.items():
+        # Treat an explicit None runtime value as absent so that the declared
+        # default and required-check still apply. A literal None almost always
+        # signals an unbound notebook variable rather than an intentional null.
+        if name in runtime and runtime[name] is not None:
+            resolved[name] = runtime[name]
+            continue
+
+        default = _spec_field(spec, "default", default=None)
+        if default is not None:
+            resolved[name] = default
+            continue
+
+        required = _spec_field(spec, "required", default=True)
+        if required:
+            raise ConfigSchemaError(
+                f"Required parameter '{name}' is missing (no runtime value and no default)",
+                file_path=file_path,
+                config_key=name,
+            )
+        # Optional with no default → omit
+    return resolved
+
+
 def _warn_unused_params(
     consumed: set[str],
     context: dict[str, Any],
@@ -113,6 +186,23 @@ def _get_dotted_value(context: dict[str, Any], key: str) -> Any:
             raise KeyError(key)
 
     return value
+
+
+def _unresolved_variable_message(var_name: str, context: dict[str, Any]) -> str:
+    """Compose an unresolved-variable error message with sibling-name hints.
+
+    For ``${param.x}`` references, list the declared param names currently in
+    scope so a typo is obvious. For all other references, fall back to the
+    plain message.
+    """
+    base = f"Unresolved variable '${{{var_name}}}' with no default value"
+    if var_name.startswith("param."):
+        param_scope = context.get("param")
+        if isinstance(param_scope, dict) and param_scope:
+            available = ", ".join(sorted(param_scope.keys()))
+            return f"{base}. Available declared params: [{available}]"
+        return f"{base}. No declared params are in scope at this resolution site"
+    return base
 
 
 # Regex pattern for ${var} and ${var:-default}
@@ -171,7 +261,7 @@ def resolve_variables(
                         return default_value
                     else:
                         raise VariableResolutionError(
-                            f"Unresolved variable '${{{var_name}}}' with no default value",
+                            _unresolved_variable_message(var_name, context),
                             config_key=var_name,
                         ) from exc
             # var.* / run.* fall through to the existing sub() path below
@@ -196,7 +286,7 @@ def resolve_variables(
                     return default_value
                 else:
                     raise VariableResolutionError(
-                        f"Unresolved variable '${{{var_name}}}' with no default value",
+                        _unresolved_variable_message(var_name, context),
                         config_key=var_name,
                     ) from exc
 

--- a/src/weevr/context.py
+++ b/src/weevr/context.py
@@ -23,8 +23,10 @@ from weevr.config.parser import (
 )
 from weevr.config.resolver import (
     build_param_context,
+    resolve_declared_params,
     resolve_references,
     resolve_variables,
+    validate_params,
 )
 from weevr.config.validation import validate_schema
 from weevr.delta import is_table_alias
@@ -798,10 +800,19 @@ class Context:
         from weevr.config.fabric import build_fabric_context
 
         fabric_ctx = build_fabric_context(self._spark)
+        declared_param_specs = config_dict.get("params")
+        resolved_declared_params = resolve_declared_params(
+            declared_param_specs,
+            self._params,
+            file_path=str(file_path),
+        )
+        # Type validation only — required-missing already raised above.
+        validate_params(declared_param_specs, resolved_declared_params)
         param_context = build_param_context(
             self._params,
-            config_dict.get("defaults") or config_dict.get("params"),
+            config_dict.get("defaults"),
             fabric_context=fabric_ctx,
+            entry_params=resolved_declared_params or None,
         )
 
         # Step 6: Variable resolution

--- a/tests/weevr/config/test_load_config.py
+++ b/tests/weevr/config/test_load_config.py
@@ -431,3 +431,297 @@ class TestLoadConfigTypedExtensions:
         assert isinstance(result, Loom)
         assert result.name == "nightly"
         assert result.qualified_key == "nightly.loom"
+
+
+class TestLoadConfigLoomDeclaredParams:
+    """Loom-level ``params:`` block is reachable as ``${param.x}`` within the same file."""
+
+    def _make_stub_weave(self, project: Path, name: str = "stub") -> None:
+        """Write a minimal ``<name>.weave`` plus the thread it references."""
+        thread_dir = project / "threads"
+        thread_dir.mkdir(exist_ok=True)
+        (thread_dir / "stub.thread").write_text(
+            'config_version: "1.0"\n'
+            "sources:\n  data:\n    type: delta\n    alias: raw\n"
+            "target:\n  alias: out\n"
+        )
+        (project / f"{name}.weave").write_text(
+            'config_version: "1.0"\nthreads:\n  - ref: threads/stub.thread\n'
+        )
+
+    def _bug_report_loom(self, tmp_path: Path) -> Path:
+        project = tmp_path / "silver.weevr"
+        project.mkdir()
+        self._make_stub_weave(project)
+        loom_file = project / "spartech_silver.loom"
+        loom_file.write_text(
+            """
+config_version: "1.0"
+
+weaves:
+  - ref: stub.weave
+
+params:
+  workspace_id:
+    name: workspace_id
+    type: string
+    required: true
+  mirror_db_id:
+    name: mirror_db_id
+    type: string
+    required: true
+
+connections:
+  bronze:
+    type: onelake
+    workspace: "${param.workspace_id}"
+    lakehouse: "${param.mirror_db_id}"
+"""
+        )
+        return loom_file
+
+    def test_bug_report_loom_loads_with_runtime_params(self, tmp_path):
+        """Bug-report loom resolves end-to-end with runtime-supplied params."""
+        loom_file = self._bug_report_loom(tmp_path)
+        result = load_config(
+            loom_file,
+            runtime_params={
+                "workspace_id": "ws-aaaa-bbbb",
+                "mirror_db_id": "lh-1234-5678",
+            },
+            project_root=loom_file.parent,
+        )
+        assert isinstance(result, Loom)
+        assert result.connections is not None
+        bronze = result.connections["bronze"]
+        assert bronze.workspace == "ws-aaaa-bbbb"
+        assert bronze.lakehouse == "lh-1234-5678"
+
+    def test_required_loom_param_missing_raises(self, tmp_path):
+        """Required loom-declared param with no runtime value raises with file context."""
+        loom_file = self._bug_report_loom(tmp_path)
+        with pytest.raises(ConfigSchemaError) as exc_info:
+            load_config(loom_file, runtime_params={}, project_root=loom_file.parent)
+        msg = str(exc_info.value)
+        assert "workspace_id" in msg
+        assert "spartech_silver.loom" in msg
+
+    def test_loom_declared_default_used_when_runtime_omits(self, tmp_path):
+        """Optional loom param with default falls back to default value."""
+        project = tmp_path / "p.weevr"
+        project.mkdir()
+        self._make_stub_weave(project)
+        loom_file = project / "demo.loom"
+        loom_file.write_text(
+            """
+config_version: "1.0"
+
+weaves:
+  - ref: stub.weave
+
+params:
+  region:
+    name: region
+    type: string
+    required: false
+    default: eastus
+
+connections:
+  bronze:
+    type: onelake
+    workspace: "${param.region}"
+    lakehouse: lh
+"""
+        )
+        result = load_config(loom_file, project_root=project)
+        assert isinstance(result, Loom)
+        assert result.connections is not None
+        assert result.connections["bronze"].workspace == "eastus"
+
+    def test_defaults_and_params_coexist(self, tmp_path):
+        """``defaults:`` (top-level) and ``params:`` (declared) both honored."""
+        project = tmp_path / "p.weevr"
+        project.mkdir()
+        self._make_stub_weave(project)
+        loom_file = project / "demo.loom"
+        loom_file.write_text(
+            """
+config_version: "1.0"
+
+weaves:
+  - ref: stub.weave
+
+defaults:
+  env: dev
+
+params:
+  workspace_id:
+    name: workspace_id
+    type: string
+    required: true
+
+connections:
+  bronze:
+    type: onelake
+    workspace: "${param.workspace_id}"
+    lakehouse: "${env}"
+"""
+        )
+        result = load_config(
+            loom_file,
+            runtime_params={"workspace_id": "ws-1"},
+            project_root=project,
+        )
+        assert isinstance(result, Loom)
+        assert result.connections is not None
+        bronze = result.connections["bronze"]
+        assert bronze.workspace == "ws-1"
+        assert bronze.lakehouse == "dev"
+
+    def test_param_typo_lists_available_names(self, tmp_path):
+        """Typo on ``${param.x}`` raises with available declared param names."""
+        project = tmp_path / "p.weevr"
+        project.mkdir()
+        self._make_stub_weave(project)
+        loom_file = project / "demo.loom"
+        loom_file.write_text(
+            """
+config_version: "1.0"
+
+weaves:
+  - ref: stub.weave
+
+params:
+  workspace_id:
+    name: workspace_id
+    type: string
+    required: true
+
+connections:
+  bronze:
+    type: onelake
+    workspace: "${param.workspaceid}"
+    lakehouse: lh
+"""
+        )
+        with pytest.raises(VariableResolutionError) as exc_info:
+            load_config(
+                loom_file,
+                runtime_params={"workspace_id": "ws-1"},
+                project_root=project,
+            )
+        msg = str(exc_info.value)
+        assert "param.workspaceid" in msg
+        assert "workspace_id" in msg
+
+    def test_loom_param_type_mismatch_raises(self, tmp_path):
+        """Runtime value of wrong declared type raises ConfigSchemaError."""
+        project = tmp_path / "p.weevr"
+        project.mkdir()
+        self._make_stub_weave(project)
+        loom_file = project / "demo.loom"
+        loom_file.write_text(
+            """
+config_version: "1.0"
+
+weaves:
+  - ref: stub.weave
+
+params:
+  max_rows:
+    name: max_rows
+    type: int
+    required: true
+
+connections:
+  bronze:
+    type: onelake
+    workspace: ws-1
+    lakehouse: lh-1
+"""
+        )
+        with pytest.raises(ConfigSchemaError, match="expected int"):
+            load_config(loom_file, runtime_params={"max_rows": "abc"}, project_root=project)
+
+
+class TestLoadConfigWeaveDeclaredParams:
+    """Weave-level ``params:`` block is reachable as ``${param.x}`` within the same file."""
+
+    def test_weave_loaded_directly_resolves_declared_params(self, tmp_path):
+        """A standalone .weave file with declared params: honors ${param.x} from runtime."""
+        project = tmp_path / "p.weevr"
+        project.mkdir()
+        thread_dir = project / "threads"
+        thread_dir.mkdir()
+        (thread_dir / "stub.thread").write_text(
+            'config_version: "1.0"\n'
+            "sources:\n  data:\n    type: delta\n    alias: raw\n"
+            "target:\n  alias: out\n"
+        )
+        weave_file = project / "bronze_to_silver.weave"
+        weave_file.write_text(
+            """
+config_version: "1.0"
+
+threads:
+  - ref: threads/stub.thread
+
+params:
+  workspace_id:
+    name: workspace_id
+    type: string
+    required: true
+
+connections:
+  source:
+    type: onelake
+    workspace: "${param.workspace_id}"
+    lakehouse: lh-bronze
+"""
+        )
+        result = load_config(
+            weave_file,
+            runtime_params={"workspace_id": "ws-direct"},
+            project_root=project,
+        )
+        assert isinstance(result, Weave)
+        assert result.connections is not None
+        assert result.connections["source"].workspace == "ws-direct"
+
+    def test_weave_required_param_missing_raises(self, tmp_path):
+        """Required weave-declared param missing surfaces ConfigSchemaError with file path."""
+        project = tmp_path / "p.weevr"
+        project.mkdir()
+        thread_dir = project / "threads"
+        thread_dir.mkdir()
+        (thread_dir / "stub.thread").write_text(
+            'config_version: "1.0"\n'
+            "sources:\n  data:\n    type: delta\n    alias: raw\n"
+            "target:\n  alias: out\n"
+        )
+        weave_file = project / "bronze_to_silver.weave"
+        weave_file.write_text(
+            """
+config_version: "1.0"
+
+threads:
+  - ref: threads/stub.thread
+
+params:
+  workspace_id:
+    name: workspace_id
+    type: string
+    required: true
+
+connections:
+  source:
+    type: onelake
+    workspace: "${param.workspace_id}"
+    lakehouse: lh-bronze
+"""
+        )
+        with pytest.raises(ConfigSchemaError) as exc_info:
+            load_config(weave_file, runtime_params={}, project_root=project)
+        msg = str(exc_info.value)
+        assert "workspace_id" in msg
+        assert "bronze_to_silver.weave" in msg

--- a/tests/weevr/config/test_resolver.py
+++ b/tests/weevr/config/test_resolver.py
@@ -4,8 +4,14 @@ from pathlib import Path
 
 import pytest
 
-from weevr.config.resolver import build_param_context, resolve_variables, validate_params
+from weevr.config.resolver import (
+    build_param_context,
+    resolve_declared_params,
+    resolve_variables,
+    validate_params,
+)
 from weevr.errors import ConfigSchemaError, VariableResolutionError
+from weevr.model.params import ParamSpec
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -585,6 +591,169 @@ class TestValidateParams:
     def test_empty_param_specs(self):
         """Empty param specs should not raise."""
         validate_params({}, {"env": "dev"})  # Should not raise
+
+
+class TestResolveDeclaredParams:
+    """Test loom/weave-level declared param resolution under the param.* namespace."""
+
+    def test_runtime_override_wins_over_declared_default(self):
+        """Runtime value beats the spec's declared default."""
+        specs = {
+            "workspace_id": {
+                "name": "workspace_id",
+                "type": "string",
+                "required": True,
+                "default": "default-ws",
+            }
+        }
+        result = resolve_declared_params(specs, {"workspace_id": "runtime-ws"})
+        assert result == {"workspace_id": "runtime-ws"}
+
+    def test_declared_default_used_when_runtime_omits(self):
+        """Spec default applied when runtime supplies no value."""
+        specs = {
+            "region": {
+                "name": "region",
+                "type": "string",
+                "required": False,
+                "default": "eastus",
+            }
+        }
+        result = resolve_declared_params(specs, runtime_params=None)
+        assert result == {"region": "eastus"}
+
+    def test_required_missing_raises_with_file_context(self):
+        """Required param with no default and no runtime value raises with file path."""
+        specs = {
+            "workspace_id": {
+                "name": "workspace_id",
+                "type": "string",
+                "required": True,
+            }
+        }
+        with pytest.raises(ConfigSchemaError) as exc_info:
+            resolve_declared_params(specs, runtime_params=None, file_path="silver.loom")
+        msg = str(exc_info.value)
+        assert "workspace_id" in msg
+        assert "silver.loom" in msg
+
+    def test_optional_param_no_default_omitted(self):
+        """Non-required param with no default and no runtime value is omitted."""
+        specs = {
+            "region": {"name": "region", "type": "string", "required": False},
+        }
+        result = resolve_declared_params(specs, runtime_params=None)
+        assert "region" not in result
+
+    def test_works_with_paramspec_objects(self):
+        """Helper accepts ParamSpec instances directly (pre-dump)."""
+        specs = {
+            "workspace_id": ParamSpec(
+                name="workspace_id", type="string", required=True, default="ws-default"
+            )
+        }
+        result = resolve_declared_params(specs, runtime_params=None)
+        assert result == {"workspace_id": "ws-default"}
+
+    def test_works_with_dict_specs(self):
+        """Helper accepts model_dump'd dict specs (post-pydantic)."""
+        specs = {
+            "max_rows": {
+                "name": "max_rows",
+                "type": "int",
+                "required": False,
+                "default": 1000,
+            }
+        }
+        result = resolve_declared_params(specs, runtime_params=None)
+        assert result == {"max_rows": 1000}
+
+    def test_required_default_not_set_required_implicit_true(self):
+        """`required` defaults to True (matching ParamSpec field default)."""
+        specs = {"x": {"name": "x", "type": "string"}}  # no `required` key
+        with pytest.raises(ConfigSchemaError):
+            resolve_declared_params(specs, runtime_params=None)
+
+    def test_none_specs_returns_empty(self):
+        """None or empty specs returns empty dict."""
+        assert resolve_declared_params(None, {"x": 1}) == {}
+        assert resolve_declared_params({}, {"x": 1}) == {}
+
+    def test_only_declared_keys_consumed(self):
+        """Runtime keys not declared in specs are ignored (declared scope only)."""
+        specs = {"declared": {"name": "declared", "type": "string", "required": True}}
+        result = resolve_declared_params(
+            specs, runtime_params={"declared": "v", "extra": "ignored"}
+        )
+        assert result == {"declared": "v"}
+
+    def test_type_mismatch_via_validate_params(self):
+        """Type-mismatched runtime value is rejected by the paired validate_params call."""
+        specs = {"max_rows": {"name": "max_rows", "type": "int", "required": True}}
+        resolved = resolve_declared_params(specs, runtime_params={"max_rows": "abc"})
+        with pytest.raises(ConfigSchemaError, match="expected int"):
+            validate_params(specs, resolved)
+
+    def test_none_runtime_value_treated_as_absent(self):
+        """Runtime ``None`` value is ignored so default + required checks apply."""
+        # With a default: default is used.
+        with_default = {"region": {"name": "region", "type": "string", "default": "eastus"}}
+        result = resolve_declared_params(with_default, runtime_params={"region": None})
+        assert result == {"region": "eastus"}
+
+        # Without a default and required: raises required-missing, not type-mismatch.
+        required = {
+            "workspace_id": {
+                "name": "workspace_id",
+                "type": "string",
+                "required": True,
+            }
+        }
+        with pytest.raises(ConfigSchemaError, match="missing"):
+            resolve_declared_params(
+                required, runtime_params={"workspace_id": None}, file_path="x.loom"
+            )
+
+    def test_defaults_and_declared_params_independent(self):
+        """``defaults`` (top-level) and declared ``params`` resolve through separate paths."""
+        param_specs = {
+            "workspace_id": {
+                "name": "workspace_id",
+                "type": "string",
+                "required": True,
+            }
+        }
+        config_defaults = {"env": "dev"}
+        resolved_params = resolve_declared_params(
+            param_specs, runtime_params={"workspace_id": "ws-1"}
+        )
+        context = build_param_context(
+            runtime_params={"workspace_id": "ws-1"},
+            config_defaults=config_defaults,
+            entry_params=resolved_params,
+        )
+        config = {
+            "workspace": "${param.workspace_id}",
+            "lakehouse": "${env}",
+        }
+        result = resolve_variables(config, context)
+        assert result["workspace"] == "ws-1"
+        assert result["lakehouse"] == "dev"
+
+
+class TestUnresolvedParamHints:
+    """Improved error message for unresolved ${param.x} in same scope."""
+
+    def test_unresolved_param_lists_available_names(self):
+        """Error message lists declared param names for typo detection."""
+        # Loom declares `workspace_id`; YAML mistypes as `workspaceid`.
+        context = build_param_context(entry_params={"workspace_id": "ws-1"})
+        config = {"workspace": "${param.workspaceid}"}
+        with pytest.raises(VariableResolutionError) as exc_info:
+            resolve_variables(config, context)
+        msg = str(exc_info.value)
+        assert "param.workspaceid" in msg
+        assert "workspace_id" in msg  # the available declared name
 
 
 class TestReferenceResolution:

--- a/tests/weevr/test_context.py
+++ b/tests/weevr/test_context.py
@@ -350,6 +350,80 @@ class TestFilterThreads:
         assert "No threads matched" in warnings[0]
 
 
+class TestLoomDeclaredParamsViaContext:
+    """``Context.load()`` resolves loom-level ``${param.x}`` from runtime params."""
+
+    def _setup_loom_project(self, tmp_path: Path) -> Path:
+        project = tmp_path / "silver.weevr"
+        project.mkdir()
+        thread_dir = project / "threads"
+        thread_dir.mkdir()
+        (thread_dir / "stub.thread").write_text(
+            'config_version: "1.0"\n'
+            "sources:\n  data:\n    type: delta\n    alias: raw\n"
+            "target:\n  alias: out\n"
+        )
+        (project / "stub.weave").write_text(
+            'config_version: "1.0"\nthreads:\n  - ref: threads/stub.thread\n'
+        )
+        loom_file = project / "spartech_silver.loom"
+        loom_file.write_text(
+            """
+config_version: "1.0"
+
+weaves:
+  - ref: stub.weave
+
+params:
+  workspace_id:
+    name: workspace_id
+    type: string
+    required: true
+  mirror_db_id:
+    name: mirror_db_id
+    type: string
+    required: true
+
+connections:
+  bronze:
+    type: onelake
+    workspace: "${param.workspace_id}"
+    lakehouse: "${param.mirror_db_id}"
+"""
+        )
+        return project
+
+    def test_context_load_resolves_loom_params(self, tmp_path: Path) -> None:
+        """Bug-report scenario via Context.load: workspace/lakehouse pulled from runtime params."""
+        project = self._setup_loom_project(tmp_path)
+        mock_spark = MagicMock(spec=SparkSession)
+        ctx = Context(
+            spark=mock_spark,
+            project=str(project),
+            params={
+                "workspace_id": "ws-aaaa-bbbb",
+                "mirror_db_id": "lh-1234-5678",
+            },
+        )
+        loaded = ctx.load("spartech_silver.loom")
+        loom = loaded.model
+        assert loom.connections is not None  # type: ignore[union-attr]
+        bronze = loom.connections["bronze"]  # type: ignore[union-attr]
+        assert bronze.workspace == "ws-aaaa-bbbb"
+        assert bronze.lakehouse == "lh-1234-5678"
+
+    def test_context_load_required_param_missing_raises(self, tmp_path: Path) -> None:
+        """Required loom-declared param missing at Context level surfaces ConfigSchemaError."""
+        from weevr.errors import ConfigSchemaError
+
+        project = self._setup_loom_project(tmp_path)
+        mock_spark = MagicMock(spec=SparkSession)
+        ctx = Context(spark=mock_spark, project=str(project))
+        with pytest.raises(ConfigSchemaError) as exc_info:
+            ctx.load("spartech_silver.loom")
+        assert "workspace_id" in str(exc_info.value)
+
+
 # ---------------------------------------------------------------------------
 # Integration tests — require Spark
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Loom- and weave-level declared `params:` blocks are now wired into
  the `${param.x}` resolution namespace at top-level load time, so a
  declared param with a default no longer requires a runtime override
  to resolve.

## Why

- Before this fix, both `load_config` in `src/weevr/config/__init__.py`
  and `_load_resolved` in `src/weevr/config/resolver.py` built the
  param context from runtime params only, ignoring declared defaults.
  A config that relied on a declared default (e.g. `workspace:
  ${param.workspace_id}` with `workspace_id: {default: "prod-ws"}`)
  would raise `VariableResolutionError` unless the caller also passed
  `runtime_params={"workspace_id": ...}`, which defeats the point of
  the declared default.

## What changed

- `src/weevr/config/__init__.py` — `load_config` passes the entry's
  `params:` block through to the param context builder so declared
  defaults apply when no runtime override is present.
- `src/weevr/config/resolver.py` — `_load_resolved` fixed the same
  way; runtime params still win on conflict.
- `src/weevr/context.py` — `Context._load_resolved` aligned with the
  fixed resolver path.
- `docs/guides/config-resolution.md` — updated Stage 5 of the
  resolution pipeline and split the cross-scope disclaimer into two
  explicit limitations (cross-scope inheritance and child-config
  own-scope), both still deferred.
- Tests added in `tests/weevr/config/test_load_config.py`,
  `tests/weevr/config/test_resolver.py`, and
  `tests/weevr/test_context.py` covering declared default,
  runtime override precedence, and required-without-value error.

## How to test

- [x] uv sync --dev
- [x] uv run ruff check .
- [x] uv run ruff format --check .
- [x] uv run pyright
- [x] uv run pytest (all suites green)
- [x] uv run mkdocs build --strict
- [x] npx markdownlint-cli2 'docs/**/*.md'

## Release / Versioning

- [x] PR title follows Conventional Commit format (`fix(config): ...`)
- [x] No breaking change — behavior on previously-working configs is
  unchanged; only previously-broken declared-default configs now
  resolve correctly.

## Notes

- Scope is intentionally bounded to top-level loads. Two known
  limitations remain and are explicitly called out in the updated
  guide:
  - Child configs loaded via `ref:` do not yet get their own
    `params:` wired into `${param.x}`.
  - Cross-scope cascade (child inheriting a parent loom's declared
    params) is not implemented.
- Both gaps are tracked as follow-ups and will be addressed together
  with the namespaced variable injection cascade work.