### PR TITLE
test(operations): cover DecimalType business key in system member seeding

### DIFF
--- a/tests/weevr/operations/test_seeding.py
+++ b/tests/weevr/operations/test_seeding.py
@@ -1,12 +1,14 @@
 """Tests for seed execution operations."""
 
 from datetime import date
+from decimal import Decimal
 
 import pytest
 from pyspark.sql import SparkSession
 from pyspark.sql.types import (
     BooleanType,
     DateType,
+    DecimalType,
     DoubleType,
     IntegerType,
     LongType,
@@ -389,6 +391,24 @@ class TestBuildSystemMemberRows:
         rows = build_system_member_rows(dim, df)
         assert rows[0]["as_of_date"] == date(1970, 1, 1)
         assert rows[1]["as_of_date"] == date(1970, 1, 1)
+
+    def test_decimal_business_key_gets_type_default(self, spark: SparkSession) -> None:
+        """DecimalType BK column gets Decimal(0) at the column's scale."""
+        dim = self._make_dim_config(
+            business_key=["account_id"],
+            surrogate_key={"name": "_sk", "columns": ["account_id"]},
+            seed_system_members=True,
+        )
+        schema = StructType(
+            [
+                StructField("account_id", DecimalType(12, 2), True),
+                StructField("_sk", LongType(), True),
+            ]
+        )
+        df = spark.createDataFrame([{"account_id": Decimal("19.99"), "_sk": 1}], schema=schema)
+        rows = build_system_member_rows(dim, df)
+        assert rows[0]["account_id"] == Decimal(0)
+        assert rows[1]["account_id"] == Decimal(0)
 
     def test_composite_bk_mixed_string_and_integer(self, spark: SparkSession) -> None:
         """Composite BK: string column gets member.code, integer column gets 0."""


### PR DESCRIPTION
## Summary

- Adds a regression test for the one remaining non-string BK type
  not already exercised by the B-004 fix test suite.

## Why

`build_system_member_rows` correctly routes a `DecimalType` BK
column through `resolve_type_defaults` (returning `Decimal(0)`)
and skips the string-code override — but no test explicitly
covered this path. This commit closes that coverage gap without
changing behavior.

## What changed

- `test_decimal_business_key_gets_type_default` added to
  `TestBuildSystemMemberRows` alongside the existing integer,
  long, and date cases.
- Imports for `Decimal` and `DecimalType` added.

## How to test

- [x] uv run ruff check . / uv run ruff format --check .
- [x] uv run pytest tests/weevr/operations/test_seeding.py -m spark (15 passed)

## Release / Versioning

- [x] PR title follows Conventional Commit format (`test(operations): ...`)
- [x] No breaking change. No runtime impact — test-only.

## Notes

- Pairs with the already-merged non-string BK coverage for
  Integer/Long/Date. The fix ships behavior-wise from #162; this
  closes the test coverage matrix.