### PR TITLE
fix(operations): support Date/Timestamp/Decimal in fill_null type_defaults

### DIFF
--- a/src/weevr/operations/pipeline/null_handling.py
+++ b/src/weevr/operations/pipeline/null_handling.py
@@ -2,14 +2,37 @@
 
 from __future__ import annotations
 
+from datetime import date, datetime
+from decimal import Decimal
 from typing import Any
 
-from pyspark.sql import DataFrame
+from pyspark.sql import Column, DataFrame
 from pyspark.sql import functions as F
+from pyspark.sql.types import DateType, DecimalType, StructField, TimestampType
 
 from weevr.model.pipeline import CoalesceParams, FillNullParams
 from weevr.operations.pipeline._result import StepResult
 from weevr.operations.pipeline.type_defaults import resolve_type_defaults
+
+
+def _fill_literal(field: StructField, value: Any) -> Column:
+    """Build a Column expression for a fill value matching the field's type.
+
+    ``df.fillna()`` rejects ``date``, ``datetime``, and ``Decimal``
+    values, so the no-``where`` branch of :func:`apply_fill_null`
+    falls back to per-column ``withColumn`` for those types. This
+    helper constructs the right Spark column expression per type:
+    parsed ISO literal for Date/Timestamp, scale-matching cast for
+    Decimal, plain ``F.lit`` for everything else.
+    """
+    dt = field.dataType
+    if isinstance(dt, DateType) and isinstance(value, date):
+        return F.to_date(F.lit(value.isoformat()))
+    if isinstance(dt, TimestampType) and isinstance(value, datetime):
+        return F.to_timestamp(F.lit(value.isoformat()))
+    if isinstance(dt, DecimalType) and isinstance(value, Decimal):
+        return F.lit(str(value)).cast(dt)
+    return F.lit(value)
 
 
 def apply_fill_null(df: DataFrame, params: FillNullParams) -> StepResult:
@@ -64,7 +87,27 @@ def apply_fill_null(df: DataFrame, params: FillNullParams) -> StepResult:
                         ).otherwise(F.col(col_name)),
                     )
             else:
-                result = result.fillna(fill_dict)
+                # df.fillna() only accepts str/int/float/bool. Split date,
+                # datetime, and Decimal into a per-column withColumn loop
+                # that constructs a type-matched Spark literal.
+                schema_by_name = {f.name: f for f in result.schema.fields}
+                simple: dict[str, Any] = {}
+                column_wise: dict[str, Any] = {}
+                for col_name, fill_value in fill_dict.items():
+                    if isinstance(fill_value, (date, datetime, Decimal)):
+                        column_wise[col_name] = fill_value
+                    else:
+                        simple[col_name] = fill_value
+                if simple:
+                    result = result.fillna(simple)
+                for col_name, fill_value in column_wise.items():
+                    result = result.withColumn(
+                        col_name,
+                        F.when(
+                            F.col(col_name).isNull(),
+                            _fill_literal(schema_by_name[col_name], fill_value),
+                        ).otherwise(F.col(col_name)),
+                    )
             metadata["columns_filled"] = list(fill_dict.keys())
 
     # Phase 2: explicit columns (applied on top of type_defaults)

--- a/src/weevr/operations/pipeline/null_handling.py
+++ b/src/weevr/operations/pipeline/null_handling.py
@@ -24,13 +24,35 @@ def _fill_literal(field: StructField, value: Any) -> Column:
     helper constructs the right Spark column expression per type:
     parsed ISO literal for Date/Timestamp, scale-matching cast for
     Decimal, plain ``F.lit`` for everything else.
+
+    Temporal and Decimal values must match the target field type;
+    mismatches raise ``TypeError`` rather than silently coercing —
+    for example, a ``datetime`` override against a ``DateType``
+    column would otherwise truncate the time component invisibly.
+    ``datetime`` is checked before ``date`` because ``datetime`` is
+    a ``date`` subclass.
     """
     dt = field.dataType
-    if isinstance(dt, DateType) and isinstance(value, date):
-        return F.to_date(F.lit(value.isoformat()))
-    if isinstance(dt, TimestampType) and isinstance(value, datetime):
+    if isinstance(value, datetime):
+        if not isinstance(dt, TimestampType):
+            raise TypeError(
+                f"datetime fill value for field {field.name!r} of type "
+                f"{type(dt).__name__} requires TimestampType"
+            )
         return F.to_timestamp(F.lit(value.isoformat()))
-    if isinstance(dt, DecimalType) and isinstance(value, Decimal):
+    if isinstance(value, date):
+        if not isinstance(dt, DateType):
+            raise TypeError(
+                f"date fill value for field {field.name!r} of type "
+                f"{type(dt).__name__} requires DateType"
+            )
+        return F.to_date(F.lit(value.isoformat()))
+    if isinstance(value, Decimal):
+        if not isinstance(dt, DecimalType):
+            raise TypeError(
+                f"Decimal fill value for field {field.name!r} of type "
+                f"{type(dt).__name__} requires DecimalType"
+            )
         return F.lit(str(value)).cast(dt)
     return F.lit(value)
 
@@ -87,9 +109,7 @@ def apply_fill_null(df: DataFrame, params: FillNullParams) -> StepResult:
                         ).otherwise(F.col(col_name)),
                     )
             else:
-                # df.fillna() only accepts str/int/float/bool. Split date,
-                # datetime, and Decimal into a per-column withColumn loop
-                # that constructs a type-matched Spark literal.
+                # df.fillna() only accepts str/int/float/bool.
                 schema_by_name = {f.name: f for f in result.schema.fields}
                 simple: dict[str, Any] = {}
                 column_wise: dict[str, Any] = {}

--- a/tests/weevr/operations/pipeline/test_null_handling.py
+++ b/tests/weevr/operations/pipeline/test_null_handling.py
@@ -1,8 +1,20 @@
 """Tests for null-handling pipeline step handlers — fill_null, coalesce."""
 
+from datetime import date, datetime
+from decimal import Decimal
+
 import pytest
 from pyspark.sql import SparkSession
-from pyspark.sql.types import BooleanType, IntegerType, StringType, StructField, StructType
+from pyspark.sql.types import (
+    BooleanType,
+    DateType,
+    DecimalType,
+    IntegerType,
+    StringType,
+    StructField,
+    StructType,
+    TimestampType,
+)
 
 from weevr.model.pipeline import CoalesceParams, FillNullParams
 from weevr.operations.pipeline.null_handling import apply_coalesce, apply_fill_null
@@ -232,3 +244,141 @@ class TestFillNullTypeDefaults:
         row = result.df.collect()[0]
         assert row.discount == 0
         assert row.region == "Unknown"
+
+    def test_type_defaults_date_no_where(self, spark: SparkSession):
+        """Null DateType column filled with epoch date (no where predicate)."""
+        df = spark.createDataFrame(
+            [(1, None), (2, date(2024, 6, 1))],
+            schema=StructType(
+                [
+                    StructField("id", IntegerType()),
+                    StructField("event_date", DateType()),
+                ]
+            ),
+        )
+        params = FillNullParams(mode="type_defaults", code="unknown")
+        result = apply_fill_null(df, params)
+        rows = {r["id"]: r["event_date"] for r in result.df.collect()}
+        assert rows[1] == date(1970, 1, 1)
+        assert rows[2] == date(2024, 6, 1)
+
+    def test_type_defaults_timestamp_no_where(self, spark: SparkSession):
+        """Null TimestampType column filled with epoch timestamp (no where)."""
+        df = spark.createDataFrame(
+            [(1, None), (2, datetime(2024, 6, 1, 12, 30))],
+            schema=StructType(
+                [
+                    StructField("id", IntegerType()),
+                    StructField("event_ts", TimestampType()),
+                ]
+            ),
+        )
+        params = FillNullParams(mode="type_defaults", code="unknown")
+        result = apply_fill_null(df, params)
+        rows = {r["id"]: r["event_ts"] for r in result.df.collect()}
+        assert rows[1] == datetime(1970, 1, 1)
+        assert rows[2] == datetime(2024, 6, 1, 12, 30)
+
+    def test_type_defaults_decimal_no_where(self, spark: SparkSession):
+        """Null DecimalType column filled with zero at the column's scale."""
+        df = spark.createDataFrame(
+            [(1, None), (2, Decimal("19.99"))],
+            schema=StructType(
+                [
+                    StructField("id", IntegerType()),
+                    StructField("amount", DecimalType(10, 2)),
+                ]
+            ),
+        )
+        params = FillNullParams(mode="type_defaults", code="unknown")
+        result = apply_fill_null(df, params)
+        rows = {r["id"]: r["amount"] for r in result.df.collect()}
+        assert rows[1] == Decimal("0.00")
+        assert rows[2] == Decimal("19.99")
+
+    def test_type_defaults_date_with_where(self, spark: SparkSession):
+        """Where predicate applies DateType fill only to matching rows."""
+        df = spark.createDataFrame(
+            [("UNKNOWN", None), ("VALID", None)],
+            schema=StructType(
+                [
+                    StructField("status", StringType()),
+                    StructField("event_date", DateType()),
+                ]
+            ),
+        )
+        params = FillNullParams(
+            mode="type_defaults",
+            code="unknown",
+            where="status = 'UNKNOWN'",
+        )
+        result = apply_fill_null(df, params)
+        rows = sorted(result.df.collect(), key=lambda r: r.status)
+        assert rows[0].status == "UNKNOWN"
+        assert rows[0].event_date == date(1970, 1, 1)
+        assert rows[1].status == "VALID"
+        assert rows[1].event_date is None
+
+    def test_type_defaults_timestamp_with_where(self, spark: SparkSession):
+        """Where predicate applies TimestampType fill only to matching rows."""
+        df = spark.createDataFrame(
+            [("UNKNOWN", None), ("VALID", None)],
+            schema=StructType(
+                [
+                    StructField("status", StringType()),
+                    StructField("event_ts", TimestampType()),
+                ]
+            ),
+        )
+        params = FillNullParams(
+            mode="type_defaults",
+            code="unknown",
+            where="status = 'UNKNOWN'",
+        )
+        result = apply_fill_null(df, params)
+        rows = sorted(result.df.collect(), key=lambda r: r.status)
+        assert rows[0].event_ts == datetime(1970, 1, 1)
+        assert rows[1].event_ts is None
+
+    def test_type_defaults_decimal_with_where(self, spark: SparkSession):
+        """Where predicate applies DecimalType fill only to matching rows."""
+        df = spark.createDataFrame(
+            [("UNKNOWN", None), ("VALID", None)],
+            schema=StructType(
+                [
+                    StructField("status", StringType()),
+                    StructField("amount", DecimalType(10, 2)),
+                ]
+            ),
+        )
+        params = FillNullParams(
+            mode="type_defaults",
+            code="unknown",
+            where="status = 'UNKNOWN'",
+        )
+        result = apply_fill_null(df, params)
+        rows = sorted(result.df.collect(), key=lambda r: r.status)
+        assert rows[0].amount == Decimal("0.00")
+        assert rows[1].amount is None
+
+    def test_type_defaults_mixed_simple_and_column_wise_no_where(self, spark: SparkSession):
+        """Mixed simple + column-wise types all get filled and reported in metadata."""
+        df = spark.createDataFrame(
+            [(None, None, None)],
+            schema=StructType(
+                [
+                    StructField("name", StringType()),
+                    StructField("amount", IntegerType()),
+                    StructField("event_date", DateType()),
+                ]
+            ),
+        )
+        params = FillNullParams(mode="type_defaults", code="unknown")
+        result = apply_fill_null(df, params)
+        row = result.df.collect()[0]
+        assert row.name == "Unknown"
+        assert row.amount == 0
+        assert row.event_date == date(1970, 1, 1)
+        # Every filled column must land in metadata, regardless of which
+        # internal branch (fillna vs withColumn) handled it.
+        assert set(result.metadata["columns_filled"]) == {"name", "amount", "event_date"}

--- a/tests/weevr/operations/pipeline/test_null_handling.py
+++ b/tests/weevr/operations/pipeline/test_null_handling.py
@@ -17,7 +17,11 @@ from pyspark.sql.types import (
 )
 
 from weevr.model.pipeline import CoalesceParams, FillNullParams
-from weevr.operations.pipeline.null_handling import apply_coalesce, apply_fill_null
+from weevr.operations.pipeline.null_handling import (
+    _fill_literal,
+    apply_coalesce,
+    apply_fill_null,
+)
 
 pytestmark = pytest.mark.spark
 
@@ -406,3 +410,63 @@ class TestFillNullTypeDefaults:
         # Every filled column must land in metadata, regardless of which
         # internal branch (fillna vs withColumn) handled it.
         assert set(result.metadata["columns_filled"]) == {"name", "amount", "event_date"}
+
+
+class TestFillLiteral:
+    """Branch-level coverage for the `_fill_literal` helper.
+
+    Complements the end-to-end tests above by exercising each helper
+    branch directly without routing through `apply_fill_null`. Each
+    test requires the spark fixture only because `F.lit(...)` needs
+    a live JVM; no DataFrame operations are executed.
+    """
+
+    def test_date_branch_returns_column(self, spark: SparkSession):
+        """Date value on DateType field produces a Column expression."""
+        from pyspark.sql import Column
+
+        field = StructField("event_date", DateType())
+        result = _fill_literal(field, date(1970, 1, 1))
+        assert isinstance(result, Column)
+
+    def test_timestamp_branch_returns_column(self, spark: SparkSession):
+        """Datetime value on TimestampType field produces a Column expression."""
+        from pyspark.sql import Column
+
+        field = StructField("event_ts", TimestampType())
+        result = _fill_literal(field, datetime(1970, 1, 1))
+        assert isinstance(result, Column)
+
+    def test_decimal_branch_casts_to_field_type(self, spark: SparkSession):
+        """Decimal value on DecimalType field casts to the field's scale."""
+        from pyspark.sql import Column
+
+        field = StructField("amount", DecimalType(10, 2))
+        result = _fill_literal(field, Decimal("19.99"))
+        assert isinstance(result, Column)
+
+    def test_fallback_branch_returns_f_lit(self, spark: SparkSession):
+        """Non-temporal, non-Decimal values go through plain F.lit."""
+        from pyspark.sql import Column
+
+        field = StructField("name", StringType())
+        result = _fill_literal(field, "Unknown")
+        assert isinstance(result, Column)
+
+    def test_datetime_for_date_field_raises(self, spark: SparkSession):
+        """A datetime value for a DateType field raises TypeError."""
+        field = StructField("birth_date", DateType())
+        with pytest.raises(TypeError, match="datetime fill value.*DateType"):
+            _fill_literal(field, datetime(2024, 6, 1, 12, 30))
+
+    def test_date_for_timestamp_field_raises(self, spark: SparkSession):
+        """A pure date value for a TimestampType field raises TypeError."""
+        field = StructField("event_ts", TimestampType())
+        with pytest.raises(TypeError, match="date fill value.*TimestampType"):
+            _fill_literal(field, date(2024, 6, 1))
+
+    def test_decimal_for_non_decimal_field_raises(self, spark: SparkSession):
+        """A Decimal value for a non-DecimalType field raises TypeError."""
+        field = StructField("amount", IntegerType())
+        with pytest.raises(TypeError, match="Decimal fill value.*IntegerType"):
+            _fill_literal(field, Decimal("1"))

--- a/tests/weevr/operations/pipeline/test_null_handling.py
+++ b/tests/weevr/operations/pipeline/test_null_handling.py
@@ -361,6 +361,30 @@ class TestFillNullTypeDefaults:
         assert rows[0].amount == Decimal("0.00")
         assert rows[1].amount is None
 
+    def test_type_defaults_datetime_override_for_date_column_raises(self, spark: SparkSession):
+        """A datetime override against a DateType column raises TypeError.
+
+        Without the explicit check, isinstance(value, date) admits the
+        datetime subclass and would silently truncate the time portion
+        via F.to_date. The helper now rejects the mismatch.
+        """
+        df = spark.createDataFrame(
+            [(1, None)],
+            schema=StructType(
+                [
+                    StructField("id", IntegerType()),
+                    StructField("birth_date", DateType()),
+                ]
+            ),
+        )
+        params = FillNullParams(
+            mode="type_defaults",
+            code="unknown",
+            overrides={"birth_date": datetime(2024, 6, 1, 12, 30)},
+        )
+        with pytest.raises(TypeError, match="datetime fill value.*DateType"):
+            apply_fill_null(df, params)
+
     def test_type_defaults_mixed_simple_and_column_wise_no_where(self, spark: SparkSession):
         """Mixed simple + column-wise types all get filled and reported in metadata."""
         df = spark.createDataFrame(


### PR DESCRIPTION
## Summary

- `fill_null` with `mode: type_defaults` failed on columns of type
  `DateType`, `TimestampType`, or `DecimalType` when no `where`
  predicate was supplied, raising
  `IllegalArgumentException: Unsupported value type`.

## Why

`df.fillna()` only accepts `str`/`int`/`float`/`bool`, so the
type-aware fill values (`date(1970, 1, 1)`, `datetime(1970, 1, 1)`,
`Decimal(0)`) produced by `resolve_type_defaults` could not be
applied in the no-`where` branch of `apply_fill_null`. The
documented behavior at `docs/reference/yaml-schema/thread.md` said
these types were supported; the runtime disagreed.

## What changed

- `apply_fill_null` now splits the resolved fill dictionary into
  the values `fillna()` accepts (still applied via `fillna`) and
  the temporal/decimal values (applied per-column via `withColumn`
  with a type-matched Spark literal).
- A new private `_fill_literal(field, value)` helper builds the
  right Spark column expression:
  - `DateType` + `date` → `F.to_date(F.lit(iso))`
  - `TimestampType` + `datetime` → `F.to_timestamp(F.lit(iso))`
  - `DecimalType` + `Decimal` → `F.lit(str).cast(field.dataType)`
  - anything else → `F.lit(value)`
- The helper raises `TypeError` when a caller passes a temporal
  or `Decimal` value whose type does not match the target field
  (e.g. a `datetime` override for a `DateType` column), instead
  of silently truncating.
- The `where`-predicate branch is unchanged — it already handled
  these types correctly on the target Spark runtime.
- `metadata["columns_filled"]` still reports every filled column
  regardless of which internal branch handled it.

## How to test

- [x] uv sync --dev
- [x] uv run ruff check .
- [x] uv run ruff format --check .
- [x] uv run pyright
- [x] uv run pytest -m spark tests/weevr/operations/pipeline/test_null_handling.py (30 passed)
- [x] uv run pytest (full non-spark suite green)
- [x] uv run mkdocs build --strict
- [x] npx markdownlint-cli2 'docs/**/*.md'

## Release / Versioning

- [x] PR title follows Conventional Commit format (`fix(operations): ...`)
- [x] No breaking change — previously-failing configs now succeed;
  configs that already worked are unchanged.

## Notes

- 14 new tests: 7 end-to-end cases for `apply_fill_null` across
  Date/Timestamp/Decimal in both the no-`where` and `where`-present
  paths (the `where`-path tests serve as regression guards), plus
  7 unit-level tests covering each `_fill_literal` branch including
  the type-mismatch `TypeError` paths.
- No documentation changes: the type-default mapping table already
  listed Date, Timestamp, and Decimal as supported — this fix
  brings the runtime in line with what was documented.