### PR TITLE
fix(operations): single-pass fact and warp validation probes

### DIFF
--- a/docs/guides/engine-internals.md
+++ b/docs/guides/engine-internals.md
@@ -219,7 +219,9 @@ write -> finalize
 10. Resolve the target write path
 11. Apply target column mapping
 12. Inject audit columns (bypasses mapping mode; applied for all write modes)
-13. Write to the Delta target (standard write or CDC merge routing)
+13. Write to the Delta target (standard write or CDC merge routing).
+    For fact targets, the sentinel advisory then runs against the
+    written table in a single pass (warnings only — never blocking)
 14. Persist watermark or CDC state
 15. Run post-write assertions
 16. Write exports (secondary outputs, if configured)

--- a/docs/guides/fact-tables.md
+++ b/docs/guides/fact-tables.md
@@ -24,7 +24,8 @@ raise an execution error with a clear message.
 
 This catches configuration drift early — if a column is renamed
 or dropped upstream, the fact validation fails before any data
-is written.
+is written. The existence check inspects only the schema, so it
+adds no compute cost to the run.
 
 ## Sentinel Values
 
@@ -48,6 +49,31 @@ Defaults:
 These values align with the sentinel defaults used by the
 [`resolve` step](resolve.md). The resolve step assigns these
 sentinel SKs when FK lookups fail or BKs are incomplete.
+
+### Sentinel Advisory
+
+After a successful write, the engine checks each FK column for
+the declared sentinel values and logs a warning for any column
+that contains none. A fact whose FKs never carry sentinels
+usually means the resolve step is not wired up for that column,
+or lookup failures are being silently dropped upstream.
+
+The advisory is:
+
+- **Exact** — every row is considered, not a sample. Columns
+  with many distinct values cannot produce false warnings.
+- **Post-write** — evaluated against the written Delta table,
+  where column statistics make the scan cheap. All FK columns
+  are checked in a single pass, so cost does not grow with the
+  number of foreign keys.
+- **Advisory only** — it never blocks or fails the run. Only
+  the pre-write existence check is enforcing.
+
+Because the check reads the written table, it sees the table's
+full contents: on `append` or `merge` targets, sentinels present
+in historical rows satisfy the check even if the current run
+added none. FK columns that are renamed or excluded by target
+column mapping are skipped.
 
 ## Relationship to Dimension Targets
 

--- a/packages/weevr/src/weevr/engine/executor.py
+++ b/packages/weevr/src/weevr/engine/executor.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from pyspark.sql import SparkSession
 
+from weevr.delta import read_delta
 from weevr.engine.column_sets import materialize_column_sets
 from weevr.engine.hooks import run_hook_steps
 from weevr.engine.lookups import cleanup_lookups, materialize_lookups, resolve_thread_lookups
@@ -597,7 +598,9 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
             # scans cheap. Advisory only: failures never block the run.
             if fact_config is not None and target_path:
                 try:
-                    written_df = spark.read.format("delta").load(target_path)
+                    written_df = read_delta(spark, target_path)
+                    # Return value intentionally unused: the check logs its
+                    # own WARNs, and advisory diagnostics are not stored.
                     check_fact_sentinels(written_df, fact_config)
                 except Exception:
                     logger.debug(

--- a/packages/weevr/src/weevr/engine/executor.py
+++ b/packages/weevr/src/weevr/engine/executor.py
@@ -36,7 +36,7 @@ from weevr.operations.audit import AuditContext, build_sources_json, inject_audi
 from weevr.operations.dimension import DimensionMergeBuilder, execute_dimension_merge
 from weevr.operations.drift import handle_drift
 from weevr.operations.exports import resolve_exports, write_export
-from weevr.operations.fact import validate_fact_target
+from weevr.operations.fact import check_fact_sentinels, validate_fact_schema
 from weevr.operations.hashing import compute_dimension_keys, compute_keys
 from weevr.operations.naming import normalize_columns
 from weevr.operations.pipeline import run_pipeline
@@ -489,13 +489,13 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
                     thread, weave_name, loom_name, run_timestamp, run_id
                 )
 
-            # Step 10b — validate fact target (if fact mode)
+            # Step 10b — validate fact target schema (if fact mode).
+            # Schema-only, no Spark actions; the sentinel advisory runs
+            # post-write against the written table (step 13b).
             if fact_config is not None:
-                fact_diags = validate_fact_target(df, fact_config)
-                for diag in fact_diags:
-                    if diag.startswith("ERROR:"):
-                        raise ExecutionError(diag)
-                    logger.warning(diag)
+                fact_diags = validate_fact_schema(df, fact_config)
+                if fact_diags:
+                    raise ExecutionError(fact_diags[0])
 
             # Step 11/12/13 — write to Delta
             write_mode = thread.write.mode if thread.write else "overwrite"
@@ -591,6 +591,20 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
                 with contextlib.suppress(Exception):
                     output_sample = df.limit(10).toPandas().to_dict("records")
                 rows_written = write_target(spark, df, thread.target, thread.write, target_path)
+
+            # Step 13b — post-write fact sentinel advisory. Runs against
+            # the written table, where columnar stats make per-column
+            # scans cheap. Advisory only: failures never block the run.
+            if fact_config is not None and target_path:
+                try:
+                    written_df = spark.read.format("delta").load(target_path)
+                    check_fact_sentinels(written_df, fact_config)
+                except Exception:
+                    logger.debug(
+                        "Post-write fact sentinel advisory failed for thread '%s'",
+                        thread.name,
+                        exc_info=True,
+                    )
 
             # Auto-generate warp after successful write (all paths)
             if thread.target.warp_mode == "auto":

--- a/packages/weevr/src/weevr/operations/fact.py
+++ b/packages/weevr/src/weevr/operations/fact.py
@@ -3,17 +3,89 @@
 import logging
 
 from pyspark.sql import DataFrame
+from pyspark.sql import functions as F
 
 from weevr.model.fact import FactConfig
 
 logger = logging.getLogger(__name__)
 
 
+def validate_fact_schema(df: DataFrame, fact_config: FactConfig) -> list[str]:
+    """Validate FK column existence against the output DataFrame.
+
+    Driver-side only — inspects the schema and triggers no Spark actions.
+
+    Args:
+        df: Output DataFrame after transforms.
+        fact_config: Fact target configuration with FK column names.
+
+    Returns:
+        List of ``ERROR:`` prefixed diagnostics, one per missing FK column.
+    """
+    diagnostics: list[str] = []
+    df_columns = set(df.columns)
+    for fk_col in fact_config.foreign_keys:
+        if fk_col not in df_columns:
+            diagnostics.append(f"ERROR: FK column '{fk_col}' not found in output DataFrame")
+    return diagnostics
+
+
+def check_fact_sentinels(df: DataFrame, fact_config: FactConfig) -> list[str]:
+    """Warn when FK columns contain no sentinel values.
+
+    Evaluates all present FK columns in a single aggregation pass, so the
+    cost does not scale with FK count. The check is exact — every row is
+    considered, not a sample. FK columns absent from the DataFrame are
+    skipped (existence is ``validate_fact_schema``'s job). Advisory only:
+    failures are swallowed and logged at debug level.
+
+    Args:
+        df: DataFrame to check — the pipeline output or the written table.
+        fact_config: Fact target configuration with FK column names and
+            sentinel value conventions.
+
+    Returns:
+        List of ``WARN:`` prefixed advisory diagnostics.
+    """
+    diagnostics: list[str] = []
+    df_columns = set(df.columns)
+    present_fks = [c for c in fact_config.foreign_keys if c in df_columns]
+    if not present_fks:
+        return diagnostics
+
+    sentinel_vals = {
+        fact_config.sentinel_values.invalid,
+        fact_config.sentinel_values.missing,
+    }
+    logger.debug(
+        "Fact target validation: %d FK columns present, %d missing",
+        len(present_fks),
+        len(fact_config.foreign_keys) - len(present_fks),
+    )
+    try:
+        # max(isin) yields True when any sentinel exists, False when none
+        # do, and NULL for all-null or empty columns — only True clears
+        # the advisory.
+        exprs = [
+            F.max(F.col(fk).isin(*sentinel_vals)).alias(fk) for fk in dict.fromkeys(present_fks)
+        ]
+        sentinel_row = df.agg(*exprs).collect()[0]
+        for fk_col in present_fks:
+            if not sentinel_row[fk_col]:
+                msg = f"WARN: FK column '{fk_col}' contains no sentinel values ({sentinel_vals})"
+                diagnostics.append(msg)
+                logger.warning(msg)
+    except Exception:
+        logger.debug("FK sentinel advisory check failed", exc_info=True)
+
+    return diagnostics
+
+
 def validate_fact_target(df: DataFrame, fact_config: FactConfig) -> list[str]:
     """Validate fact target constraints against the output DataFrame.
 
-    Checks FK column existence and emits advisory warnings when FK
-    columns contain no sentinel values matching the declared conventions.
+    Combines the schema-only FK existence check with the sentinel
+    advisory check.
 
     Args:
         df: Output DataFrame after transforms.
@@ -23,36 +95,4 @@ def validate_fact_target(df: DataFrame, fact_config: FactConfig) -> list[str]:
         List of diagnostic messages. ``ERROR:`` prefixed messages are fatal;
         ``WARN:`` prefixed messages are advisory.
     """
-    diagnostics: list[str] = []
-    df_columns = set(df.columns)
-    for fk_col in fact_config.foreign_keys:
-        if fk_col not in df_columns:
-            diagnostics.append(f"ERROR: FK column '{fk_col}' not found in output DataFrame")
-
-    # Advisory: warn if present FK columns contain no sentinel values.
-    present_fks = [c for c in fact_config.foreign_keys if c in df_columns]
-    if present_fks:
-        sentinel_vals = {
-            fact_config.sentinel_values.invalid,
-            fact_config.sentinel_values.missing,
-        }
-        logger.debug(
-            "Fact target validation: %d FK columns present, %d missing",
-            len(present_fks),
-            len(fact_config.foreign_keys) - len(present_fks),
-        )
-        for fk_col in present_fks:
-            try:
-                distinct_vals = {
-                    row[0] for row in df.select(fk_col).distinct().limit(1000).collect()
-                }
-                if not distinct_vals & sentinel_vals:
-                    msg = (
-                        f"WARN: FK column '{fk_col}' contains no sentinel values ({sentinel_vals})"
-                    )
-                    diagnostics.append(msg)
-                    logger.warning(msg)
-            except Exception:
-                logger.debug("FK sentinel advisory check failed", exc_info=True)
-
-    return diagnostics
+    return validate_fact_schema(df, fact_config) + check_fact_sentinels(df, fact_config)

--- a/packages/weevr/src/weevr/operations/warp.py
+++ b/packages/weevr/src/weevr/operations/warp.py
@@ -59,7 +59,12 @@ def enforce_warp(
     engine_set = set(engine_columns or [])
     warp_only_set = set(warp_only_columns or [])
     df_fields = {field.name: field for field in df.schema.fields}
-    findings: list[dict[str, str]] = []
+
+    # Findings are buffered per column so the batched nullable probe can
+    # slot its results back in declaration order, interleaved with the
+    # schema-side findings exactly as the per-column loop would emit them.
+    column_slots: list[list[dict[str, str]]] = []
+    null_check_slots: list[tuple[str, list[dict[str, str]]]] = []
 
     for col in warp.columns:
         # Skip engine-managed columns
@@ -70,8 +75,11 @@ def enforce_warp(
         if col.name in warp_only_set:
             continue
 
+        slot: list[dict[str, str]] = []
+        column_slots.append(slot)
+
         if col.name not in df_fields:
-            findings.append(
+            slot.append(
                 {
                     "type": "missing_column",
                     "column": col.name,
@@ -87,7 +95,7 @@ def enforce_warp(
         expected_type = col.type.lower()
         actual_type = df_field.dataType.simpleString().lower()
         if expected_type != actual_type:
-            findings.append(
+            slot.append(
                 {
                     "type": "type_mismatch",
                     "column": col.name,
@@ -96,18 +104,31 @@ def enforce_warp(
                 }
             )
 
-        # Nullable check: if warp says non-nullable, verify no nulls
+        # Nullable check candidates: probed together below, one action
         if not col.nullable:
-            null_count = df.where(F.col(col.name).isNull()).limit(1).count()
-            if null_count > 0:
-                findings.append(
+            null_check_slots.append((col.name, slot))
+
+    # Single aggregation pass for all non-nullable columns. max(isNull)
+    # yields True when any null exists, False when none do, and NULL on
+    # an empty DataFrame — only True is a violation.
+    if null_check_slots:
+        exprs = [
+            F.max(F.col(name).isNull()).alias(name)
+            for name in dict.fromkeys(name for name, _ in null_check_slots)
+        ]
+        null_row = df.agg(*exprs).collect()[0]
+        for name, slot in null_check_slots:
+            if null_row[name]:
+                slot.append(
                     {
                         "type": "nullable_violation",
-                        "column": col.name,
+                        "column": name,
                         "expected": "non-nullable",
                         "actual": "contains nulls",
                     }
                 )
+
+    findings: list[dict[str, str]] = [f for slot in column_slots for f in slot]
 
     if findings and mode == "enforce":
         summary = ", ".join(f"{f['column']} ({f['type']})" for f in findings[:3])

--- a/tests/weevr/conftest.py
+++ b/tests/weevr/conftest.py
@@ -44,6 +44,39 @@ def spark() -> Generator[SparkSession, None, None]:
 
 
 @pytest.fixture()
+def spark_action_counter(monkeypatch) -> dict[str, int]:
+    """Count Spark actions triggered through DataFrame methods.
+
+    Wraps every DataFrame method that launches a job (collect, count,
+    first, take, toPandas) and counts outermost invocations only —
+    first() delegates to take() which delegates to collect(), and the
+    depth guard keeps that chain from counting as three actions.
+
+    Returns a dict whose "total" key holds the running action count.
+    """
+    from pyspark.sql import DataFrame
+
+    state = {"total": 0, "_depth": 0}
+
+    def _make_wrapper(original):
+        def wrapper(self, *args, **kwargs):
+            state["_depth"] += 1
+            if state["_depth"] == 1:
+                state["total"] += 1
+            try:
+                return original(self, *args, **kwargs)
+            finally:
+                state["_depth"] -= 1
+
+        return wrapper
+
+    for method_name in ("collect", "count", "first", "take", "toPandas"):
+        monkeypatch.setattr(DataFrame, method_name, _make_wrapper(getattr(DataFrame, method_name)))
+
+    return state
+
+
+@pytest.fixture()
 def tmp_delta_path(tmp_path: Path):
     """Function-scoped factory for isolated Delta table paths.
 

--- a/tests/weevr/engine/test_integration.py
+++ b/tests/weevr/engine/test_integration.py
@@ -2,6 +2,7 @@
 
 import csv
 import json
+import logging
 from pathlib import Path
 
 import pytest
@@ -12,6 +13,7 @@ from spark_helpers import create_delta_table
 from weevr.config import load_config
 from weevr.engine import ThreadResult, execute_thread
 from weevr.errors.exceptions import ExecutionError
+from weevr.model.fact import FactConfig
 from weevr.model.keys import KeyConfig
 from weevr.model.pipeline import (
     DedupParams,
@@ -574,6 +576,105 @@ class TestWriteModes:
         written = spark.read.format("delta").load(tgt)
         assert written.count() == 1
         assert written.collect()[0]["id"] == 1
+
+
+class TestFactValidation:
+    """Fact validation: blocking existence pre-write, sentinel advisory post-write."""
+
+    def _fact_thread(
+        self,
+        name: str,
+        src: str,
+        tgt: str,
+        foreign_keys: list[str],
+        *,
+        write: WriteConfig | None = None,
+        target: Target | None = None,
+    ) -> Thread:
+        return _thread(
+            name,
+            src,
+            tgt,
+            target=target or Target(path=tgt, fact=FactConfig(foreign_keys=foreign_keys)),
+            write=write,
+        )
+
+    def test_missing_fk_column_aborts_before_write(
+        self, spark: SparkSession, tmp_delta_path
+    ) -> None:
+        """A missing FK column raises ExecutionError and nothing is written."""
+        src = tmp_delta_path("fact_err_src")
+        tgt = tmp_delta_path("fact_err_tgt")
+        create_delta_table(spark, src, [{"sk_customer": 1, "amount": 100}])
+
+        thread = self._fact_thread("fact_err", src, tgt, ["sk_customer", "sk_product"])
+        with pytest.raises(ExecutionError) as exc_info:
+            execute_thread(spark, thread)
+
+        assert "sk_product" in str(exc_info.value)
+        assert not (Path(tgt) / "_delta_log").exists()
+
+    def test_sentinel_advisory_warns_after_successful_write(
+        self, spark: SparkSession, tmp_delta_path, caplog
+    ) -> None:
+        """A sentinel-free fact still writes; the advisory WARN fires post-write."""
+        src = tmp_delta_path("fact_warn_src")
+        tgt = tmp_delta_path("fact_warn_tgt")
+        create_delta_table(spark, src, [{"sk_customer": 1, "amount": 100}])
+
+        thread = self._fact_thread("fact_warn", src, tgt, ["sk_customer"])
+        with caplog.at_level(logging.WARNING, logger="weevr.operations.fact"):
+            result = execute_thread(spark, thread)
+
+        assert result.status == "success"
+        assert spark.read.format("delta").load(tgt).count() == 1
+        assert any("contains no sentinel values" in r.message for r in caplog.records)
+
+    def test_advisory_evaluates_written_table_not_pipeline_frame(
+        self, spark: SparkSession, tmp_delta_path, caplog
+    ) -> None:
+        """Appending sentinel-free rows onto history that has sentinels → no WARN.
+
+        The advisory reads the written table; the in-flight DataFrame alone
+        (no sentinels) would have WARNed under pre-write checking.
+        """
+        src = tmp_delta_path("fact_hist_src")
+        tgt = tmp_delta_path("fact_hist_tgt")
+        create_delta_table(spark, tgt, [{"sk_customer": -1, "amount": 0}])
+        create_delta_table(spark, src, [{"sk_customer": 1, "amount": 100}])
+
+        thread = self._fact_thread(
+            "fact_hist", src, tgt, ["sk_customer"], write=WriteConfig(mode="append")
+        )
+        with caplog.at_level(logging.WARNING, logger="weevr.operations.fact"):
+            result = execute_thread(spark, thread)
+
+        assert result.status == "success"
+        assert not any("contains no sentinel values" in r.message for r in caplog.records)
+
+    def test_advisory_skips_fk_dropped_by_mapping(
+        self, spark: SparkSession, tmp_delta_path, caplog
+    ) -> None:
+        """An FK dropped by explicit mapping is absent post-write — the run
+        still succeeds and no advisory fires for it."""
+        src = tmp_delta_path("fact_map_src")
+        tgt = tmp_delta_path("fact_map_tgt")
+        create_delta_table(spark, src, [{"sk_customer": 1, "amount": 100}])
+
+        target = Target(
+            path=tgt,
+            mapping_mode="explicit",
+            columns={"amount": ColumnMapping()},
+            fact=FactConfig(foreign_keys=["sk_customer"]),
+        )
+        thread = self._fact_thread("fact_map", src, tgt, ["sk_customer"], target=target)
+        with caplog.at_level(logging.WARNING, logger="weevr.operations.fact"):
+            result = execute_thread(spark, thread)
+
+        assert result.status == "success"
+        written = spark.read.format("delta").load(tgt)
+        assert "sk_customer" not in written.columns
+        assert not any("contains no sentinel values" in r.message for r in caplog.records)
 
 
 class TestErrorWrapping:

--- a/tests/weevr/engine/test_integration.py
+++ b/tests/weevr/engine/test_integration.py
@@ -652,6 +652,59 @@ class TestFactValidation:
         assert result.status == "success"
         assert not any("contains no sentinel values" in r.message for r in caplog.records)
 
+    def test_sentinel_advisory_fires_for_alias_target(
+        self, spark: SparkSession, tmp_delta_path, caplog
+    ) -> None:
+        """The post-write advisory reads table-alias targets via the
+        metastore, not just filesystem paths."""
+        src = tmp_delta_path("fact_alias_src")
+        create_delta_table(spark, src, [{"sk_customer": 1, "amount": 100}])
+        alias = "fact_alias_advisory_tgt"
+
+        try:
+            spark.sql(f"CREATE TABLE {alias} (sk_customer BIGINT, amount BIGINT) USING delta")
+            target = Target(alias=alias, fact=FactConfig(foreign_keys=["sk_customer"]))
+            thread = self._fact_thread(
+                "fact_alias",
+                src,
+                alias,
+                ["sk_customer"],
+                write=WriteConfig(mode="append"),
+                target=target,
+            )
+            with caplog.at_level(logging.WARNING, logger="weevr.operations.fact"):
+                result = execute_thread(spark, thread)
+
+            assert result.status == "success"
+            assert spark.read.format("delta").table(alias).count() == 1
+            assert any("contains no sentinel values" in r.message for r in caplog.records)
+        finally:
+            spark.sql(f"DROP TABLE IF EXISTS {alias}")
+
+    def test_advisory_read_failure_never_fails_run(
+        self, spark: SparkSession, tmp_delta_path, caplog, monkeypatch
+    ) -> None:
+        """A failing post-write table read degrades to a debug log; the
+        run still succeeds."""
+        import weevr.engine.executor as executor_mod
+
+        src = tmp_delta_path("fact_boom_src")
+        tgt = tmp_delta_path("fact_boom_tgt")
+        create_delta_table(spark, src, [{"sk_customer": 1, "amount": 100}])
+
+        def _unreadable(*args, **kwargs):
+            raise RuntimeError("table unreadable")
+
+        monkeypatch.setattr(executor_mod, "read_delta", _unreadable)
+
+        thread = self._fact_thread("fact_boom", src, tgt, ["sk_customer"])
+        with caplog.at_level(logging.WARNING, logger="weevr.operations.fact"):
+            result = execute_thread(spark, thread)
+
+        assert result.status == "success"
+        assert spark.read.format("delta").load(tgt).count() == 1
+        assert not any("contains no sentinel values" in r.message for r in caplog.records)
+
     def test_advisory_skips_fk_dropped_by_mapping(
         self, spark: SparkSession, tmp_delta_path, caplog
     ) -> None:

--- a/tests/weevr/operations/test_fact.py
+++ b/tests/weevr/operations/test_fact.py
@@ -183,6 +183,39 @@ class TestCheckFactSentinels:
         diagnostics = check_fact_sentinels(df, fact_config)
         assert len(diagnostics) == 1
 
+    def test_duplicate_fk_names_single_action(
+        self, spark: SparkSession, spark_action_counter: dict[str, int]
+    ):
+        """Duplicate FK names are deduplicated in the aggregation.
+
+        FactConfig does not enforce FK uniqueness, so a duplicated name
+        must not produce ambiguous aggregation aliases. Diagnostics keep
+        one entry per declared FK, matching the old per-column loop.
+        """
+        schema = StructType([StructField("sk_customer", IntegerType(), True)])
+        df = spark.createDataFrame([(1,), (2,)], schema)
+        fact_config = FactConfig(foreign_keys=["sk_customer", "sk_customer"])
+        diagnostics = check_fact_sentinels(df, fact_config)
+        assert len(diagnostics) == 2
+        assert all("sk_customer" in d for d in diagnostics)
+        assert spark_action_counter["total"] == 1
+
+    def test_aggregation_failure_swallowed_as_advisory(self, spark: SparkSession, monkeypatch):
+        """A failing sentinel aggregation returns no diagnostics and
+        raises nothing — the check is advisory only."""
+        from pyspark.sql import DataFrame
+
+        schema = StructType([StructField("sk_customer", IntegerType(), True)])
+        df = spark.createDataFrame([(1,)], schema)
+
+        def _boom(self, *args, **kwargs):
+            raise RuntimeError("aggregation failed")
+
+        monkeypatch.setattr(DataFrame, "agg", _boom)
+        fact_config = FactConfig(foreign_keys=["sk_customer"])
+        diagnostics = check_fact_sentinels(df, fact_config)
+        assert diagnostics == []
+
     def test_absent_fk_columns_skipped(
         self, spark: SparkSession, spark_action_counter: dict[str, int]
     ):

--- a/tests/weevr/operations/test_fact.py
+++ b/tests/weevr/operations/test_fact.py
@@ -5,7 +5,11 @@ from pyspark.sql import SparkSession
 from pyspark.sql.types import IntegerType, StructField, StructType
 
 from weevr.model.fact import FactConfig
-from weevr.operations.fact import validate_fact_target
+from weevr.operations.fact import (
+    check_fact_sentinels,
+    validate_fact_schema,
+    validate_fact_target,
+)
 
 pytestmark = pytest.mark.spark
 
@@ -113,3 +117,79 @@ class TestValidateFactTarget:
         diagnostics = validate_fact_target(df, fact_config)
         warns = [d for d in diagnostics if d.startswith("WARN:")]
         assert len(warns) == 0
+
+
+class TestValidateFactSchema:
+    """Test the schema-only FK existence check."""
+
+    def test_no_spark_actions(self, spark: SparkSession, spark_action_counter: dict[str, int]):
+        """Existence validation is driver-side only."""
+        schema = StructType([StructField("dim_date_id", IntegerType(), True)])
+        df = spark.createDataFrame([(1,)], schema)
+        fact_config = FactConfig(foreign_keys=["dim_date_id", "dim_product_id"])
+        diagnostics = validate_fact_schema(df, fact_config)
+        assert diagnostics == ["ERROR: FK column 'dim_product_id' not found in output DataFrame"]
+        assert spark_action_counter["total"] == 0
+
+
+class TestCheckFactSentinels:
+    """Test the single-pass sentinel advisory check."""
+
+    def test_single_action_for_multiple_fks(
+        self, spark: SparkSession, spark_action_counter: dict[str, int]
+    ):
+        """All FK columns are checked in one Spark action."""
+        schema = StructType(
+            [
+                StructField("sk_customer", IntegerType(), True),
+                StructField("sk_product", IntegerType(), True),
+                StructField("sk_date", IntegerType(), True),
+            ]
+        )
+        df = spark.createDataFrame([(-1, 1, 1), (2, 2, 2)], schema)
+        fact_config = FactConfig(foreign_keys=["sk_customer", "sk_product", "sk_date"])
+        diagnostics = check_fact_sentinels(df, fact_config)
+        warned_cols = {d.split("'")[1] for d in diagnostics}
+        assert warned_cols == {"sk_product", "sk_date"}
+        assert spark_action_counter["total"] == 1
+
+    def test_exact_beyond_1000_distinct_values(self, spark: SparkSession):
+        """A sentinel among >1000 distinct FK values is always found.
+
+        Regression for the sampled probe: distinct().limit(1000) could
+        miss the sentinel and emit a false WARN.
+        """
+        schema = StructType([StructField("sk_customer", IntegerType(), True)])
+        rows = [(v,) for v in range(1, 1501)] + [(-1,)]
+        df = spark.createDataFrame(rows, schema)
+        fact_config = FactConfig(foreign_keys=["sk_customer"])
+        diagnostics = check_fact_sentinels(df, fact_config)
+        assert diagnostics == []
+
+    def test_all_null_fk_warns(self, spark: SparkSession):
+        """An all-null FK column contains no sentinels and WARNs."""
+        schema = StructType([StructField("sk_customer", IntegerType(), True)])
+        df = spark.createDataFrame([(None,), (None,)], schema)
+        fact_config = FactConfig(foreign_keys=["sk_customer"])
+        diagnostics = check_fact_sentinels(df, fact_config)
+        assert len(diagnostics) == 1
+        assert "sk_customer" in diagnostics[0]
+
+    def test_empty_dataframe_warns(self, spark: SparkSession):
+        """An empty DataFrame with present FK columns WARNs."""
+        schema = StructType([StructField("sk_customer", IntegerType(), True)])
+        df = spark.createDataFrame([], schema)
+        fact_config = FactConfig(foreign_keys=["sk_customer"])
+        diagnostics = check_fact_sentinels(df, fact_config)
+        assert len(diagnostics) == 1
+
+    def test_absent_fk_columns_skipped(
+        self, spark: SparkSession, spark_action_counter: dict[str, int]
+    ):
+        """Missing FK columns are the existence check's job — skipped here."""
+        schema = StructType([StructField("amount", IntegerType(), True)])
+        df = spark.createDataFrame([(100,)], schema)
+        fact_config = FactConfig(foreign_keys=["sk_customer"])
+        diagnostics = check_fact_sentinels(df, fact_config)
+        assert diagnostics == []
+        assert spark_action_counter["total"] == 0

--- a/tests/weevr/operations/test_warp.py
+++ b/tests/weevr/operations/test_warp.py
@@ -150,6 +150,106 @@ class TestEnforceWarp:
         with pytest.raises(WarpEnforcementError):
             enforce_warp(df, warp, "enforce")
 
+    def test_nullable_probe_single_action(
+        self, spark: SparkSession, spark_action_counter: dict[str, int]
+    ):
+        """Multiple non-nullable columns are probed in one Spark action."""
+        df = spark.createDataFrame(
+            [(1, 10, None), (2, None, None)],
+            schema=T.StructType(
+                [
+                    T.StructField("id", T.LongType(), True),
+                    T.StructField("name", T.LongType(), True),
+                    T.StructField("code", T.LongType(), True),
+                ]
+            ),
+        )
+        warp = self._make_warp(
+            [
+                {"name": "id", "type": "bigint", "nullable": False},
+                {"name": "name", "type": "bigint", "nullable": False},
+                {"name": "code", "type": "bigint", "nullable": False},
+            ]
+        )
+        findings = enforce_warp(df, warp, "warn")
+        violations = {f["column"] for f in findings if f["type"] == "nullable_violation"}
+        assert violations == {"name", "code"}
+        assert spark_action_counter["total"] == 1
+
+    def test_no_non_nullable_columns_zero_actions(
+        self, spark: SparkSession, spark_action_counter: dict[str, int]
+    ):
+        """Nullable-only warps trigger no Spark actions at all."""
+        df = spark.createDataFrame(
+            [(1, "a")],
+            schema=T.StructType(
+                [
+                    T.StructField("id", T.LongType(), True),
+                    T.StructField("name", T.StringType(), True),
+                ]
+            ),
+        )
+        warp = self._make_warp(
+            [
+                {"name": "id", "type": "bigint"},
+                {"name": "name", "type": "string"},
+            ]
+        )
+        findings = enforce_warp(df, warp, "enforce")
+        assert findings == []
+        assert spark_action_counter["total"] == 0
+
+    def test_missing_non_nullable_column_zero_actions(
+        self, spark: SparkSession, spark_action_counter: dict[str, int]
+    ):
+        """A missing non-nullable column is reported schema-side, no probe."""
+        df = spark.createDataFrame([(1,)], ["id"])
+        warp = self._make_warp(
+            [
+                {"name": "id", "type": "bigint"},
+                {"name": "gone", "type": "bigint", "nullable": False},
+            ]
+        )
+        findings = enforce_warp(df, warp, "warn")
+        assert [f["type"] for f in findings] == ["missing_column"]
+        assert spark_action_counter["total"] == 0
+
+    def test_empty_dataframe_no_nullable_violation(self, spark: SparkSession):
+        """An empty DataFrame has no nulls to violate non-nullable columns."""
+        df = spark.createDataFrame(
+            [],
+            schema=T.StructType([T.StructField("id", T.LongType(), True)]),
+        )
+        warp = self._make_warp([{"name": "id", "type": "bigint", "nullable": False}])
+        findings = enforce_warp(df, warp, "enforce")
+        assert findings == []
+
+    def test_finding_order_interleaved_per_column(self, spark: SparkSession):
+        """Findings keep per-column order: each column's schema finding
+        precedes its nullable finding, in warp declaration order."""
+        df = spark.createDataFrame(
+            [(None, None)],
+            schema=T.StructType(
+                [
+                    T.StructField("a", T.StringType(), True),
+                    T.StructField("b", T.StringType(), True),
+                ]
+            ),
+        )
+        warp = self._make_warp(
+            [
+                {"name": "a", "type": "bigint", "nullable": False},
+                {"name": "b", "type": "bigint", "nullable": False},
+            ]
+        )
+        findings = enforce_warp(df, warp, "warn")
+        assert [(f["column"], f["type"]) for f in findings] == [
+            ("a", "type_mismatch"),
+            ("a", "nullable_violation"),
+            ("b", "type_mismatch"),
+            ("b", "nullable_violation"),
+        ]
+
 
 # ---------------------------------------------------------------------------
 # append_warp_only_columns (Task 12)


### PR DESCRIPTION
## Summary

- Fact FK sentinel checks and warp nullability enforcement now run as single
  aggregation passes instead of one Spark action per column, and the sentinel
  advisory moves post-write against the written table.

Closes #181.

## Why

- Both probes ran against the transformed, uncached DataFrame, so each
  per-column action re-executed the entire upstream lineage. On a 12-FK fact
  with an expensive pipeline this cost ~2 hours of redundant compute per run
  (live-deployment evidence: uniform ~10-minute gaps between per-FK WARN
  lines). The cost scaled with column count on every fact run, at every
  verbosity level.
- The sentinel probe also sampled 1000 arbitrary distinct values, so FKs with
  more than 1000 distinct members could false-WARN "contains no sentinel
  values" even when sentinels existed.

## What changed

- `enforce_warp` probes all non-nullable columns in one `max(isNull())`
  aggregation. Findings are unchanged, including per-column ordering; zero
  actions when no non-nullable columns are declared.
- Fact validation is split: FK existence stays pre-write and write-blocking
  but is now schema-only (no Spark actions); the sentinel advisory runs in
  one exact `max(isin(...))` aggregation — no sampling, so the
  high-cardinality false WARNs disappear.
- The sentinel advisory now runs after the write, against the written Delta
  table (via the shared `read_delta` helper, so both path and table-alias
  targets work). It is advisory-only: read or aggregation failures degrade to
  debug logs and never fail the run. On append/merge targets the check sees
  the whole table, so historical sentinels satisfy it.
- Tests: action-count regression tests via a new `spark_action_counter`
  fixture (monkeypatch-counted DataFrame actions with a re-entrancy guard),
  a >1000-distinct exactness regression, and integration tests covering
  pre-write abort, post-write advisory timing, whole-table semantics, alias
  targets, mapping-dropped FKs, and advisory failure paths.
- Docs: fact-tables guide gains a Sentinel Advisory section; engine-internals
  step list updated.

## How to test

- [x] uv sync --dev
- [x] uv run ruff check .
- [x] uv run ruff format .
- [x] uv run pyright .
- [x] uv run pytest (2450 passed) and uv run pytest -m spark (798 passed)
- [x] uv run mkdocs build --strict && npx markdownlint-cli2 'docs/**/*.md'

## Release / Versioning

- [x] PR title follows Conventional Commit format (feat:, fix:, chore:, docs:, ci:, etc.)
- [ ] Breaking change indicated (feat!: / fix!: or BREAKING CHANGE in body)

Not breaking: no documented behavior is altered. Sentinel warnings become
exact instead of sampled, and the advisory's log lines move after the write —
ordering changes, outcomes do not.

## Notes

- Users with >1000-distinct FK columns may see false sentinel warnings
  disappear; incremental facts may see fewer advisories because historical
  sentinels now satisfy the post-write check. Both are called out in the
  fact-tables guide.
- Found while testing alias targets: a first write via `saveAsTable` in
  overwrite mode fails on vanilla OSS Spark + Delta ("does not support
  truncate in batch mode"), independent of this change. The alias test
  works around it by pre-creating the table; tracked separately.
- Executor telemetry counts/samples and the pre-write row count in
  `writers.py` are intentionally untouched — they belong to the
  thread-materialization-boundary work.