### PR TITLE
fix(engine): keep loom-level lookup caches alive across weaves

### DIFF
--- a/packages/weevr/src/weevr/engine/runner.py
+++ b/packages/weevr/src/weevr/engine/runner.py
@@ -128,6 +128,8 @@ def execute_weave(
         pre_cached_lookups: Already-materialized lookup DataFrames from a
             parent scope (e.g. loom level). Seeded into the weave's cached
             lookup dict so threads can reference them without re-materializing.
+            The parent scope owns their lifecycle — weave cleanup never
+            unpersists them.
         connections: Merged loom + weave connections forwarded to
             ``materialize_column_sets`` so connection-backed column sets can
             resolve their lakehouse target.
@@ -158,7 +160,11 @@ def execute_weave(
 
     # Initialize hook lifecycle components
     variable_ctx = VariableContext(variables)
-    cached_lookup_dfs: dict[str, Any] = dict(pre_cached_lookups) if pre_cached_lookups else {}
+    # Loom-seeded caches are owned by the parent scope: the weave may consume
+    # them but must not unpersist them. Ownership is tracked by object identity
+    # so a weave lookup that shadows a loom lookup by name is still released.
+    loom_seeded: dict[str, Any] = dict(pre_cached_lookups) if pre_cached_lookups else {}
+    cached_lookup_dfs: dict[str, Any] = dict(loom_seeded)
     all_hook_results: list[HookResult] = []
     all_lookup_results: list[LookupResult] = []
 
@@ -203,13 +209,14 @@ def execute_weave(
             # Materialize only lookups scheduled at group 0 (external / pre-thread)
             _materialize_scheduled(0)
         elif lookups:
-            cached_lookup_dfs, all_lookup_results = materialize_lookups(
+            new_cached, all_lookup_results = materialize_lookups(
                 spark,
                 lookups,
                 collector=collector,
                 parent_span_id=weave_span_id,
                 connections=connections,
             )
+            cached_lookup_dfs.update(new_cached)
 
         # Materialize column sets — resolve all defs into name→mapping dicts
         resolved_column_sets: dict[str, dict[str, str]] | None = None
@@ -417,7 +424,7 @@ def execute_weave(
         raise
     finally:
         cache.cleanup()
-        cleanup_lookups(cached_lookup_dfs)
+        cleanup_lookups({k: v for k, v in cached_lookup_dfs.items() if loom_seeded.get(k) is not v})
         if weave_span_builder is not None and collector is not None:
             if _weave_raised:
                 _span_status = SpanStatus.ERROR

--- a/packages/weevr/src/weevr/engine/runner.py
+++ b/packages/weevr/src/weevr/engine/runner.py
@@ -160,11 +160,12 @@ def execute_weave(
 
     # Initialize hook lifecycle components
     variable_ctx = VariableContext(variables)
-    # Loom-seeded caches are owned by the parent scope: the weave may consume
-    # them but must not unpersist them. Ownership is tracked by object identity
-    # so a weave lookup that shadows a loom lookup by name is still released.
-    loom_seeded: dict[str, Any] = dict(pre_cached_lookups) if pre_cached_lookups else {}
-    cached_lookup_dfs: dict[str, Any] = dict(loom_seeded)
+    # Pre-cached lookups are owned by the parent scope (e.g. the loom): the
+    # weave may consume them but must not unpersist them. Ownership is tracked
+    # by object identity so a weave lookup that shadows a parent lookup by
+    # name is still released.
+    parent_seeded: dict[str, Any] = dict(pre_cached_lookups) if pre_cached_lookups else {}
+    cached_lookup_dfs: dict[str, Any] = dict(parent_seeded)
     all_hook_results: list[HookResult] = []
     all_lookup_results: list[LookupResult] = []
 
@@ -424,7 +425,14 @@ def execute_weave(
         raise
     finally:
         cache.cleanup()
-        cleanup_lookups({k: v for k, v in cached_lookup_dfs.items() if loom_seeded.get(k) is not v})
+        weave_owned = {k: v for k, v in cached_lookup_dfs.items() if parent_seeded.get(k) is not v}
+        if len(weave_owned) != len(cached_lookup_dfs):
+            logger.debug(
+                "Weave '%s' — %d parent-owned lookup(s) excluded from cleanup",
+                plan.weave_name,
+                len(cached_lookup_dfs) - len(weave_owned),
+            )
+        cleanup_lookups(weave_owned)
         if weave_span_builder is not None and collector is not None:
             if _weave_raised:
                 _span_status = SpanStatus.ERROR

--- a/tests/weevr/engine/test_runner.py
+++ b/tests/weevr/engine/test_runner.py
@@ -1324,6 +1324,49 @@ class TestLoomSeededLookupOwnership:
         cleaned = mock_cleanup.call_args[0][0]
         assert cleaned == {"weave_ref": weave_df}
 
+    @patch("weevr.engine.runner.execute_thread")
+    @patch("weevr.engine.runner.cleanup_lookups")
+    def test_seeded_lookups_survive_weave_exception(self, mock_cleanup, mock_exec):
+        """Seeded entries stay excluded from cleanup when the weave raises.
+
+        The exclusion filter lives in the finally block, so it must hold on
+        the exception path (e.g. a pre-hook failure), not just on success.
+        """
+        from weevr.errors.exceptions import HookError
+        from weevr.model.hooks import QualityGateStep
+
+        loom_df = MagicMock()
+        pre = [
+            QualityGateStep(
+                type="quality_gate",
+                check="table_exists",
+                source="db.missing",
+            )
+        ]
+        threads = {"A": _make_thread("A")}
+        plan = build_plan("test_weave", threads, _entries("A"))
+
+        import contextlib
+
+        with (
+            patch(
+                "weevr.engine.runner.run_hook_steps",
+                side_effect=HookError("gate failed"),
+            ),
+            contextlib.suppress(HookError),
+        ):
+            execute_weave(
+                _MOCK_SPARK,
+                plan,
+                threads,
+                pre_steps=pre,
+                pre_cached_lookups={"loom_ref": loom_df},
+            )
+
+        mock_exec.assert_not_called()
+        mock_cleanup.assert_called_once_with({})
+        loom_df.unpersist.assert_not_called()
+
 
 class TestWeaveVariableIntegration:
     """Test variable context in execute_weave."""

--- a/tests/weevr/engine/test_runner.py
+++ b/tests/weevr/engine/test_runner.py
@@ -1180,6 +1180,151 @@ class TestDeferredLookupMaterialization:
         assert "cust" in call_log[1]["lookups"]
 
 
+class TestLoomSeededLookupOwnership:
+    """Weave cleanup must not evict lookups seeded from the loom scope.
+
+    Loom-level materialized lookups are shared across all weaves via
+    pre_cached_lookups; only the loom's own cleanup may unpersist them.
+    A weave unpersists only what it materialized itself.
+    """
+
+    @patch("weevr.engine.runner.execute_thread")
+    @patch("weevr.engine.runner.cleanup_lookups")
+    @patch("weevr.engine.runner.materialize_lookups")
+    def test_weave_cleanup_excludes_loom_seeded_lookups(self, mock_mat, mock_cleanup, mock_exec):
+        """Loom-seeded entries are excluded from the weave's cleanup call."""
+        from weevr.engine.lookups import LookupResult
+        from weevr.model.lookup import Lookup
+        from weevr.model.source import Source
+
+        loom_df = MagicMock()
+        weave_df = MagicMock()
+        mock_mat.return_value = (
+            {"weave_ref": weave_df},
+            [LookupResult(name="weave_ref", materialized=True, row_count=5)],
+        )
+        mock_exec.return_value = _make_result("A")
+
+        lookups = {
+            "weave_ref": Lookup(
+                source=Source(type="delta", alias="gold.other"),
+                materialize=True,
+            )
+        }
+        threads = {"A": _make_thread("A")}
+        plan = build_plan("test_weave", threads, _entries("A"), lookups=lookups)
+
+        execute_weave(
+            _MOCK_SPARK,
+            plan,
+            threads,
+            lookups=lookups,
+            pre_cached_lookups={"loom_ref": loom_df},
+        )
+
+        mock_cleanup.assert_called_once()
+        cleaned = mock_cleanup.call_args[0][0]
+        assert cleaned == {"weave_ref": weave_df}
+        loom_df.unpersist.assert_not_called()
+
+    @patch("weevr.engine.runner.execute_thread")
+    @patch("weevr.engine.runner.cleanup_lookups")
+    @patch("weevr.engine.runner.materialize_lookups")
+    def test_weave_cleanup_includes_shadowing_weave_lookup(self, mock_mat, mock_cleanup, mock_exec):
+        """A weave lookup that shadows a loom lookup by name is still cleaned up.
+
+        The weave's own DataFrame replaces the seeded entry in the cache dict;
+        exclusion is by object identity, not by name, so the weave-materialized
+        DataFrame must not leak.
+        """
+        from weevr.engine.lookups import LookupResult
+        from weevr.model.lookup import Lookup
+        from weevr.model.source import Source
+
+        loom_df = MagicMock()
+        weave_df = MagicMock()
+        mock_mat.return_value = (
+            {"ref": weave_df},
+            [LookupResult(name="ref", materialized=True, row_count=5)],
+        )
+        mock_exec.return_value = _make_result("A")
+
+        lookups = {
+            "ref": Lookup(
+                source=Source(type="delta", alias="gold.other"),
+                materialize=True,
+            )
+        }
+        threads = {"A": _make_thread("A")}
+        plan = build_plan("test_weave", threads, _entries("A"), lookups=lookups)
+
+        execute_weave(
+            _MOCK_SPARK,
+            plan,
+            threads,
+            lookups=lookups,
+            pre_cached_lookups={"ref": loom_df},
+        )
+
+        mock_cleanup.assert_called_once()
+        cleaned = mock_cleanup.call_args[0][0]
+        assert cleaned == {"ref": weave_df}
+
+    @patch("weevr.engine.runner.execute_thread")
+    @patch("weevr.engine.runner.cleanup_lookups")
+    @patch("weevr.engine.runner.materialize_lookups")
+    def test_upfront_materialization_preserves_seeded_lookups(
+        self, mock_mat, mock_cleanup, mock_exec
+    ):
+        """The no-schedule fallback merges into the seeded cache, not over it.
+
+        When the plan carries no lookup_schedule, upfront materialization must
+        keep loom-seeded entries available to threads and still exclude them
+        from the weave's cleanup.
+        """
+        from weevr.engine.lookups import LookupResult
+        from weevr.model.lookup import Lookup
+        from weevr.model.source import Source
+
+        loom_df = MagicMock()
+        weave_df = MagicMock()
+        mock_mat.return_value = (
+            {"weave_ref": weave_df},
+            [LookupResult(name="weave_ref", materialized=True, row_count=5)],
+        )
+        mock_exec.return_value = _make_result("A")
+
+        lookups = {
+            "weave_ref": Lookup(
+                source=Source(type="delta", alias="gold.other"),
+                materialize=True,
+            )
+        }
+        threads = {"A": _make_thread("A")}
+        # Plan built without lookups — no lookup_schedule, upfront fallback path
+        plan = build_plan("test_weave", threads, _entries("A"))
+        assert plan.lookup_schedule is None
+
+        execute_weave(
+            _MOCK_SPARK,
+            plan,
+            threads,
+            lookups=lookups,
+            pre_cached_lookups={"loom_ref": loom_df},
+        )
+
+        # Threads see both the seeded and the weave-materialized lookups
+        thread_cached = mock_exec.call_args.kwargs.get("cached_lookups")
+        assert thread_cached is not None
+        assert thread_cached.get("loom_ref") is loom_df
+        assert thread_cached.get("weave_ref") is weave_df
+
+        # Cleanup releases only the weave-materialized entry
+        mock_cleanup.assert_called_once()
+        cleaned = mock_cleanup.call_args[0][0]
+        assert cleaned == {"weave_ref": weave_df}
+
+
 class TestWeaveVariableIntegration:
     """Test variable context in execute_weave."""
 
@@ -1843,6 +1988,48 @@ class TestLoomResourceLifecycle:
         assert pre_cached is not None
         assert "ref" in pre_cached
         assert pre_cached["ref"] is mock_df
+
+    @patch("weevr.engine.runner.execute_thread")
+    @patch("weevr.engine.runner.cleanup_lookups")
+    @patch("weevr.engine.runner.materialize_lookups")
+    def test_loom_lookups_survive_weave_completion(self, mock_mat, mock_cleanup, mock_exec):
+        """A loom lookup outlives each weave; only loom cleanup releases it.
+
+        Regression for the multi-weave case: weave 1's cleanup used to
+        unpersist the shared loom cache, forcing weaves 2..N to recompute.
+        """
+        from weevr.engine.lookups import LookupResult
+        from weevr.model.lookup import Lookup
+        from weevr.model.source import Source
+
+        loom_df = MagicMock()
+        mock_mat.return_value = (
+            {"ref": loom_df},
+            [LookupResult(name="ref", materialized=True, row_count=10)],
+        )
+        mock_exec.side_effect = lambda spark, thread, **kwargs: _make_result(thread.name)
+
+        loom_lookup = Lookup(
+            source=Source(type="delta", alias="gold.ref"),
+            materialize=True,
+        )
+        loom = self._make_loom(weaves=["w1", "w2"], lookups={"ref": loom_lookup.model_dump()})
+        weaves = {"w1": self._make_weave("w1"), "w2": self._make_weave("w2")}
+        threads = {
+            "w1": {"t1": _make_thread("t1")},
+            "w2": {"t1": _make_thread("t1")},
+        }
+
+        result = execute_loom(_MOCK_SPARK, loom, weaves, threads)
+
+        assert result.status == "success"
+        # Both weaves ran with real execute_weave, so cleanup fires per weave
+        # plus once at loom end. The loom lookup appears only in the final call.
+        assert mock_cleanup.call_count == 3
+        weave_cleanups = [c.args[0] for c in mock_cleanup.call_args_list[:2]]
+        assert all("ref" not in cleaned for cleaned in weave_cleanups)
+        loom_cleanup = mock_cleanup.call_args_list[2].args[0]
+        assert loom_cleanup == {"ref": loom_df}
 
     @patch("weevr.engine.runner.execute_weave")
     def test_loom_variables_cascade_into_weave(self, mock_weave_exec):


### PR DESCRIPTION
## Summary

- Weave cleanup no longer unpersists lookup caches that were materialized at
  loom level, so loom-scoped lookups stay cached for the whole loom run.

## Why

Loom-level `materialize: true` lookups are cached once and seeded into every
weave, but `execute_weave` copied them into its own cache dict and its
`finally` block unpersisted the entire dict. The shared DataFrames were
evicted as soon as the first weave finished, and every later weave silently
recomputed the lookup from storage on each consuming action — defeating the
point of loom-level materialization. Results stayed correct; only cost
regressed, which is why it went unnoticed.

Fixes #182

## What changed

- `execute_weave` tracks the seeded entries separately and excludes them from
  its cleanup call; the loom's own cleanup still releases them at end of run.
  Exclusion is by object identity, so a weave lookup that shadows a loom
  lookup by name is still released correctly.
- The no-schedule fallback path now merges materialized lookups into the
  seeded cache instead of replacing it, matching the documented seeding
  contract for direct `execute_weave` callers.
- Cleanup exclusions are logged at debug level so cache lifecycle decisions
  are traceable.
- New regression tests cover the multi-weave loom scenario, name shadowing,
  the fallback merge path, and the exception path (a failing pre-hook must
  not evict seeded caches).

## How to test

- [x] uv sync --dev
- [x] uv run ruff check .
- [x] uv run ruff format .
- [x] uv run pyright .
- [x] uv run pytest

Full suite: 2445 passed, 56 skipped. The loom-level regression test drives
the real `execute_loom` → `execute_weave` chain across two weaves and fails
against the previous cleanup behavior.

## Release / Versioning

- [x] PR title follows Conventional Commit format (feat:, fix:, chore:, docs:, ci:, etc.)
- [ ] Breaking change indicated (feat!: / fix!: or BREAKING CHANGE in body)

Not breaking — no user-visible behavior change beyond restored performance.

## Notes

- Workaround before this fix was declaring the lookup at weave level in every
  weave, which still re-materialized once per weave; true cross-weave sharing
  needed the ownership fix.
- A broader shared-resource lifecycle cleanup (cache registry, lookup
  materialization) is deliberately out of scope here and tracked separately.