### PR TITLE
chore(build): keep the claude cli up to date in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,10 +29,16 @@
         "source=${localEnv:USERPROFILE}/.codex,target=/home/vscode/.codex,type=bind,consistency=cached"
     ],
 
-    "postCreateCommand": "git config --global --add safe.directory /workspaces/weevr && curl -fsSL https://claude.ai/install.sh | bash && git clone https://github.com/coderabbitai/git-worktree-runner.git /home/vscode/.gtr && sudo ln -sf /home/vscode/.gtr/bin/git-gtr /usr/local/bin/git-gtr && sudo ln -sf /home/vscode/.gtr/bin/gtr /usr/local/bin/gtr && uv sync --dev",
+    // After install.sh, flip the in-process auto-updater on (the native
+    // installer ships with it disabled by default).
+    "postCreateCommand": "git config --global --add safe.directory /workspaces/weevr && curl -fsSL https://claude.ai/install.sh | bash && python3 -c \"import json, os; p=os.path.expanduser('~/.claude.json'); d=json.load(open(p)) if os.path.exists(p) and os.path.getsize(p)>0 else {}; d['autoUpdates']=True; json.dump(d, open(p,'w'), indent=2)\" && git clone https://github.com/coderabbitai/git-worktree-runner.git /home/vscode/.gtr && sudo ln -sf /home/vscode/.gtr/bin/git-gtr /usr/local/bin/git-gtr && sudo ln -sf /home/vscode/.gtr/bin/gtr /usr/local/bin/gtr && uv sync --dev",
 
-    // Keep the venv current on every container start (not just first create).
-    "postStartCommand": "uv sync",
+    // Keep the venv current and the claude CLI fresh on every container start
+    // (in-process auto-updater handles between-session refreshes; this is the
+    // belt-and-suspenders check at start). The trailing find prunes any
+    // version binary that is not the current symlink target — each one is
+    // ~250 MB and the native installer never cleans them up.
+    "postStartCommand": "uv sync; claude update 2>/dev/null || true; TARGET=\"$(readlink -f /home/vscode/.local/bin/claude 2>/dev/null)\"; [ -n \"$TARGET\" ] && find /home/vscode/.local/share/claude/versions -maxdepth 1 -type f ! -path \"$TARGET\" -delete 2>/dev/null || true",
 
     "remoteEnv": {
         "UV_PROJECT_ENVIRONMENT": "/home/vscode/.venv",


### PR DESCRIPTION
## Summary

- Stop the devcontainer's claude CLI from drifting multiple versions between rebuilds.

## Why

- The container only installed claude at create-time (`postCreateCommand`), and `~/.claude.json` had `autoUpdates: false`, so the CLI never refreshed itself between rebuilds. The on-disk version history (2.1.132 → 2.1.150 → 2.1.152 → 2.1.162) tracks rebuild cadence, not release cadence.
- The native installer also never prunes old version binaries — each one is ~250 MB. After four rebuilds the `versions/` dir was ~950 MB.

## What changed

- `postCreateCommand`: after `install.sh` runs, flip `autoUpdates` to `true` in `~/.claude.json` via a small `python3 -c` one-liner (idempotent, preserves all other keys).
- `postStartCommand`: now runs `claude update` after `uv sync` as a startup safety net, then prunes any binary in `~/.local/share/claude/versions/` that isn't the current symlink target.
- All steps are guarded so transient failures (no network, missing files) don't break container start.

## How to test

- [x] uv sync --dev
- [x] uv run ruff check .
- [x] uv run ruff format --check .
- [x] uv run pyright
- [x] uv run pytest
- [x] JSON validity check on the edited devcontainer.json
- [x] Dry-run of the prune logic (correctly targeted only stale binaries, left current alone)
- [x] `claude update` invocation smoke-tested in the running container

To verify on a fresh rebuild: rebuild the devcontainer, then check `cat ~/.claude.json | python3 -c "import json,sys; print(json.load(sys.stdin)['autoUpdates'])"` returns `True`, and `ls ~/.local/share/claude/versions/` contains only the current version.

## Release / Versioning

- [x] PR title follows Conventional Commit format
- [x] No breaking change — devcontainer config only, no library surface affected
- [x] `chore(build)` scope chosen to avoid a Release Please version bump

## Notes

- The running container is unaffected until rebuild — applying the same three actions manually (flip autoUpdates, run `claude update`, prune old binaries) brings the current container into the same state immediately.