### PR TITLE
fix(model): support ReservedWordConfig rename in core-only installs

### DIFF
--- a/packages/weevr-core/src/weevr/model/column_set.py
+++ b/packages/weevr-core/src/weevr/model/column_set.py
@@ -331,7 +331,7 @@ class ReservedWordConfig(FrozenBase):
             raise ValueError("rename_map must be provided and non-empty when strategy is 'rename'")
         # Warn if rename_map values are themselves reserved words
         if self.rename_map and self.strategy == "rename":
-            from weevr.operations.reserved_words import resolve_effective_words
+            from weevr.reserved_words import resolve_effective_words
 
             effective = resolve_effective_words(self)
             reserved_values = [v for v in self.rename_map.values() if v.lower() in effective]

--- a/tests/test_no_pyspark_imports.py
+++ b/tests/test_no_pyspark_imports.py
@@ -1,10 +1,18 @@
-"""Phase A lock: assert weevr's validation API resolves without PySpark.
+"""Import-isolation locks for the validation API.
 
-This test installs a sys.meta_path finder that rejects every ``pyspark*``
-import with ImportError, then asserts that the public validation surface
-remains usable. It is the regression lock for the in-place preparation
-that lets external tooling (CLI, docs generation) consume weevr.config
-without paying for Spark. Must remain green for any future change.
+Two regression locks live here, each backed by a ``sys.meta_path`` finder
+that rejects a specific import namespace:
+
+- **No-PySpark lock** (Phase A of R-001): rejects every ``pyspark*`` import
+  and asserts that the public validation surface remains usable. Lets
+  external tooling (CLI, docs generation) consume ``weevr.config`` without
+  paying for Spark.
+- **No-engine-wheel lock** (Phase B of R-001): rejects every
+  ``weevr.operations*`` import and asserts that the core wheel
+  (``weevr-core``) validates configuration without the engine wheel
+  installed. Locks in the core/engine layer-direction invariant.
+
+Both must remain green for any future change.
 """
 
 from __future__ import annotations
@@ -34,6 +42,26 @@ class _PysparkBlocker(MetaPathFinder):
         return None
 
 
+class _OperationsBlocker(MetaPathFinder):
+    """Reject every ``weevr.operations*`` module name with ImportError.
+
+    Simulates a ``weevr-core``-only install where the engine wheel
+    (which owns ``weevr/operations/``) is absent.
+    """
+
+    def find_spec(
+        self,
+        fullname: str,
+        _path: object = None,
+        _target: object = None,
+    ) -> ModuleSpec | None:
+        if fullname == "weevr.operations" or fullname.startswith("weevr.operations."):
+            raise ImportError(
+                f"weevr.operations import blocked by core-only lock test: {fullname!r}",
+            )
+        return None
+
+
 @contextmanager
 def _block_pyspark() -> Iterator[None]:
     """Install a PySpark import blocker and clear cached pyspark modules.
@@ -57,6 +85,33 @@ def _block_pyspark() -> Iterator[None]:
             del sys.modules[name]
 
     blocker = _PysparkBlocker()
+    sys.meta_path.insert(0, blocker)
+
+    try:
+        yield
+    finally:
+        sys.meta_path[:] = saved_meta_path
+        sys.modules.clear()
+        sys.modules.update(saved_modules)
+
+
+@contextmanager
+def _block_engine_wheel() -> Iterator[None]:
+    """Install a ``weevr.operations`` import blocker and clear cached weevr modules.
+
+    Snapshots ``sys.modules`` and ``sys.meta_path`` on entry, evicts every
+    ``weevr*`` module so reload semantics are honored, and restores both on
+    exit. Simulates a ``weevr-core``-only install in-process without
+    requiring a separate venv.
+    """
+    saved_modules = dict(sys.modules)
+    saved_meta_path = list(sys.meta_path)
+
+    for name in list(sys.modules):
+        if name == "weevr" or name.startswith("weevr."):
+            del sys.modules[name]
+
+    blocker = _OperationsBlocker()
     sys.meta_path.insert(0, blocker)
 
     try:
@@ -117,6 +172,24 @@ def test_load_config_without_pyspark() -> None:
         result = config_module.load_config(FIXTURE_PATH)
         assert result is not None
         assert getattr(result, "name", None) == "lock_thread"
+
+
+def test_validate_rename_strategy_without_engine_wheel() -> None:
+    """``ReservedWordConfig(strategy="rename")`` must validate in a core-only install.
+
+    Regression test for the layer-direction defect where
+    ``column_set._validate_rename_strategy`` chained through the engine-wheel
+    shim ``weevr.operations.reserved_words`` instead of the canonical core
+    module ``weevr.reserved_words``. In a ``weevr-core``-only install (engine
+    wheel absent), the function-local import raised ImportError.
+    """
+    with _block_engine_wheel():
+        column_set = importlib.import_module("weevr.model.column_set")
+        config = column_set.ReservedWordConfig(
+            strategy="rename",
+            rename_map={"order": "order_id"},
+        )
+        assert config.strategy == "rename"
 
 
 def test_pyspark_blocker_cleanup() -> None:


### PR DESCRIPTION
## Summary

- Restore the core/engine layer boundary that the workspace split (v1.18.0) was meant to enforce.
- `ReservedWordConfig(strategy="rename", ...)` now validates correctly in `weevr-core`-only installs (engine wheel absent).
- Add a regression lock so the layer violation cannot silently return.

## Why

`ReservedWordConfig._validate_rename_strategy` performed a function-local import through `weevr.operations.reserved_words` — the engine-wheel back-compat shim. That path does not exist in a `weevr-core`-only install, so instantiating a `ReservedWordConfig` with `strategy="rename"` raised `ImportError`. The canonical module (`weevr.reserved_words`) lives in core and exposes the same `resolve_effective_words` symbol.

The function-local form of the import hid the violation from the Phase A module-level submodule-path check; the Phase B regression test verified import resolution but did not exercise rename-strategy validation under a wheel-isolation blocker.

## What changed

- `packages/weevr-core/src/weevr/model/column_set.py` — swap the function-local import on line 334 from `weevr.operations.reserved_words` to `weevr.reserved_words`. No surrounding logic touched.
- `tests/test_no_pyspark_imports.py`:
  - Add `_OperationsBlocker` (rejects `weevr.operations*` imports) and `_block_engine_wheel()` context manager — mirrors the existing `_PysparkBlocker` / `_block_pyspark()` pattern.
  - Add `test_validate_rename_strategy_without_engine_wheel` — instantiates `ReservedWordConfig(strategy="rename", rename_map=...)` under the engine-wheel blocker.
  - Refresh the module docstring to describe both lock invariants (no-PySpark Phase A lock + no-engine-wheel Phase B lock).

Engine-side `weevr/operations/naming.py` continues to use the shim — its migration is tracked separately as part of post-split cleanup. The `weevr.operations.reserved_words` shim file itself stays for external back-compat.

## How to test

- [x] uv sync --dev
- [x] uv run ruff check .
- [x] uv run ruff format .
- [x] uv run pyright .
- [x] uv run pytest (2440 passed, 56 skipped)

The new regression test was verified red → green: it fails against the pre-fix code with `ImportError: weevr.operations import blocked by core-only lock test`, then passes after the import swap.

## Release / Versioning

- [x] PR title follows Conventional Commit format (`fix(model):`)
- [x] Not a breaking change — the prior behavior (ImportError in core-only installs) was non-functional; this restores intended behavior

## Notes

- Affected versions: introduced by the workspace split in v1.18.0 (2026-05-07). All prior versions co-located the modules, so the layer violation was structurally impossible.
- No release-notes callout proposed — the core-only install pattern is not yet a documented supported deployment shape; the auto-changelog entry from the Conventional Commit is sufficient.
- The schema regeneration script was run; it produced no diffs (the fix is import-only and does not alter the model surface).