### PR TITLE
fix(operations): respect business-key column type in seed_system_members

### DIFF
--- a/docs/guides/dimension-modeling.md
+++ b/docs/guides/dimension-modeling.md
@@ -142,12 +142,13 @@ Override with custom members:
 ```
 
 Business-key columns receive the member's `code` when the column
-is a string type. For non-string business keys (e.g. an
-`IntegerType` calendar-date key `id = YYYYMMDD`, or a `DateType`
-`as_of_date`), the column is filled with the type-appropriate
-default instead (`0` for numeric types, `1970-01-01` for dates,
-`Decimal(0)` for decimals). Composite business keys are evaluated
-per column.
+is a string type. For non-string business keys (e.g. an integer
+calendar-date key `id = YYYYMMDD`, or a date `as_of_date`), the
+column is filled with the type-appropriate default from the same
+mapping used by `fill_null mode: type_defaults` — see
+[fill_null type defaults](../reference/yaml-schema/thread.md#fill_null)
+for the full table. Composite business keys are evaluated per
+column.
 
 ## General Seed Rows
 

--- a/docs/guides/dimension-modeling.md
+++ b/docs/guides/dimension-modeling.md
@@ -141,6 +141,14 @@ Override with custom members:
   label_column: member_label
 ```
 
+Business-key columns receive the member's `code` when the column
+is a string type. For non-string business keys (e.g. an
+`IntegerType` calendar-date key `id = YYYYMMDD`, or a `DateType`
+`as_of_date`), the column is filled with the type-appropriate
+default instead (`0` for numeric types, `1970-01-01` for dates,
+`Decimal(0)` for decimals). Composite business keys are evaluated
+per column.
+
 ## General Seed Rows
 
 Any target can declare seed rows:

--- a/src/weevr/operations/seeding.py
+++ b/src/weevr/operations/seeding.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from pyspark.sql import DataFrame, SparkSession
-from pyspark.sql.types import StringType, StructType
+from pyspark.sql.types import CharType, StringType, StructType, VarcharType
 
 from weevr.delta import delta_table_exists
 from weevr.errors.exceptions import ExecutionError
@@ -211,6 +211,7 @@ def build_system_member_rows(
 
     sk_col = dimension_config.surrogate_key.name
     rows: list[dict[str, Any]] = []
+    schema_by_name = {f.name: f for f in target_df.schema.fields}
 
     for member in members:
         # Resolve type-aware defaults using the member's code
@@ -226,10 +227,15 @@ def build_system_member_rows(
         # BK columns the type default set by resolve_type_defaults
         # (e.g. 0 for Integer, date(1970,1,1) for Date) is kept — the
         # string code would fail Spark's schema coercion downstream.
-        schema_by_name = {f.name: f for f in target_df.schema.fields}
         for bk_col in dimension_config.business_key:
             field = schema_by_name.get(bk_col)
-            if field is not None and isinstance(field.dataType, StringType):
+            if field is None:
+                logger.debug(
+                    "BK column %r not found in target schema; skipping override",
+                    bk_col,
+                )
+                continue
+            if isinstance(field.dataType, (StringType, CharType, VarcharType)):
                 row[bk_col] = member.code
 
         # Set label column if configured

--- a/src/weevr/operations/seeding.py
+++ b/src/weevr/operations/seeding.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from pyspark.sql import DataFrame, SparkSession
-from pyspark.sql.types import StructType
+from pyspark.sql.types import StringType, StructType
 
 from weevr.delta import delta_table_exists
 from weevr.errors.exceptions import ExecutionError
@@ -222,9 +222,15 @@ def build_system_member_rows(
         row: dict[str, Any] = {**defaults}
         row[sk_col] = member.sk
 
-        # Override string columns with the member's code for BK columns
+        # Assign the member's code to string BK columns. For non-string
+        # BK columns the type default set by resolve_type_defaults
+        # (e.g. 0 for Integer, date(1970,1,1) for Date) is kept — the
+        # string code would fail Spark's schema coercion downstream.
+        schema_by_name = {f.name: f for f in target_df.schema.fields}
         for bk_col in dimension_config.business_key:
-            row[bk_col] = member.code
+            field = schema_by_name.get(bk_col)
+            if field is not None and isinstance(field.dataType, StringType):
+                row[bk_col] = member.code
 
         # Set label column if configured
         if dimension_config.label_column is not None:

--- a/tests/weevr/operations/test_seeding.py
+++ b/tests/weevr/operations/test_seeding.py
@@ -1,9 +1,12 @@
 """Tests for seed execution operations."""
 
+from datetime import date
+
 import pytest
 from pyspark.sql import SparkSession
 from pyspark.sql.types import (
     BooleanType,
+    DateType,
     DoubleType,
     IntegerType,
     LongType,
@@ -332,6 +335,86 @@ class TestBuildSystemMemberRows:
         rows = build_system_member_rows(dim, df)
         unknown_row = next(r for r in rows if r["_sk"] == -1)
         assert unknown_row["customer_id"] == "unknown"
+
+    def test_integer_business_key_gets_type_default(self, spark: SparkSession) -> None:
+        """IntegerType BK column gets 0, not the string code (dim_calendar pattern)."""
+        dim = self._make_dim_config(
+            business_key=["calendar_id"],
+            surrogate_key={"name": "_sk", "columns": ["calendar_id"]},
+            seed_system_members=True,
+        )
+        schema = StructType(
+            [
+                StructField("calendar_id", IntegerType(), True),
+                StructField("_sk", LongType(), True),
+            ]
+        )
+        df = spark.createDataFrame([{"calendar_id": 20240601, "_sk": 1}], schema=schema)
+        rows = build_system_member_rows(dim, df)
+        assert rows[0]["calendar_id"] == 0
+        assert rows[1]["calendar_id"] == 0
+
+    def test_long_business_key_gets_type_default(self, spark: SparkSession) -> None:
+        """LongType BK column gets 0, not the string code."""
+        dim = self._make_dim_config(
+            business_key=["account_id"],
+            surrogate_key={"name": "_sk", "columns": ["account_id"]},
+            seed_system_members=True,
+        )
+        schema = StructType(
+            [
+                StructField("account_id", LongType(), True),
+                StructField("_sk", LongType(), True),
+            ]
+        )
+        df = spark.createDataFrame([{"account_id": 1_000_000, "_sk": 1}], schema=schema)
+        rows = build_system_member_rows(dim, df)
+        assert rows[0]["account_id"] == 0
+        assert rows[1]["account_id"] == 0
+
+    def test_date_business_key_gets_type_default(self, spark: SparkSession) -> None:
+        """DateType BK column gets date(1970, 1, 1), not the string code."""
+        dim = self._make_dim_config(
+            business_key=["as_of_date"],
+            surrogate_key={"name": "_sk", "columns": ["as_of_date"]},
+            seed_system_members=True,
+        )
+        schema = StructType(
+            [
+                StructField("as_of_date", DateType(), True),
+                StructField("_sk", LongType(), True),
+            ]
+        )
+        df = spark.createDataFrame([{"as_of_date": date(2024, 6, 1), "_sk": 1}], schema=schema)
+        rows = build_system_member_rows(dim, df)
+        assert rows[0]["as_of_date"] == date(1970, 1, 1)
+        assert rows[1]["as_of_date"] == date(1970, 1, 1)
+
+    def test_composite_bk_mixed_string_and_integer(self, spark: SparkSession) -> None:
+        """Composite BK: string column gets member.code, integer column gets 0."""
+        dim = self._make_dim_config(
+            business_key=["customer_id", "tenant_id"],
+            surrogate_key={"name": "_sk", "columns": ["customer_id", "tenant_id"]},
+            seed_system_members=True,
+        )
+        schema = StructType(
+            [
+                StructField("customer_id", StringType(), True),
+                StructField("tenant_id", IntegerType(), True),
+                StructField("_sk", LongType(), True),
+            ]
+        )
+        df = spark.createDataFrame(
+            [{"customer_id": "C1", "tenant_id": 42, "_sk": 1}], schema=schema
+        )
+        rows = build_system_member_rows(dim, df)
+        # String BK column receives member.code directly (lowercase);
+        # resolve_type_defaults would have returned "Unknown" (title-cased).
+        assert rows[0]["customer_id"] == "unknown"
+        assert rows[1]["customer_id"] == "not_applicable"
+        # Integer BK column keeps the type default from resolve_type_defaults.
+        assert rows[0]["tenant_id"] == 0
+        assert rows[1]["tenant_id"] == 0
 
     def test_scd_columns_set_for_track_history(self, spark: SparkSession) -> None:
         """SCD columns set when track_history is True."""


### PR DESCRIPTION
## Summary

- `seed_system_members: true` failed with
  `PySparkTypeError: CANNOT_ACCEPT_OBJECT_IN_TYPE` on dimensions
  with a non-string business key — e.g. a `dim_calendar` whose
  BK is `id = YYYYMMDD` (IntegerType).

## Why

`build_system_member_rows` unconditionally assigned the semantic
code string (e.g. `"unknown"`) to every business-key column,
regardless of the column's Spark type. For non-string BKs this
overwrote the type-appropriate default that `resolve_type_defaults`
had already placed there, then triggered Spark's schema rejection
downstream when the seed DataFrame was built. The only workaround
was to replace `seed_system_members: true` with a hand-written
`seed:` block.

## What changed

- The BK-column override in `build_system_member_rows` is now gated
  on the column's Spark type. String-like BK columns (`StringType`,
  `VarcharType`, `CharType`) still receive the member's `code`;
  non-string BK columns keep the value set by
  `resolve_type_defaults` (e.g. `0` for integers, `1970-01-01` for
  dates, `Decimal(0)` for decimals).
- Composite business keys are evaluated per column.
- The `seed_system_members` section of the dimension-modeling guide
  now documents the non-string BK behaviour and cross-references the
  `fill_null type_defaults` table that provides the fill values.

## How to test

- [x] uv sync --dev
- [x] uv run ruff check .
- [x] uv run ruff format --check .
- [x] uv run pyright
- [x] uv run pytest -m spark tests/weevr/operations/test_seeding.py (31 passed)
- [x] uv run pytest (full non-spark suite green)
- [x] uv run mkdocs build --strict
- [x] npx markdownlint-cli2 'docs/**/*.md'

## Release / Versioning

- [x] PR title follows Conventional Commit format (`fix(operations): ...`)
- [x] No breaking change — dimensions that worked before still work
  identically; dimensions that previously failed now succeed.

## Notes

- 4 new tests in `TestBuildSystemMemberRows` cover IntegerType,
  LongType, DateType, and composite (string + integer) business
  keys. The existing StringType BK coverage is unchanged and
  regression-tests the happy path.
- Depends on the `fill_null type_defaults` fix for Date/Timestamp/
  Decimal that shipped earlier today — `resolve_type_defaults` needs
  to actually produce usable values for those types before this
  fix can rely on them.