### PR TITLE
chore(docs): reflect 1.18.1 patch and version bumps

### DIFF
--- a/docs/guides/fabric-runtime.md
+++ b/docs/guides/fabric-runtime.md
@@ -54,8 +54,8 @@ Lakehouse Files area. Both wheels are required because `weevr` declares
 
 ```python
 %pip install \
-    /lakehouse/default/Files/libs/weevr-1.18.0-py3-none-any.whl \
-    /lakehouse/default/Files/libs/weevr_core-1.18.0-py3-none-any.whl
+    /lakehouse/default/Files/libs/weevr-1.18.1-py3-none-any.whl \
+    /lakehouse/default/Files/libs/weevr_core-1.18.1-py3-none-any.whl
 ```
 
 Replace the version numbers with the actual wheel filenames; both

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -3,7 +3,7 @@
 weevr is designed to run within the Microsoft Fabric runtime. The table below
 lists the tested and supported versions for each dependency.
 
-Last validated against weevr **1.18.0**.
+Last validated against weevr **1.18.1**.
 
 ## Runtime matrix
 

--- a/docs/release-notes/1.18.md
+++ b/docs/release-notes/1.18.md
@@ -152,6 +152,26 @@ example.
   `ExecutionMode`, `LoadedConfig`) still resolve to the same
   underlying objects.
 
+## 1.18.1 patch (2026-05-27)
+
+A defect surfaced in v1.18.0 affecting the new core-only install
+persona: `ReservedWordConfig(strategy="rename", ...)` raised
+`ImportError` when the engine wheel was absent. The
+`ReservedWordConfig` validator performed a function-local import
+through the engine-wheel back-compat shim
+`weevr.operations.reserved_words` instead of the canonical core
+module `weevr.reserved_words`. Both modules export the same
+`resolve_effective_words` symbol, so installs that had both wheels
+were unaffected — the failure mode was silent until a
+`weevr-core`-only caller exercised the rename strategy.
+
+v1.18.1 swaps the import to the canonical core path, restoring the
+core/engine layer-direction invariant that the workspace split was
+designed to enforce. A regression test lock now exercises the
+rename-strategy validator under an in-process `weevr.operations`
+import blocker so the violation cannot silently return. No API
+change; no behavior change for installs with both wheels.
+
 ## What's next
 
 The new core-only persona is the foundation; consumer adoption is


### PR DESCRIPTION
## Summary

- Document the 1.18.1 patch on the v1.18 release-notes page so the new core-only install persona's known-good behavior is recorded.
- Bump the last-validated-against version on the compatibility page from 1.18.0 to 1.18.1.
- Update the example wheel filenames in the Fabric runtime guide's restricted-network install snippet to match.

## Why

v1.18.1 (PR #174) restored the core/engine layer-direction invariant in the `ReservedWordConfig` validator. The published docs still referenced v1.18.0 as the last-validated version and used 1.18.0 wheel filenames in the Fabric install example. The release-notes page also had no record of the patch — and the project policy is that patch releases fold into the existing minor-release notes page rather than getting a dedicated page.

## What changed

- `docs/release-notes/1.18.md` — new `## 1.18.1 patch (2026-05-27)` subsection between "Backwards compatibility" and "What's next" describing the defect, the fix, and the regression lock that prevents recurrence.
- `docs/reference/compatibility.md` — one-line bump of the "Last validated against" version.
- `docs/guides/fabric-runtime.md` — two-line bump of the example wheel filenames (`weevr-1.18.0` → `weevr-1.18.1`, same for `weevr_core`).

No source changes. No mkdocstrings-generated reference pages were edited (those regenerate from source).

## How to test

- [x] uv sync --dev
- [x] npx markdownlint-cli2 'docs/**/*.md' (0 errors, 63 files)
- [x] uv run mkdocs build --strict (clean build)

## Release / Versioning

- [x] PR title follows Conventional Commit format (`chore(docs):` — does not trigger a release-please version bump)
- [x] Not a breaking change — documentation only

## Notes

- Schema regeneration script was run for the underlying 1.18.1 source change and produced no diffs, so no JSON Schema files are touched here.
- Mid-release-train: this lands on top of v1.18.1 and does not itself bump the version.