### PR TITLE
chore(build): fix devcontainer build under rootless podman

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,6 @@
+FROM mcr.microsoft.com/devcontainers/python:3.11
+
+# Rootless podman runs the build in a user namespace, where apt's privilege-dropped
+# _apt sandbox user can't write temp files to /tmp during signature verification.
+# Run apt as root instead so feature installs (d2, etc.) succeed.
+RUN echo 'APT::Sandbox::User "root";' > /etc/apt/apt.conf.d/99-disable-sandbox

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,54 @@
+{
+  "features": {
+    "ghcr.io/devcontainers-extra/features/actionlint:1": {
+      "version": "1.0.7",
+      "resolved": "ghcr.io/devcontainers-extra/features/actionlint@sha256:6a3dde90cb31e366892f8f2ebb766d73d7293d6e79ed9ac4041014d31599fdda",
+      "integrity": "sha256:6a3dde90cb31e366892f8f2ebb766d73d7293d6e79ed9ac4041014d31599fdda"
+    },
+    "ghcr.io/devcontainers-extra/features/shellcheck:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers-extra/features/shellcheck@sha256:8e6d050e4ead6a0350dbe4c70611e351f32cb61a8cc5cb2b39da0cf29ff3bed5",
+      "integrity": "sha256:8e6d050e4ead6a0350dbe4c70611e351f32cb61a8cc5cb2b39da0cf29ff3bed5"
+    },
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "version": "2.5.9",
+      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:cb0c4d3c276f157eed17935747e364178d75fee17f55c4e129966f64633deb3a",
+      "integrity": "sha256:cb0c4d3c276f157eed17935747e364178d75fee17f55c4e129966f64633deb3a"
+    },
+    "ghcr.io/devcontainers/features/copilot-cli:1": {
+      "version": "1.1.3",
+      "resolved": "ghcr.io/devcontainers/features/copilot-cli@sha256:e10d091ae7ef9b8d2ed5f601d75f5a090bc04acbac1a26d4cd3c0d5edde4ea10",
+      "integrity": "sha256:e10d091ae7ef9b8d2ed5f601d75f5a090bc04acbac1a26d4cd3c0d5edde4ea10"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    },
+    "ghcr.io/devcontainers/features/java:1": {
+      "version": "1.8.0",
+      "resolved": "ghcr.io/devcontainers/features/java@sha256:9663ce0219ff85786e87901ce5f0a59f488edd5f99b46015192cda48468b233a",
+      "integrity": "sha256:9663ce0219ff85786e87901ce5f0a59f488edd5f99b46015192cda48468b233a"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
+    },
+    "ghcr.io/jsburckhardt/devcontainer-features/codex:1": {
+      "version": "1.0.0",
+      "resolved": "ghcr.io/jsburckhardt/devcontainer-features/codex@sha256:e6ec5fabc4c804ddda9e0aee677d13e989decc7fbbdcf27f70551f986bb9b28a",
+      "integrity": "sha256:e6ec5fabc4c804ddda9e0aee677d13e989decc7fbbdcf27f70551f986bb9b28a"
+    },
+    "ghcr.io/jsburckhardt/devcontainer-features/uv:1": {
+      "version": "1.0.0",
+      "resolved": "ghcr.io/jsburckhardt/devcontainer-features/uv@sha256:542a0bc2203205b3c696de650ba862f280b20af3543493cc232edd9ac35791f7",
+      "integrity": "sha256:542a0bc2203205b3c696de650ba862f280b20af3543493cc232edd9ac35791f7"
+    },
+    "ghcr.io/ksh5022/devcontainer-features/d2:1": {
+      "version": "1.0.0",
+      "resolved": "ghcr.io/ksh5022/devcontainer-features/d2@sha256:6d2cacd7f73f30d80a2bcffe195cef49911136bcd3bf19e9f2042b710b994379",
+      "integrity": "sha256:6d2cacd7f73f30d80a2bcffe195cef49911136bcd3bf19e9f2042b710b994379"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,21 @@
 {
     "name": "weevr",
 
-    "image": "mcr.microsoft.com/devcontainers/python:3.11",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+
+    // Skip the login-shell env probe. Our login shell auto-attaches zellij, which
+    // blocks the probe until it times out (~10s) on every container start.
+    "userEnvProbe": "none",
+
+    // Rootless podman maps the host user to container root by default, so host
+    // bind mounts (the ~/.config/gh, ~/.claude, ~/.codex shares below) appear
+    // owned by an unmapped UID and vscode (UID 1000) can't write to them. keep-id
+    // maps the host UID straight through, so those dirs land owned by vscode.
+    "runArgs": [
+        "--userns=keep-id"
+    ],
 
     "features": {
         "ghcr.io/devcontainers/features/common-utils:2": {},
@@ -25,13 +39,18 @@
         "source=${localEnv:USERPROFILE}/.config/gh,target=/home/vscode/.config/gh,type=bind,consistency=cached",
         // Claude Code: share host's ~/.claude (global auth/config, not project .claude/).
         "source=${localEnv:USERPROFILE}/.claude,target=/home/vscode/.claude,type=bind,consistency=cached",
+        // Overlay a container-local volume on the installer's staging dir. The
+        // native installer streams its ~250 MB binary into ~/.claude/downloads;
+        // writing that through the host bind mount fails under rootless podman
+        // (curl: (23) error on write). Keep the staging write on the VM's FS.
+        "source=weevr-claude-downloads,target=/home/vscode/.claude/downloads,type=volume",
         // Codex CLI: share host's ~/.codex so auth.json and config.toml persist across rebuilds.
         "source=${localEnv:USERPROFILE}/.codex,target=/home/vscode/.codex,type=bind,consistency=cached"
     ],
 
     // After install.sh, flip the in-process auto-updater on (the native
     // installer ships with it disabled by default).
-    "postCreateCommand": "git config --global --add safe.directory /workspaces/weevr && curl -fsSL https://claude.ai/install.sh | bash && python3 -c \"import json, os; p=os.path.expanduser('~/.claude.json'); d=json.load(open(p)) if os.path.exists(p) and os.path.getsize(p)>0 else {}; d['autoUpdates']=True; json.dump(d, open(p,'w'), indent=2)\" && git clone https://github.com/coderabbitai/git-worktree-runner.git /home/vscode/.gtr && sudo ln -sf /home/vscode/.gtr/bin/git-gtr /usr/local/bin/git-gtr && sudo ln -sf /home/vscode/.gtr/bin/gtr /usr/local/bin/gtr && uv sync --dev",
+    "postCreateCommand": "git config --global --add safe.directory /workspaces/weevr && sudo chown vscode:vscode /home/vscode/.claude/downloads && curl -fsSL https://claude.ai/install.sh | bash && python3 -c \"import json, os; p=os.path.expanduser('~/.claude.json'); d=json.load(open(p)) if os.path.exists(p) and os.path.getsize(p)>0 else {}; d['autoUpdates']=True; json.dump(d, open(p,'w'), indent=2)\" && git clone https://github.com/coderabbitai/git-worktree-runner.git /home/vscode/.gtr && sudo ln -sf /home/vscode/.gtr/bin/git-gtr /usr/local/bin/git-gtr && sudo ln -sf /home/vscode/.gtr/bin/gtr /usr/local/bin/gtr && uv sync --dev",
 
     // Keep the venv current and the claude CLI fresh on every container start
     // (in-process auto-updater handles between-session refreshes; this is the

--- a/.gitignore
+++ b/.gitignore
@@ -221,3 +221,6 @@ __marimo__/
 # on every mkdocs build to give mkdocstrings a single canonical weevr
 # package; the federated weevr-core / weevr split confuses griffe).
 .docs-merged/
+
+# Local Spark/Delta smoke-test output (emulates the Fabric Lakehouse Files area)
+/Files/


### PR DESCRIPTION
## Summary

- Fix the devcontainer so it builds and starts cleanly under rootless podman (in addition to Docker).

## Why

- Under rootless podman the existing config failed in several places: the apt `_apt` sandbox user
  couldn't write temp files during feature installs, bind-mounted config dirs landed owned by an
  unmapped UID (unwritable by `vscode`), the installer's ~250 MB download failed when streamed
  through a host bind mount, and the login-shell env probe stalled ~10s on the auto-attached zellij
  session on every start.

## What changed

- Switch from a prebuilt `image` to a local `Dockerfile` that disables the apt sandbox
  (`APT::Sandbox::User "root"`) so feature installs succeed in the build's user namespace.
- Add `--userns=keep-id` so the host UID maps straight through and bind-mounted config dirs
  (`~/.config/gh`, `~/.claude`, `~/.codex`) stay writable by `vscode`.
- Stage the installer download on a container-local named volume mounted over
  `~/.claude/downloads`, avoiding write failures through the host bind mount.
- Set `userEnvProbe: none` to skip the stalling login-shell env probe.
- Ignore local Spark/Delta smoke-test output under `Files/` via `.gitignore`.

## How to test

- [x] uv run ruff check .
- [x] uv run ruff format --check .
- [ ] Rebuild the devcontainer under rootless podman and confirm it reaches a ready state
- [ ] Rebuild under Docker and confirm no regression

## Release / Versioning

- [x] PR title follows Conventional Commit format (chore:)
- [x] Not a breaking change

## Notes

- Changes are confined to `.devcontainer/` and `.gitignore`; no library source is touched, so the
  Python quality gates (typecheck/pytest) are unaffected.