### PR TITLE
feat(engine): wire execution block with max_parallel_threads

### DIFF
--- a/docs/concepts/thread-weave-loom.md
+++ b/docs/concepts/thread-weave-loom.md
@@ -160,8 +160,8 @@ weaves:
 defaults:
   write:
     mode: merge
-  execution:
-    log_level: standard
+execution:
+  log_level: standard
 params:
   run_date:
     type: date
@@ -196,9 +196,14 @@ merged.
 !!! tip "Inheritance reduces repetition"
 
     Define common patterns once at the loom level (write modes, audit
-    columns, execution settings) and override only where a thread differs.
-    Most threads need very little thread-level configuration when inheritance
-    is used effectively.
+    columns) and override only where a thread differs. Most threads need
+    very little thread-level configuration when inheritance is used
+    effectively.
+
+    The top-level `execution:` block is the exception: declared on the
+    loom or weave only, merged field-level between the two, and never
+    applied at thread scope. See
+    [Execution Settings](../guides/execution-settings.md).
 
 ### Example
 

--- a/docs/guides/execution-settings.md
+++ b/docs/guides/execution-settings.md
@@ -1,0 +1,108 @@
+# Execution Settings
+
+The `execution:` block controls runtime behavior — logging verbosity,
+telemetry collection, and thread parallelism. It is declared at the
+**top level** of a loom or weave file:
+
+```yaml
+# nightly.loom
+execution:
+  max_parallel_threads: 3   # capacity-wide default
+
+# facts.weave — inherits the cap, overrides logging only
+execution:
+  log_level: verbose
+```
+
+## Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `log_level` | `minimal` \| `standard` \| `verbose` \| `debug` | `standard` | Logging verbosity for execution output |
+| `trace` | `bool` | `true` | Whether execution spans are collected for telemetry |
+| `max_parallel_threads` | `int >= 1` | unset | Upper bound on concurrently executing threads within a weave's parallel group; unset means unbounded |
+
+## How loom and weave blocks combine
+
+The effective settings for each weave merge **field-level**: a field the
+weave explicitly sets wins; otherwise the loom's value applies; otherwise
+the default. In the example above, the `facts` weave runs with
+`log_level: verbose` *and* the loom's cap of 3 — declaring a
+logging-only block does not drop an inherited capacity cap.
+
+This is a deliberate exception to the usual cascade rule where value
+blocks replace whole-value. The `execution:` block is the only top-level
+block that merges per field.
+
+## Thread parallelism
+
+Threads inside a weave execute in dependency-ordered groups; threads
+within a group run concurrently. By default each group's worker pool is
+sized to the group, so six independent facts contend for the same Spark
+executors at once. `max_parallel_threads` bounds that concurrency:
+
+```yaml
+execution:
+  max_parallel_threads: 3
+```
+
+With a cap of 3, a six-thread group never has more than three threads in
+flight. Groups still execute sequentially, and dependency ordering and
+failure routing are unchanged. Size the cap to your Fabric capacity — a
+good starting point is the number of concurrent Spark jobs your pool
+serves without queueing.
+
+When tracing is on, the weave span records the effective cap and the
+per-group thread counts, so a capped run is identifiable in `RunResult`
+telemetry.
+
+## Log level
+
+Precedence, highest first:
+
+1. An explicit `Context(log_level=...)` argument — a runtime override
+   that beats any YAML setting for the whole run.
+2. The effective YAML value from the loom/weave `execution:` block.
+3. The default, `standard`.
+
+The effective level applies in every mode (`execute`, `validate`,
+`plan`, `preview`). During a loom run, a weave whose effective level
+differs from the loom's is applied for that weave and restored
+afterward — including when the weave fails.
+
+## Tracing
+
+`trace: false` suppresses telemetry at the scope that declares it:
+
+- **Loom scope** — no telemetry is collected for the run;
+  `RunResult.telemetry` is `None`.
+- **Weave scope** (under a tracing loom) — that weave's nodes are absent
+  from the telemetry tree; other weaves are unaffected.
+- **Standalone weave run** — the weave's own block gates collection.
+
+Tracing composes one-directionally: a weave can turn tracing *off* under
+a tracing loom, but `trace: true` on a weave cannot re-enable it under a
+loom whose effective `trace` is false — there is no root collector to
+attach to. Config validation warns when a weave declares an ineffective
+`trace: true`.
+
+Standalone thread runs always trace.
+
+## Thread-scoped execution is not applied
+
+`execution:` on a *thread* — whether authored in the thread file or
+arrived via a `defaults.execution` block — is declared but **not
+applied** in v1.x, in any invocation shape. Within a weave the cap is a
+group property, and per-thread logging or tracing under parallel
+execution would race on global state.
+
+`defaults.execution` is therefore not a recognized declaration site: it
+cascades to thread scope, where execution settings do not apply. A run
+whose configs declare either form logs a warning at start naming the
+unapplied fields and pointing at the top-level block:
+
+```text
+WARN: loom 'nightly' declares defaults.execution (log_level) — thread-scoped
+execution settings are not applied. Move them to the top-level execution
+block on the loom or weave.
+```

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -63,17 +63,20 @@ ctx = Context(spark, "my-project.weevr", log_level="verbose")
 result = ctx.run("nightly.loom")
 ```
 
-You can also set it in YAML execution settings on a loom or weave, and it
-cascades through configuration inheritance:
+You can also set it in the top-level `execution:` block of a loom or
+weave:
 
 ```yaml
 # nightly.loom
-defaults:
-  execution:
-    log_level: standard
+execution:
+  log_level: standard
 ```
 
 The `Context` constructor value takes precedence over YAML settings.
+Loom and weave blocks merge field-level; `defaults.execution` lands at
+thread scope, where execution settings are not applied. See
+[Execution Settings](execution-settings.md) for the full precedence and
+merge rules.
 
 ## Execution spans
 

--- a/docs/reference/configuration-keys.md
+++ b/docs/reference/configuration-keys.md
@@ -121,7 +121,7 @@ The top-level configuration unit for a single data pipeline.
 | `params` | `dict[str, ParamSpec]` | `None` | Parameter declarations |
 | `defaults` | `dict[str, Any]` | `None` | Inherited defaults |
 | `failure` | `FailureConfig` | `None` | Failure handling policy |
-| `execution` | `ExecutionConfig` | `None` | Runtime settings |
+| `execution` | `ExecutionConfig` | `None` | Declared but not applied at thread scope (warned) |
 | `cache` | `bool` | `None` | Cache DataFrame before writing |
 | `exports` | `list[Export]` | `None` | Secondary output destinations |
 | `lookups` | `dict[str, Lookup]` | `None` | Thread-level lookup definitions |
@@ -378,12 +378,16 @@ Post-execution assertions on the target dataset.
 
 ## ExecutionConfig
 
-Runtime settings that cascade through loom/weave/thread.
+Runtime settings, declared on the top-level `execution:` block of a loom
+or weave. Loom and weave blocks merge field-level (explicitly set weave
+fields win). Thread-scoped declarations are not applied. See the
+[Execution Settings guide](../guides/execution-settings.md).
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `log_level` | `"minimal" \| "standard" \| "verbose" \| "debug"` | `"standard"` | Logging verbosity |
-| `trace` | `bool` | `True` | Collect execution spans |
+| `log_level` | `"minimal" \| "standard" \| "verbose" \| "debug"` | `"standard"` | Logging verbosity. An explicit `Context(log_level=...)` argument takes precedence. |
+| `trace` | `bool` | `True` | Collect execution spans. `false` at loom scope disables telemetry for the run; at weave scope, omits that weave's nodes. |
+| `max_parallel_threads` | `int >= 1` | `None` | Cap on concurrently executing threads per weave group. Unset means unbounded. |
 
 ---
 
@@ -536,7 +540,7 @@ A collection of threads with shared lookups, hooks, and defaults.
 | `post_steps` | `list[HookStep]` | `None` | Hook steps run after threads |
 | `defaults` | `dict[str, Any]` | `None` | Default values cascaded to threads |
 | `params` | `dict[str, ParamSpec]` | `None` | Parameter declarations |
-| `execution` | `ExecutionConfig` | `None` | Runtime settings cascaded to threads |
+| `execution` | `ExecutionConfig` | `None` | Runtime settings; field-level merge with the loom block |
 | `naming` | `NamingConfig` | `None` | Naming normalization cascaded to threads |
 | `column_sets` | `dict[str, ColumnSet]` | `None` | Named column sets for bulk rename |
 | `audit_templates` | `dict[str, dict[str, str]]` | `None` | Named audit column templates cascaded to threads |
@@ -570,7 +574,7 @@ Deployment unit grouping one or more weaves.
 | `weaves` | `list[WeaveEntry]` | *required* | Weave references |
 | `defaults` | `dict[str, Any]` | `None` | Default values cascaded to weaves and threads |
 | `params` | `dict[str, ParamSpec]` | `None` | Parameter declarations |
-| `execution` | `ExecutionConfig` | `None` | Runtime settings cascaded down |
+| `execution` | `ExecutionConfig` | `None` | Runtime settings; weave blocks override field-level |
 | `naming` | `NamingConfig` | `None` | Naming normalization cascaded down |
 | `column_sets` | `dict[str, ColumnSet]` | `None` | Named column sets cascaded to weaves |
 | `lookups` | `dict[str, Lookup]` | `None` | Loom-level lookup definitions cascaded to weaves |

--- a/docs/reference/yaml-schema/loom.md
+++ b/docs/reference/yaml-schema/loom.md
@@ -15,7 +15,7 @@ runtime settings that cascade down through weaves to threads.
 | `weaves` | `list[WeaveEntry or string]` | yes | -- | Weave references. Strings are shorthand for `{ name: "<value>" }` (inline definitions). Use `ref` for external file references. |
 | `defaults` | `dict[string, any]` | no | `null` | Default values cascaded into every weave and thread. `audit_columns` and `exports` use additive merge (see [Exports guide](../../guides/exports.md)). |
 | `params` | `dict[string, ParamSpec]` | no | `null` | Typed parameter declarations scoped to this loom |
-| `execution` | `ExecutionConfig` | no | `null` | Runtime settings cascaded to weaves and threads |
+| `execution` | `ExecutionConfig` | no | `null` | Runtime settings: `log_level`, `trace`, `max_parallel_threads`. Merges field-level with weave blocks (weave-set fields win). See the [Execution Settings guide](../../guides/execution-settings.md). |
 | `naming` | `NamingConfig` | no | `null` | Naming normalization cascaded to weaves and threads |
 | `column_sets` | `dict[string, ColumnSet]` | no | `null` | Named column sets cascaded to weaves. Weave-level definitions with the same name override loom-level definitions. Column sets can read their mapping table via a loom-level `connections:` entry — see [Connections guide: Column sets via connections](../../guides/connections.md#column-sets-via-connections). See [Weave schema: column_sets](weave.md#column_sets) for field details. |
 | `lookups` | `dict[string, Lookup]` | no | `null` | Loom-level lookup definitions. Merged with weave-level lookups (weave wins on name collision). See [Weave schema: lookups](weave.md#lookups) for field details. |
@@ -115,7 +115,7 @@ post_steps:
 
 ## Configuration cascade
 
-Defaults and execution settings flow downward through the hierarchy:
+Defaults flow downward through the hierarchy:
 
 ```text
 Loom defaults
@@ -124,6 +124,11 @@ Loom defaults
 ```
 
 The most specific level always wins.
+
+The top-level `execution:` block is the exception: it is not part of
+`defaults`, loom and weave blocks merge field-level (an explicitly set
+weave field wins), and it never applies at thread scope. See the
+[Execution Settings guide](../../guides/execution-settings.md).
 
 ---
 
@@ -141,8 +146,6 @@ weaves:
   - ref: publish_marts.weave
 
 defaults:
-  execution:
-    log_level: standard
   write:
     mode: overwrite
 

--- a/docs/reference/yaml-schema/thread.md
+++ b/docs/reference/yaml-schema/thread.md
@@ -29,7 +29,7 @@ Threads can be used as **parameterized templates** via `as` and `params` on
 | `params` | `dict[string, ParamSpec]` | no | `null` | Typed parameter declarations |
 | `defaults` | `dict[string, any]` | no | `null` | Default values inherited by nested structures |
 | `failure` | `FailureConfig` | no | `null` | Per-thread failure handling policy |
-| `execution` | `ExecutionConfig` | no | `null` | Runtime settings (logging, tracing) |
+| `execution` | `ExecutionConfig` | no | `null` | Declared but **not applied** at thread scope (a run-start warning names the unapplied fields). Declare execution settings on the loom or weave top level instead. |
 | `cache` | `bool` | no | `null` | Whether to cache the final DataFrame before writing |
 | `exports` | `list[Export]` | no | `null` | Secondary output destinations. See [Exports guide](../../guides/exports.md). |
 | `lookups` | `dict[string, Lookup]` | no | `null` | Thread-level lookup definitions. Merged with weave-level lookups (thread wins on name collision). |
@@ -1311,13 +1311,16 @@ failure:
 
 ## execution
 
-Runtime execution settings. These cascade from loom to weave to thread, with
-the most specific level winning.
+Declared but **not applied** at thread scope in v1.x — a run-start
+warning names the unapplied fields. Declare execution settings on the
+loom or weave top level instead. See the
+[Execution Settings guide](../../guides/execution-settings.md).
 
 | Key | Type | Required | Default | Description |
 |-----|------|----------|---------|-------------|
 | `log_level` | `string` | no | `"standard"` | Logging verbosity: `"minimal"`, `"standard"`, `"verbose"`, `"debug"` |
 | `trace` | `bool` | no | `true` | Collect execution spans for telemetry |
+| `max_parallel_threads` | `int` | no | unset | Cap on concurrently executing threads per group (`>= 1`) |
 
 ```yaml
 execution:
@@ -1568,10 +1571,6 @@ assertions:
 
 failure:
   on_failure: skip_downstream
-
-execution:
-  log_level: standard
-  trace: true
 
 tags: [orders, curated]
 ```

--- a/docs/reference/yaml-schema/weave.md
+++ b/docs/reference/yaml-schema/weave.md
@@ -20,7 +20,7 @@ runtime settings.
 | `post_steps` | `list[HookStep]` | no | `null` | Hook steps executed after all threads complete |
 | `defaults` | `dict[string, any]` | no | `null` | Default values cascaded into every thread in this weave. `audit_columns` and `exports` use additive merge (see [Exports guide](../../guides/exports.md)). |
 | `params` | `dict[string, ParamSpec]` | no | `null` | Typed parameter declarations scoped to this weave |
-| `execution` | `ExecutionConfig` | no | `null` | Runtime settings (logging, tracing) cascaded to threads |
+| `execution` | `ExecutionConfig` | no | `null` | Runtime settings: `log_level`, `trace`, `max_parallel_threads`. Explicitly set fields override the loom's. See the [Execution Settings guide](../../guides/execution-settings.md). |
 | `naming` | `NamingConfig` | no | `null` | Naming normalization cascaded to threads |
 | `audit_templates` | `dict[string, AuditTemplate]` | no | `null` | Named audit column templates cascaded to all threads in this weave. Thread-level definitions override weave-level definitions with the same name. A flat `dict[string, string]` shorthand is also accepted. See [Audit Templates guide](../../guides/audit-templates.md). |
 | `connections` | `dict[string, OneLakeConnection]` | no | `null` | Named connection definitions cascaded to threads. Thread-level connections with the same name override weave-level. See [Connections guide](../../guides/connections.md). |
@@ -297,12 +297,16 @@ variables:
 
 ## execution (ExecutionConfig)
 
-Cascades to all threads within the weave. Thread-level settings override these.
+Merges field-level with the loom's block — an explicitly set weave field
+wins, otherwise the loom's value applies. Thread-level `execution:`
+blocks are declared but not applied. See the
+[Execution Settings guide](../../guides/execution-settings.md).
 
 | Key | Type | Required | Default | Description |
 |-----|------|----------|---------|-------------|
 | `log_level` | `string` | no | `"standard"` | Logging verbosity: `"minimal"`, `"standard"`, `"verbose"`, `"debug"` |
 | `trace` | `bool` | no | `true` | Collect execution spans for telemetry |
+| `max_parallel_threads` | `int` | no | unset | Cap on concurrently executing threads per group (`>= 1`); unset means unbounded |
 
 ---
 

--- a/docs/schema/loom.json
+++ b/docs/schema/loom.json
@@ -238,7 +238,7 @@
       "type": "object"
     },
     "ExecutionConfig": {
-      "description": "Runtime execution settings that cascade through loom/weave/thread.\n\nAttributes:\n    log_level: Logging verbosity for execution output.\n    trace: Whether to collect execution spans for telemetry.",
+      "description": "Runtime execution settings declared on the top-level ``execution:`` block.\n\nCanonical declaration sites are the top-level ``execution:`` field on\nLoom and Weave. The effective settings for a weave execution merge\nfield-level (see :func:`resolve_effective_execution`) rather than\nreplacing whole-block. Thread-scoped execution settings are declared\nbut not applied in v1.x.\n\nAttributes:\n    log_level: Logging verbosity for execution output.\n    trace: Whether to collect execution spans for telemetry.\n    max_parallel_threads: Upper bound on concurrently executing\n        threads within a weave's parallel group. Unset means\n        unbounded (pool sized to the group).",
       "properties": {
         "log_level": {
           "$ref": "#/$defs/LogLevel",
@@ -250,6 +250,20 @@
           "description": "Whether to collect execution spans for telemetry.",
           "title": "Trace",
           "type": "boolean"
+        },
+        "max_parallel_threads": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum threads executing concurrently within a weave's parallel group. Unset means unbounded.",
+          "title": "Max Parallel Threads"
         }
       },
       "title": "ExecutionConfig",

--- a/docs/schema/thread.json
+++ b/docs/schema/thread.json
@@ -1348,7 +1348,7 @@
       "type": "object"
     },
     "ExecutionConfig": {
-      "description": "Runtime execution settings that cascade through loom/weave/thread.\n\nAttributes:\n    log_level: Logging verbosity for execution output.\n    trace: Whether to collect execution spans for telemetry.",
+      "description": "Runtime execution settings declared on the top-level ``execution:`` block.\n\nCanonical declaration sites are the top-level ``execution:`` field on\nLoom and Weave. The effective settings for a weave execution merge\nfield-level (see :func:`resolve_effective_execution`) rather than\nreplacing whole-block. Thread-scoped execution settings are declared\nbut not applied in v1.x.\n\nAttributes:\n    log_level: Logging verbosity for execution output.\n    trace: Whether to collect execution spans for telemetry.\n    max_parallel_threads: Upper bound on concurrently executing\n        threads within a weave's parallel group. Unset means\n        unbounded (pool sized to the group).",
       "properties": {
         "log_level": {
           "$ref": "#/$defs/LogLevel",
@@ -1360,6 +1360,20 @@
           "description": "Whether to collect execution spans for telemetry.",
           "title": "Trace",
           "type": "boolean"
+        },
+        "max_parallel_threads": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum threads executing concurrently within a weave's parallel group. Unset means unbounded.",
+          "title": "Max Parallel Threads"
         }
       },
       "title": "ExecutionConfig",

--- a/docs/schema/weave.json
+++ b/docs/schema/weave.json
@@ -238,7 +238,7 @@
       "type": "object"
     },
     "ExecutionConfig": {
-      "description": "Runtime execution settings that cascade through loom/weave/thread.\n\nAttributes:\n    log_level: Logging verbosity for execution output.\n    trace: Whether to collect execution spans for telemetry.",
+      "description": "Runtime execution settings declared on the top-level ``execution:`` block.\n\nCanonical declaration sites are the top-level ``execution:`` field on\nLoom and Weave. The effective settings for a weave execution merge\nfield-level (see :func:`resolve_effective_execution`) rather than\nreplacing whole-block. Thread-scoped execution settings are declared\nbut not applied in v1.x.\n\nAttributes:\n    log_level: Logging verbosity for execution output.\n    trace: Whether to collect execution spans for telemetry.\n    max_parallel_threads: Upper bound on concurrently executing\n        threads within a weave's parallel group. Unset means\n        unbounded (pool sized to the group).",
       "properties": {
         "log_level": {
           "$ref": "#/$defs/LogLevel",
@@ -250,6 +250,20 @@
           "description": "Whether to collect execution spans for telemetry.",
           "title": "Trace",
           "type": "boolean"
+        },
+        "max_parallel_threads": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum threads executing concurrently within a weave's parallel group. Unset means unbounded.",
+          "title": "Max Parallel Threads"
         }
       },
       "title": "ExecutionConfig",

--- a/docs/schema/weevr.json
+++ b/docs/schema/weevr.json
@@ -1349,7 +1349,7 @@
         "type": "object"
       },
       "ExecutionConfig": {
-        "description": "Runtime execution settings that cascade through loom/weave/thread.\n\nAttributes:\n    log_level: Logging verbosity for execution output.\n    trace: Whether to collect execution spans for telemetry.",
+        "description": "Runtime execution settings declared on the top-level ``execution:`` block.\n\nCanonical declaration sites are the top-level ``execution:`` field on\nLoom and Weave. The effective settings for a weave execution merge\nfield-level (see :func:`resolve_effective_execution`) rather than\nreplacing whole-block. Thread-scoped execution settings are declared\nbut not applied in v1.x.\n\nAttributes:\n    log_level: Logging verbosity for execution output.\n    trace: Whether to collect execution spans for telemetry.\n    max_parallel_threads: Upper bound on concurrently executing\n        threads within a weave's parallel group. Unset means\n        unbounded (pool sized to the group).",
         "properties": {
           "log_level": {
             "$ref": "#/$defs/LogLevel",
@@ -1361,6 +1361,20 @@
             "description": "Whether to collect execution spans for telemetry.",
             "title": "Trace",
             "type": "boolean"
+          },
+          "max_parallel_threads": {
+            "anyOf": [
+              {
+                "minimum": 1,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Maximum threads executing concurrently within a weave's parallel group. Unset means unbounded.",
+            "title": "Max Parallel Threads"
           }
         },
         "title": "ExecutionConfig",
@@ -5309,7 +5323,7 @@
         "type": "object"
       },
       "ExecutionConfig": {
-        "description": "Runtime execution settings that cascade through loom/weave/thread.\n\nAttributes:\n    log_level: Logging verbosity for execution output.\n    trace: Whether to collect execution spans for telemetry.",
+        "description": "Runtime execution settings declared on the top-level ``execution:`` block.\n\nCanonical declaration sites are the top-level ``execution:`` field on\nLoom and Weave. The effective settings for a weave execution merge\nfield-level (see :func:`resolve_effective_execution`) rather than\nreplacing whole-block. Thread-scoped execution settings are declared\nbut not applied in v1.x.\n\nAttributes:\n    log_level: Logging verbosity for execution output.\n    trace: Whether to collect execution spans for telemetry.\n    max_parallel_threads: Upper bound on concurrently executing\n        threads within a weave's parallel group. Unset means\n        unbounded (pool sized to the group).",
         "properties": {
           "log_level": {
             "$ref": "#/$defs/LogLevel",
@@ -5321,6 +5335,20 @@
             "description": "Whether to collect execution spans for telemetry.",
             "title": "Trace",
             "type": "boolean"
+          },
+          "max_parallel_threads": {
+            "anyOf": [
+              {
+                "minimum": 1,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Maximum threads executing concurrently within a weave's parallel group. Unset means unbounded.",
+            "title": "Max Parallel Threads"
           }
         },
         "title": "ExecutionConfig",
@@ -6809,7 +6837,7 @@
         "type": "object"
       },
       "ExecutionConfig": {
-        "description": "Runtime execution settings that cascade through loom/weave/thread.\n\nAttributes:\n    log_level: Logging verbosity for execution output.\n    trace: Whether to collect execution spans for telemetry.",
+        "description": "Runtime execution settings declared on the top-level ``execution:`` block.\n\nCanonical declaration sites are the top-level ``execution:`` field on\nLoom and Weave. The effective settings for a weave execution merge\nfield-level (see :func:`resolve_effective_execution`) rather than\nreplacing whole-block. Thread-scoped execution settings are declared\nbut not applied in v1.x.\n\nAttributes:\n    log_level: Logging verbosity for execution output.\n    trace: Whether to collect execution spans for telemetry.\n    max_parallel_threads: Upper bound on concurrently executing\n        threads within a weave's parallel group. Unset means\n        unbounded (pool sized to the group).",
         "properties": {
           "log_level": {
             "$ref": "#/$defs/LogLevel",
@@ -6821,6 +6849,20 @@
             "description": "Whether to collect execution spans for telemetry.",
             "title": "Trace",
             "type": "boolean"
+          },
+          "max_parallel_threads": {
+            "anyOf": [
+              {
+                "minimum": 1,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Maximum threads executing concurrently within a weave's parallel group. Unset means unbounded.",
+            "title": "Max Parallel Threads"
           }
         },
         "title": "ExecutionConfig",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,7 @@ nav:
       - Fabric Runtime: guides/fabric-runtime.md
       - Connections: guides/connections.md
       - Observability: guides/observability.md
+      - Execution Settings: guides/execution-settings.md
       - Engine Internals: guides/engine-internals.md
       - Config Resolution: guides/config-resolution.md
       - Telemetry Architecture: guides/telemetry-architecture.md

--- a/packages/weevr-core/src/weevr/config/validation.py
+++ b/packages/weevr-core/src/weevr/config/validation.py
@@ -20,6 +20,7 @@ from typing import Any
 from pydantic import BaseModel, Field, ValidationError
 
 from weevr.errors import ConfigSchemaError
+from weevr.model.execution import resolve_effective_execution
 from weevr.model.params import ParamsConfig
 from weevr.model.warp import WarpConfig
 
@@ -376,8 +377,6 @@ def collect_trace_composition_warnings(
     Returns:
         Warning strings, one per weave with an ineffective ``trace: true``.
     """
-    from weevr.model.execution import resolve_effective_execution
-
     if resolve_effective_execution(None, loom_execution).trace:
         return []
 

--- a/packages/weevr-core/src/weevr/config/validation.py
+++ b/packages/weevr-core/src/weevr/config/validation.py
@@ -310,3 +310,83 @@ def validate_resolve_lookups(
                 )
 
     return diagnostics
+
+
+def collect_execution_scope_warnings(
+    defaults_by_scope: list[tuple[str, dict[str, Any] | None]],
+    threads: list[dict[str, Any]],
+) -> list[str]:
+    """Collect warnings for execution settings that will not apply.
+
+    Thread-scoped ``execution:`` blocks are declared but uniformly not
+    applied in v1.x, whether authored on the thread or arrived via a
+    ``defaults.execution`` cascade. Warnings are deduplicated per origin:
+    one per scope whose ``defaults`` carries an ``execution`` block, and
+    one per thread that authored its own block.
+
+    Args:
+        defaults_by_scope: ``(scope label, defaults dict)`` pairs for each
+            enclosing scope (e.g. ``("loom 'nightly'", {...})``).
+        threads: Raw thread config dicts *before* the inheritance cascade,
+            so an ``execution`` key means the thread authored it.
+
+    Returns:
+        Warning strings, one per distinct origin.
+    """
+    warnings: list[str] = []
+
+    for scope_label, defaults in defaults_by_scope:
+        if defaults and isinstance(defaults.get("execution"), dict):
+            fields = ", ".join(sorted(defaults["execution"]))
+            warnings.append(
+                f"WARN: {scope_label} declares defaults.execution ({fields}) — "
+                f"thread-scoped execution settings are not applied. Move them "
+                f"to the top-level execution block on the loom or weave."
+            )
+
+    for i, thread in enumerate(threads):
+        execution = thread.get("execution")
+        if isinstance(execution, dict) and execution:
+            name = thread.get("name") or f"#{i}"
+            fields = ", ".join(sorted(execution))
+            warnings.append(
+                f"WARN: thread '{name}' declares an execution block ({fields}) — "
+                f"thread-scoped execution settings are not applied. Move them "
+                f"to the top-level execution block on the loom or weave."
+            )
+
+    return warnings
+
+
+def collect_trace_composition_warnings(
+    loom_execution: Any,
+    weave_executions: dict[str, Any],
+) -> list[str]:
+    """Warn when a weave's explicit ``trace: true`` cannot re-enable tracing.
+
+    The root span collector exists (or not) for the whole run: under a loom
+    whose effective ``trace`` is false there is nothing for a weave to
+    attach to, so an explicit ``trace: true`` on the weave is a no-op.
+
+    Args:
+        loom_execution: The loom's hydrated ``ExecutionConfig`` (or None).
+        weave_executions: Hydrated weave ``ExecutionConfig`` (or None) by
+            weave name.
+
+    Returns:
+        Warning strings, one per weave with an ineffective ``trace: true``.
+    """
+    from weevr.model.execution import resolve_effective_execution
+
+    if resolve_effective_execution(None, loom_execution).trace:
+        return []
+
+    warnings: list[str] = []
+    for weave_name, execution in weave_executions.items():
+        if execution is not None and "trace" in execution.model_fields_set and execution.trace:
+            warnings.append(
+                f"WARN: weave '{weave_name}' sets trace: true, but the loom's "
+                f"effective trace is false — tracing cannot be re-enabled "
+                f"per-weave and no telemetry will be collected."
+            )
+    return warnings

--- a/packages/weevr-core/src/weevr/model/execution.py
+++ b/packages/weevr-core/src/weevr/model/execution.py
@@ -21,11 +21,20 @@ class LogLevel(StrEnum):
 
 
 class ExecutionConfig(FrozenBase):
-    """Runtime execution settings that cascade through loom/weave/thread.
+    """Runtime execution settings declared on the top-level ``execution:`` block.
+
+    Canonical declaration sites are the top-level ``execution:`` field on
+    Loom and Weave. The effective settings for a weave execution merge
+    field-level (see :func:`resolve_effective_execution`) rather than
+    replacing whole-block. Thread-scoped execution settings are declared
+    but not applied in v1.x.
 
     Attributes:
         log_level: Logging verbosity for execution output.
         trace: Whether to collect execution spans for telemetry.
+        max_parallel_threads: Upper bound on concurrently executing
+            threads within a weave's parallel group. Unset means
+            unbounded (pool sized to the group).
     """
 
     log_level: LogLevel = Field(
@@ -36,3 +45,41 @@ class ExecutionConfig(FrozenBase):
         default=True,
         description="Whether to collect execution spans for telemetry.",
     )
+    max_parallel_threads: int | None = Field(
+        default=None,
+        ge=1,
+        description=(
+            "Maximum threads executing concurrently within a weave's "
+            "parallel group. Unset means unbounded."
+        ),
+    )
+
+
+def resolve_effective_execution(
+    parent: ExecutionConfig | None,
+    child: ExecutionConfig | None,
+) -> ExecutionConfig:
+    """Compute the effective execution settings for a child scope.
+
+    Merges field-level: a field the child explicitly set wins, otherwise
+    a field the parent explicitly set, otherwise the field default.
+    Explicitness is read from Pydantic's ``model_fields_set`` — required
+    because ``log_level`` and ``trace`` have non-None defaults, so
+    explicit-vs-default is only knowable on hydrated instances.
+
+    Args:
+        parent: The enclosing scope's ``execution:`` block (e.g. Loom),
+            or None when absent.
+        child: The narrower scope's ``execution:`` block (e.g. Weave),
+            or None when absent.
+
+    Returns:
+        A new ExecutionConfig holding the effective field values.
+    """
+    values: dict[str, object] = {}
+    for source in (parent, child):
+        if source is None:
+            continue
+        for field_name in source.model_fields_set:
+            values[field_name] = getattr(source, field_name)
+    return ExecutionConfig(**values)  # type: ignore[arg-type]

--- a/packages/weevr/src/weevr/context.py
+++ b/packages/weevr/src/weevr/context.py
@@ -28,7 +28,11 @@ from weevr.config.resolver import (
     resolve_variables,
     validate_params,
 )
-from weevr.config.validation import validate_schema
+from weevr.config.validation import (
+    collect_execution_scope_warnings,
+    collect_trace_composition_warnings,
+    validate_schema,
+)
 from weevr.delta import is_table_alias
 from weevr.engine.executor import execute_thread
 from weevr.engine.planner import build_plan
@@ -877,7 +881,12 @@ class Context:
         # Step 7: Resolve child references
         resolved_with_refs = resolve_references(resolved, config_type, project_root, self._params)
 
-        # Step 8: Apply inheritance cascade
+        # Step 8: Apply inheritance cascade. Execution-scope warnings are
+        # collected first, against the PRE-cascade thread dicts — after the
+        # cascade an authored execution block is indistinguishable from one
+        # injected by defaults.execution.
+        execution_warnings = self._collect_execution_warnings(config_type, resolved_with_refs)
+
         if config_type == "loom" and "_resolved_weaves" in resolved_with_refs:
             loom_defaults = resolved_with_refs.get("defaults")
             loom_audit_templates = resolved_with_refs.get("audit_templates")
@@ -981,6 +990,19 @@ class Context:
                 )
                 threads[weave_name] = thread_map
 
+        # Trace composition needs hydrated models (model_fields_set): a
+        # weave's explicit trace: true under a traceless loom is a no-op.
+        if config_type == "loom" and isinstance(model, Loom):
+            execution_warnings.extend(
+                collect_trace_composition_warnings(
+                    model.execution,
+                    {name: w.execution for name, w in weaves.items()},
+                )
+            )
+
+        for warning in execution_warnings:
+            logger.warning(warning)
+
         return _ResolvedConfig(
             config_type=config_type,
             config_name=config_name,
@@ -988,6 +1010,28 @@ class Context:
             weaves=weaves,
             threads=threads,
         )
+
+    @staticmethod
+    def _collect_execution_warnings(config_type: str, resolved: dict[str, Any]) -> list[str]:
+        """Gather thread-scope execution warnings from pre-cascade dicts."""
+        defaults_by_scope: list[tuple[str, dict[str, Any] | None]] = []
+        pre_cascade_threads: list[dict[str, Any]] = []
+
+        if config_type == "loom":
+            loom_label = f"loom '{resolved.get('name') or '(unnamed)'}'"
+            defaults_by_scope.append((loom_label, resolved.get("defaults")))
+            for i, weave in enumerate(resolved.get("_resolved_weaves", [])):
+                weave_label = f"weave '{weave.get('name') or f'#{i}'}'"
+                defaults_by_scope.append((weave_label, weave.get("defaults")))
+                pre_cascade_threads.extend(weave.get("_resolved_threads", []))
+        elif config_type == "weave":
+            weave_label = f"weave '{resolved.get('name') or '(unnamed)'}'"
+            defaults_by_scope.append((weave_label, resolved.get("defaults")))
+            pre_cascade_threads.extend(resolved.get("_resolved_threads", []))
+        else:  # standalone thread
+            pre_cascade_threads.append(resolved)
+
+        return collect_execution_scope_warnings(defaults_by_scope, pre_cascade_threads)
 
     @staticmethod
     def _hydrate_model(

--- a/packages/weevr/src/weevr/context.py
+++ b/packages/weevr/src/weevr/context.py
@@ -391,7 +391,13 @@ class Context:
             from weevr.telemetry.collector import SpanCollector
             from weevr.telemetry.span import generate_trace_id
 
-            weave_collector = SpanCollector(generate_trace_id())
+            # The weave's effective trace gates collector creation for
+            # standalone weave runs. (Standalone thread runs always trace —
+            # thread-scoped execution settings are unapplied in v1.x.)
+            standalone_execution = resolve_effective_execution(None, model.execution)
+            weave_collector = (
+                SpanCollector(generate_trace_id()) if standalone_execution.trace else None
+            )
 
             engine_result = execute_weave(
                 self._spark,
@@ -406,7 +412,7 @@ class Context:
                 variables=dict(model.variables) if model.variables else None,
                 column_set_defs=dict(model.column_sets) if model.column_sets else None,
                 connections=dict(model.connections) if model.connections else None,
-                execution=resolve_effective_execution(None, model.execution),
+                execution=standalone_execution,
             )
             if engine_result.status not in ("success", "failure", "partial"):
                 raise ExecutionError(f"Unexpected weave execution status: '{engine_result.status}'")

--- a/packages/weevr/src/weevr/context.py
+++ b/packages/weevr/src/weevr/context.py
@@ -40,7 +40,7 @@ from weevr.errors import (
     ModelValidationError,
     VariableResolutionError,
 )
-from weevr.model.execution import LogLevel
+from weevr.model.execution import LogLevel, resolve_effective_execution
 from weevr.model.loom import Loom
 from weevr.model.thread import Thread
 from weevr.model.weave import ConditionSpec, Weave
@@ -374,6 +374,7 @@ class Context:
                 variables=dict(model.variables) if model.variables else None,
                 column_set_defs=dict(model.column_sets) if model.column_sets else None,
                 connections=dict(model.connections) if model.connections else None,
+                execution=resolve_effective_execution(None, model.execution),
             )
             if engine_result.status not in ("success", "failure", "partial"):
                 raise ExecutionError(f"Unexpected weave execution status: '{engine_result.status}'")

--- a/packages/weevr/src/weevr/context.py
+++ b/packages/weevr/src/weevr/context.py
@@ -90,7 +90,7 @@ class Context:
         project: str | Path,
         *,
         params: dict[str, Any] | None = None,
-        log_level: str = "standard",
+        log_level: str | None = None,
         workspace: str | None = None,
         lakehouse: str | None = None,
     ) -> None:
@@ -98,11 +98,20 @@ class Context:
         if not isinstance(spark, SparkSession):
             raise TypeError(f"'spark' must be a SparkSession, got {type(spark).__name__}")
 
-        try:
-            resolved_level = LogLevel(log_level)
-        except ValueError:
-            valid = ", ".join(f"'{v.value}'" for v in LogLevel)
-            raise ValueError(f"Invalid log_level '{log_level}'. Must be one of: {valid}") from None
+        # An explicit argument is a runtime override that beats YAML
+        # execution blocks. When omitted, STANDARD applies provisionally
+        # and the effective YAML level (if any) takes over at run()/load().
+        self._explicit_log_level = log_level is not None
+        if log_level is None:
+            resolved_level = LogLevel.STANDARD
+        else:
+            try:
+                resolved_level = LogLevel(log_level)
+            except ValueError:
+                valid = ", ".join(f"'{v.value}'" for v in LogLevel)
+                raise ValueError(
+                    f"Invalid log_level '{log_level}'. Must be one of: {valid}"
+                ) from None
 
         self._spark = spark
         self._params = params
@@ -211,6 +220,7 @@ class Context:
             A :class:`LoadedConfig` wrapping the hydrated model.
         """
         resolved = self._load_resolved(path)
+        self._apply_effective_log_level(resolved)
         return LoadedConfig(
             model=resolved.model,
             config_type=resolved.config_type,
@@ -218,6 +228,24 @@ class Context:
             threads=resolved.threads or None,
             weaves=resolved.weaves or None,
         )
+
+    def _apply_effective_log_level(self, resolved: _ResolvedConfig) -> None:
+        """Apply the effective YAML log level.
+
+        No-op when an explicit ``Context(log_level=...)`` argument is in
+        force. The source is the top-level ``execution:`` block on a Loom or
+        Weave config. Thread-scoped execution settings are not applied
+        (uniformly unapplied in v1.x).
+        """
+        if self._explicit_log_level:
+            return
+        block = None
+        if resolved.config_type in ("loom", "weave"):
+            block = getattr(resolved.model, "execution", None)
+        effective = resolve_effective_execution(None, block).log_level
+        if effective != self._log_level:
+            self._log_level = effective
+            configure_logging(effective)
 
     def run(
         self,
@@ -256,6 +284,10 @@ class Context:
 
         start_ns = time.monotonic_ns()
         resolved = self._load_resolved(path)
+
+        # Single application point for the effective YAML log level —
+        # before mode dispatch, so all four modes behave identically.
+        self._apply_effective_log_level(resolved)
 
         try:
             if resolved_mode is ExecutionMode.EXECUTE:
@@ -419,8 +451,16 @@ class Context:
                 warnings=all_warnings,
             )
 
+        # Baseline for per-weave log-level overrides; None suppresses YAML
+        # levels entirely (explicit Context argument in force).
+        baseline_level = None if self._explicit_log_level else self._log_level
         engine_result = execute_loom(
-            self._spark, model, filtered_weaves, filtered_threads, params=self._params
+            self._spark,
+            model,
+            filtered_weaves,
+            filtered_threads,
+            params=self._params,
+            log_level=baseline_level,
         )
         result = RunResult(
             status=engine_result.status,

--- a/packages/weevr/src/weevr/engine/runner.py
+++ b/packages/weevr/src/weevr/engine/runner.py
@@ -588,12 +588,20 @@ def execute_loom(
     start_ns = time.monotonic_ns()
     weave_results: list[WeaveResult] = []
 
-    # Create root collector and loom span
-    trace_id = generate_trace_id()
-    collector = SpanCollector(trace_id)
+    # Create root collector and loom span — unless the loom's effective
+    # trace is off, in which case the whole run executes collector-free
+    # and LoomResult.telemetry is None. A weave cannot re-enable tracing
+    # under a traceless loom (no root collector to attach to).
+    loom_trace = resolve_effective_execution(None, loom.execution).trace
     loom_span_label = loom.qualified_key or loom.name
-    loom_span_builder = collector.start_span(f"loom:{loom_span_label}")
-    loom_span_id = loom_span_builder.span_id
+    collector: SpanCollector | None = None
+    loom_span_builder = None
+    loom_span_id = None
+    if loom_trace:
+        trace_id = generate_trace_id()
+        collector = SpanCollector(trace_id)
+        loom_span_builder = collector.start_span(f"loom:{loom_span_label}")
+        loom_span_id = loom_span_builder.span_id
 
     logger.debug("Starting loom '%s' — %d weaves", loom.name, len(loom.weaves))
 
@@ -708,7 +716,9 @@ def execute_loom(
                     spark,
                     plan,
                     weave_threads,
-                    collector=collector,
+                    # A weave with effective trace: false runs collector-free;
+                    # its nodes are absent from the telemetry tree.
+                    collector=collector if effective_execution.trace else None,
                     parent_span_id=loom_span_id,
                     thread_conditions=thread_conditions if thread_conditions else None,
                     params=params,
@@ -754,16 +764,17 @@ def execute_loom(
         raise
     finally:
         cleanup_lookups(loom_cached_lookup_dfs)
-        if _loom_raised:
-            _loom_span_status = SpanStatus.ERROR
-        else:
-            _loom_statuses = {r.status for r in weave_results}
-            if _loom_statuses <= {"success", "skipped"}:
-                _loom_span_status = SpanStatus.OK
-            else:
+        if loom_span_builder is not None and collector is not None:
+            if _loom_raised:
                 _loom_span_status = SpanStatus.ERROR
-        loom_span = loom_span_builder.finish(status=_loom_span_status)
-        collector.add_span(loom_span)
+            else:
+                _loom_statuses = {r.status for r in weave_results}
+                if _loom_statuses <= {"success", "skipped"}:
+                    _loom_span_status = SpanStatus.OK
+                else:
+                    _loom_span_status = SpanStatus.ERROR
+            loom_span = loom_span_builder.finish(status=_loom_span_status)
+            collector.add_span(loom_span)
 
     duration_ms = (time.monotonic_ns() - start_ns) // 1_000_000
 
@@ -776,10 +787,12 @@ def execute_loom(
     else:
         loom_status = "failure"
 
-    # Build loom telemetry
-    loom_telemetry = _build_loom_telemetry(
-        loom_span_label, weave_results, collector, resolved_params=params
-    )
+    # Build loom telemetry (None for a traceless run)
+    loom_telemetry = None
+    if collector is not None:
+        loom_telemetry = _build_loom_telemetry(
+            loom_span_label, weave_results, collector, resolved_params=params
+        )
 
     logger.debug(
         "Loom '%s' complete — status=%s, duration=%dms",

--- a/packages/weevr/src/weevr/engine/runner.py
+++ b/packages/weevr/src/weevr/engine/runner.py
@@ -24,6 +24,7 @@ from weevr.engine.variables import VariableContext
 from weevr.errors.exceptions import HookError
 from weevr.model.column_set import ColumnSet
 from weevr.model.connection import OneLakeConnection
+from weevr.model.execution import ExecutionConfig, resolve_effective_execution
 from weevr.model.hooks import HookStep
 from weevr.model.lookup import Lookup
 from weevr.model.loom import Loom
@@ -86,6 +87,7 @@ def execute_weave(
     column_set_defs: dict[str, ColumnSet] | None = None,
     pre_cached_lookups: dict[str, Any] | None = None,
     connections: dict[str, OneLakeConnection] | None = None,
+    execution: ExecutionConfig | None = None,
 ) -> WeaveResult:
     """Execute threads according to the execution plan.
 
@@ -133,6 +135,10 @@ def execute_weave(
         connections: Merged loom + weave connections forwarded to
             ``materialize_column_sets`` so connection-backed column sets can
             resolve their lakehouse target.
+        execution: Effective execution settings for this weave (already
+            merged by the caller — see ``resolve_effective_execution``).
+            ``max_parallel_threads`` caps each group's pool; unset means
+            the pool is sized to the group.
 
     Returns:
         :class:`~weevr.engine.result.WeaveResult` with aggregate status and
@@ -145,6 +151,8 @@ def execute_weave(
     cache = CacheManager(plan.cache_targets, plan.dependents)
     aborted = False
     _weave_raised = False
+    max_parallel_threads = execution.max_parallel_threads if execution is not None else None
+    group_thread_counts: list[int] = []
 
     # Create weave span if collector is active
     weave_span_builder = None
@@ -292,7 +300,16 @@ def execute_weave(
             # Per-thread collectors for isolation during concurrent execution
             thread_collectors: dict[str, SpanCollector] = {}
 
-            with ThreadPoolExecutor(max_workers=len(to_run)) as executor:
+            # Cap the group's pool when an effective max_parallel_threads is
+            # set; groups still execute sequentially either way.
+            group_size = len(to_run)
+            if max_parallel_threads is not None:
+                pool_size = min(max_parallel_threads, group_size)
+            else:
+                pool_size = group_size
+            group_thread_counts.append(group_size)
+
+            with ThreadPoolExecutor(max_workers=pool_size) as executor:
                 for name in to_run:
                     thread_states[name] = "running"
                     if collector is not None:
@@ -434,6 +451,15 @@ def execute_weave(
             )
         cleanup_lookups(weave_owned)
         if weave_span_builder is not None and collector is not None:
+            if max_parallel_threads is not None:
+                weave_span_builder.set_attribute(
+                    "execution.max_parallel_threads", max_parallel_threads
+                )
+            if group_thread_counts:
+                weave_span_builder.set_attribute(
+                    "execution.group_thread_counts",
+                    ",".join(str(c) for c in group_thread_counts),
+                )
             if _weave_raised:
                 _span_status = SpanStatus.ERROR
             else:
@@ -659,6 +685,10 @@ def execute_loom(
                 loom_vars_dict, weave_vars_dict, "variable", "loom", "weave"
             )
 
+            # Effective execution settings for this weave: field-level merge
+            # of the loom and weave top-level execution blocks.
+            effective_execution = resolve_effective_execution(loom.execution, weave.execution)
+
             result = execute_weave(
                 spark,
                 plan,
@@ -677,6 +707,7 @@ def execute_loom(
                 column_set_defs=merged_column_set_defs,
                 pre_cached_lookups=loom_cached_lookup_dfs or None,
                 connections=merged_connections or None,
+                execution=effective_execution,
             )
             weave_results.append(result)
 

--- a/packages/weevr/src/weevr/engine/runner.py
+++ b/packages/weevr/src/weevr/engine/runner.py
@@ -24,7 +24,7 @@ from weevr.engine.variables import VariableContext
 from weevr.errors.exceptions import HookError
 from weevr.model.column_set import ColumnSet
 from weevr.model.connection import OneLakeConnection
-from weevr.model.execution import ExecutionConfig, resolve_effective_execution
+from weevr.model.execution import ExecutionConfig, LogLevel, resolve_effective_execution
 from weevr.model.hooks import HookStep
 from weevr.model.lookup import Lookup
 from weevr.model.loom import Loom
@@ -32,6 +32,7 @@ from weevr.model.thread import Thread
 from weevr.model.variable import VariableSpec
 from weevr.model.weave import ConditionSpec, Weave
 from weevr.telemetry.collector import SpanCollector
+from weevr.telemetry.logging import configure_logging
 from weevr.telemetry.results import (
     ColumnSetResult,
     LoomTelemetry,
@@ -559,6 +560,7 @@ def execute_loom(
     weaves: dict[str, Weave],
     threads: dict[str, dict[str, Thread]],
     params: dict[str, Any] | None = None,
+    log_level: LogLevel | None = None,
 ) -> LoomResult:
     """Execute weaves sequentially in declared order.
 
@@ -573,6 +575,11 @@ def execute_loom(
         weaves: Mapping of weave name to :class:`~weevr.model.weave.Weave` config.
         threads: Nested mapping of ``weave_name → thread_name → Thread`` config.
         params: Parameters for condition evaluation at weave and thread levels.
+        log_level: The run's baseline log level. When set, a weave whose
+            effective level differs is applied at that weave's start and
+            restored afterward (weaves execute sequentially, so this is
+            race-free). When None, YAML log levels are suppressed — the
+            caller gave an explicit runtime override.
 
     Returns:
         :class:`~weevr.engine.result.LoomResult` with aggregate status and
@@ -689,26 +696,37 @@ def execute_loom(
             # of the loom and weave top-level execution blocks.
             effective_execution = resolve_effective_execution(loom.execution, weave.execution)
 
-            result = execute_weave(
-                spark,
-                plan,
-                weave_threads,
-                collector=collector,
-                parent_span_id=loom_span_id,
-                thread_conditions=thread_conditions if thread_conditions else None,
-                params=params,
-                weave_span_label=weave.qualified_key or weave_name,
-                pre_steps=list(weave.pre_steps) if weave.pre_steps else None,
-                post_steps=list(weave.post_steps) if weave.post_steps else None,
-                lookups=weave_lookups,
-                variables=merged_variables,
-                loom_name=loom.name,
-                weave_name=weave_name,
-                column_set_defs=merged_column_set_defs,
-                pre_cached_lookups=loom_cached_lookup_dfs or None,
-                connections=merged_connections or None,
-                execution=effective_execution,
-            )
+            # Per-weave log-level override, restored in the finally so the
+            # baseline survives weave failures. Suppressed entirely when the
+            # caller passed no baseline (explicit runtime override in force).
+            weave_level = effective_execution.log_level
+            override_level = log_level is not None and weave_level != log_level
+            if override_level:
+                configure_logging(weave_level)
+            try:
+                result = execute_weave(
+                    spark,
+                    plan,
+                    weave_threads,
+                    collector=collector,
+                    parent_span_id=loom_span_id,
+                    thread_conditions=thread_conditions if thread_conditions else None,
+                    params=params,
+                    weave_span_label=weave.qualified_key or weave_name,
+                    pre_steps=list(weave.pre_steps) if weave.pre_steps else None,
+                    post_steps=list(weave.post_steps) if weave.post_steps else None,
+                    lookups=weave_lookups,
+                    variables=merged_variables,
+                    loom_name=loom.name,
+                    weave_name=weave_name,
+                    column_set_defs=merged_column_set_defs,
+                    pre_cached_lookups=loom_cached_lookup_dfs or None,
+                    connections=merged_connections or None,
+                    execution=effective_execution,
+                )
+            finally:
+                if override_level and log_level is not None:
+                    configure_logging(log_level)
             weave_results.append(result)
 
             if result.status == "failure":

--- a/packages/weevr/src/weevr/engine/runner.py
+++ b/packages/weevr/src/weevr/engine/runner.py
@@ -457,6 +457,8 @@ def execute_weave(
                     "execution.max_parallel_threads", max_parallel_threads
                 )
             if group_thread_counts:
+                # Comma-joined string ("3,2") — span attributes only take
+                # scalars, so consumers must split before parsing.
                 weave_span_builder.set_attribute(
                     "execution.group_thread_counts",
                     ",".join(str(c) for c in group_thread_counts),

--- a/tests/weevr/config/test_execution_scope_validation.py
+++ b/tests/weevr/config/test_execution_scope_validation.py
@@ -1,0 +1,102 @@
+"""Tests for execution-scope warning collection.
+
+Thread-scoped ``execution:`` blocks (authored or arrived via
+``defaults.execution``) are declared but not applied in v1.x; a weave's
+explicit ``trace: true`` under an effectively-traceless loom cannot
+re-enable tracing. Both must warn, once per distinct origin.
+"""
+
+from weevr.config.validation import (
+    collect_execution_scope_warnings,
+    collect_trace_composition_warnings,
+)
+from weevr.model.execution import ExecutionConfig
+
+
+class TestCollectExecutionScopeWarnings:
+    def test_clean_configs_produce_no_warnings(self) -> None:
+        warnings = collect_execution_scope_warnings(
+            defaults_by_scope=[("loom 'nightly'", {"naming": {}}), ("weave 'facts'", None)],
+            threads=[{"name": "t1"}, {"name": "t2"}],
+        )
+        assert warnings == []
+
+    def test_defaults_execution_warns_once_regardless_of_thread_count(self) -> None:
+        warnings = collect_execution_scope_warnings(
+            defaults_by_scope=[("loom 'nightly'", {"execution": {"log_level": "debug"}})],
+            threads=[{"name": f"t{i}"} for i in range(40)],
+        )
+        assert len(warnings) == 1
+        assert "defaults.execution" in warnings[0]
+        assert "loom 'nightly'" in warnings[0]
+        assert "log_level" in warnings[0]
+
+    def test_authored_thread_block_warns_per_thread(self) -> None:
+        warnings = collect_execution_scope_warnings(
+            defaults_by_scope=[("loom 'nightly'", None)],
+            threads=[
+                {"name": "t1", "execution": {"trace": False}},
+                {"name": "t2"},
+                {"name": "t3", "execution": {"log_level": "minimal"}},
+            ],
+        )
+        assert len(warnings) == 2
+        assert any("t1" in w and "trace" in w for w in warnings)
+        assert any("t3" in w and "log_level" in w for w in warnings)
+
+    def test_both_origins_warn_independently(self) -> None:
+        """Authored blocks get the authored label; the defaults warning
+        still fires once."""
+        warnings = collect_execution_scope_warnings(
+            defaults_by_scope=[("weave 'facts'", {"execution": {"log_level": "verbose"}})],
+            threads=[
+                {"name": "t1", "execution": {"trace": False}},
+                {"name": "t2"},
+            ],
+        )
+        assert len(warnings) == 2
+        defaults_warnings = [w for w in warnings if "defaults.execution" in w]
+        authored_warnings = [w for w in warnings if "t1" in w]
+        assert len(defaults_warnings) == 1
+        assert len(authored_warnings) == 1
+
+    def test_warning_points_at_top_level_block(self) -> None:
+        warnings = collect_execution_scope_warnings(
+            defaults_by_scope=[("loom 'nightly'", {"execution": {"log_level": "debug"}})],
+            threads=[],
+        )
+        assert "top-level" in warnings[0]
+
+
+class TestCollectTraceCompositionWarnings:
+    def test_weave_trace_true_under_traceless_loom_warns(self) -> None:
+        warnings = collect_trace_composition_warnings(
+            loom_execution=ExecutionConfig(trace=False),
+            weave_executions={"facts": ExecutionConfig(trace=True)},
+        )
+        assert len(warnings) == 1
+        assert "facts" in warnings[0]
+        assert "trace" in warnings[0]
+
+    def test_implicit_weave_trace_does_not_warn(self) -> None:
+        """A weave that never set trace is not warned — only explicit
+        trace: true is a no-op worth flagging."""
+        warnings = collect_trace_composition_warnings(
+            loom_execution=ExecutionConfig(trace=False),
+            weave_executions={"facts": ExecutionConfig(log_level="verbose")},  # type: ignore[arg-type]
+        )
+        assert warnings == []
+
+    def test_tracing_loom_produces_no_warnings(self) -> None:
+        warnings = collect_trace_composition_warnings(
+            loom_execution=None,
+            weave_executions={"facts": ExecutionConfig(trace=True)},
+        )
+        assert warnings == []
+
+    def test_weave_without_block_does_not_warn(self) -> None:
+        warnings = collect_trace_composition_warnings(
+            loom_execution=ExecutionConfig(trace=False),
+            weave_executions={"facts": None},
+        )
+        assert warnings == []

--- a/tests/weevr/engine/test_runner.py
+++ b/tests/weevr/engine/test_runner.py
@@ -660,6 +660,95 @@ class TestLoomLogLevelOverride:
 
 
 # ---------------------------------------------------------------------------
+# Trace gating
+# ---------------------------------------------------------------------------
+
+
+class TestTraceGating:
+    def _loom_fixtures(
+        self,
+        loom_execution: dict | None = None,
+        weave_execution: dict | None = None,
+    ):
+        loom_data: dict[str, Any] = {
+            "name": "nightly",
+            "config_version": "1.0",
+            "weaves": ["w1"],
+        }
+        if loom_execution is not None:
+            loom_data["execution"] = loom_execution
+        loom = Loom.model_validate(loom_data)
+        weave_data: dict[str, Any] = {
+            "config_version": "1.0",
+            "name": "w1",
+            "threads": ["A"],
+        }
+        if weave_execution is not None:
+            weave_data["execution"] = weave_execution
+        weaves = {"w1": Weave.model_validate(weave_data)}
+        threads = {"w1": {"A": _make_thread("A")}}
+        return loom, weaves, threads
+
+    @patch("weevr.engine.runner.execute_thread")
+    def test_loom_trace_false_yields_no_telemetry(self, mock_exec):
+        """Effective trace: false at loom scope → no collector, telemetry None."""
+        mock_exec.side_effect = lambda spark, thread, **kwargs: _make_result(thread.name)
+        loom, weaves, threads = self._loom_fixtures(loom_execution={"trace": False})
+
+        result = execute_loom(_MOCK_SPARK, loom, weaves, threads)
+
+        assert result.status == "success"
+        assert len(result.weave_results) == 1
+        assert result.weave_results[0].status == "success"
+        assert result.telemetry is None
+        assert result.weave_results[0].telemetry is None
+
+    @patch("weevr.engine.runner.execute_thread")
+    def test_loom_trace_default_keeps_telemetry(self, mock_exec):
+        """Default (trace unset) → telemetry populated as today."""
+        mock_exec.side_effect = lambda spark, thread, **kwargs: _make_result(thread.name)
+        loom, weaves, threads = self._loom_fixtures()
+
+        result = execute_loom(_MOCK_SPARK, loom, weaves, threads)
+
+        assert result.telemetry is not None
+        assert result.weave_results[0].telemetry is not None
+
+    @patch("weevr.engine.runner.execute_thread")
+    def test_weave_trace_false_under_tracing_loom(self, mock_exec):
+        """Weave-level trace: false narrows: that weave's nodes are absent
+        while loom telemetry remains."""
+        mock_exec.side_effect = lambda spark, thread, **kwargs: _make_result(thread.name)
+        loom, weaves, threads = self._loom_fixtures(weave_execution={"trace": False})
+
+        result = execute_loom(_MOCK_SPARK, loom, weaves, threads)
+
+        assert result.status == "success"
+        assert result.telemetry is not None
+        assert result.weave_results[0].telemetry is None
+        assert "w1" not in result.telemetry.weave_telemetry
+
+    @patch("weevr.engine.runner.execute_thread")
+    def test_loom_trace_false_still_runs_hooks(self, mock_exec):
+        """A traceless loom still executes pre/post hook steps."""
+        mock_exec.side_effect = lambda spark, thread, **kwargs: _make_result(thread.name)
+        loom = Loom.model_validate(
+            {
+                "name": "nightly",
+                "config_version": "1.0",
+                "weaves": ["w1"],
+                "execution": {"trace": False},
+                "pre_steps": [{"type": "log_message", "message": "starting"}],
+            }
+        )
+        _, weaves, threads = self._loom_fixtures()
+
+        result = execute_loom(_MOCK_SPARK, loom, weaves, threads)
+
+        assert result.status == "success"
+
+
+# ---------------------------------------------------------------------------
 # Telemetry tests — weave and loom
 # ---------------------------------------------------------------------------
 

--- a/tests/weevr/engine/test_runner.py
+++ b/tests/weevr/engine/test_runner.py
@@ -582,6 +582,84 @@ class TestParallelismCap:
 
 
 # ---------------------------------------------------------------------------
+# Per-weave log-level apply/restore during loom runs
+# ---------------------------------------------------------------------------
+
+
+class TestLoomLogLevelOverride:
+    def _loom_fixtures(self, weave_execution: dict | None, thread_fails: bool = False):
+        loom = Loom.model_validate({"name": "nightly", "config_version": "1.0", "weaves": ["w1"]})
+        weave_data: dict[str, Any] = {
+            "config_version": "1.0",
+            "name": "w1",
+            "threads": ["A"],
+        }
+        if weave_execution is not None:
+            weave_data["execution"] = weave_execution
+        weaves = {"w1": Weave.model_validate(weave_data)}
+        threads = {"w1": {"A": _make_thread("A")}}
+        return loom, weaves, threads
+
+    @patch("weevr.engine.runner.configure_logging")
+    @patch("weevr.engine.runner.execute_thread")
+    def test_weave_level_applied_and_restored(self, mock_exec, mock_log):
+        """A weave whose effective level differs from the baseline is
+        applied at weave start and restored after."""
+        from weevr.model.execution import LogLevel
+
+        mock_exec.side_effect = lambda spark, thread, **kwargs: _make_result(thread.name)
+        loom, weaves, threads = self._loom_fixtures({"log_level": "debug"})
+
+        execute_loom(_MOCK_SPARK, loom, weaves, threads, log_level=LogLevel.STANDARD)
+
+        applied = [c.args[0] for c in mock_log.call_args_list]
+        assert applied == [LogLevel.DEBUG, LogLevel.STANDARD]
+
+    @patch("weevr.engine.runner.configure_logging")
+    @patch("weevr.engine.runner.execute_thread")
+    def test_restored_when_weave_fails(self, mock_exec, mock_log):
+        """Restore runs on the failure path too (finally)."""
+        from weevr.model.execution import LogLevel
+
+        def _fail(spark, thread, **kwargs):
+            raise ExecutionError("boom", thread_name=thread.name)
+
+        mock_exec.side_effect = _fail
+        loom, weaves, threads = self._loom_fixtures({"log_level": "verbose"})
+
+        result = execute_loom(_MOCK_SPARK, loom, weaves, threads, log_level=LogLevel.STANDARD)
+
+        assert result.status == "failure"
+        applied = [c.args[0] for c in mock_log.call_args_list]
+        assert applied == [LogLevel.VERBOSE, LogLevel.STANDARD]
+
+    @patch("weevr.engine.runner.configure_logging")
+    @patch("weevr.engine.runner.execute_thread")
+    def test_no_switch_when_levels_match(self, mock_exec, mock_log):
+        """No reconfiguration churn when the weave matches the baseline."""
+        from weevr.model.execution import LogLevel
+
+        mock_exec.side_effect = lambda spark, thread, **kwargs: _make_result(thread.name)
+        loom, weaves, threads = self._loom_fixtures(None)
+
+        execute_loom(_MOCK_SPARK, loom, weaves, threads, log_level=LogLevel.STANDARD)
+
+        assert mock_log.call_args_list == []
+
+    @patch("weevr.engine.runner.configure_logging")
+    @patch("weevr.engine.runner.execute_thread")
+    def test_yaml_suppressed_when_baseline_absent(self, mock_exec, mock_log):
+        """log_level=None (explicit Context argument given) → YAML levels
+        never applied by the loom."""
+        mock_exec.side_effect = lambda spark, thread, **kwargs: _make_result(thread.name)
+        loom, weaves, threads = self._loom_fixtures({"log_level": "debug"})
+
+        execute_loom(_MOCK_SPARK, loom, weaves, threads)
+
+        assert mock_log.call_args_list == []
+
+
+# ---------------------------------------------------------------------------
 # Telemetry tests — weave and loom
 # ---------------------------------------------------------------------------
 

--- a/tests/weevr/engine/test_runner.py
+++ b/tests/weevr/engine/test_runner.py
@@ -4,6 +4,7 @@ All tests are fast (no Spark required). execute_thread is patched to return
 controlled ThreadResult objects, allowing pure logic testing.
 """
 
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -12,6 +13,7 @@ from weevr.engine.planner import build_plan
 from weevr.engine.result import ThreadResult, WeaveResult
 from weevr.engine.runner import execute_loom, execute_weave
 from weevr.errors.exceptions import ExecutionError
+from weevr.model.execution import ExecutionConfig
 from weevr.model.loom import Loom
 from weevr.model.thread import Thread
 from weevr.model.weave import ConditionSpec, ThreadEntry, Weave
@@ -442,6 +444,141 @@ class TestLoomRunner:
         result = execute_loom(_MOCK_SPARK, loom, weaves, threads)
         assert isinstance(result.duration_ms, int)
         assert result.duration_ms >= 0
+
+
+# ---------------------------------------------------------------------------
+# Parallelism cap
+# ---------------------------------------------------------------------------
+
+
+class TestParallelismCap:
+    def _tracking_side_effect(self):
+        """Return (side_effect, state) tracking peak concurrent executions."""
+        import threading
+        import time
+
+        state = {"active": 0, "peak": 0}
+        lock = threading.Lock()
+
+        def side_effect(spark, thread, **kwargs):
+            with lock:
+                state["active"] += 1
+                state["peak"] = max(state["peak"], state["active"])
+            time.sleep(0.05)
+            with lock:
+                state["active"] -= 1
+            return _make_result(thread.name)
+
+        return side_effect, state
+
+    @patch("weevr.engine.runner.execute_thread")
+    def test_cap_bounds_group_concurrency(self, mock_exec):
+        """Effective cap 3 over a 6-thread group → at most 3 in flight."""
+        side_effect, state = self._tracking_side_effect()
+        mock_exec.side_effect = side_effect
+        threads = {n: _make_thread(n) for n in "ABCDEF"}
+        plan = build_plan("capped", threads, _entries(*threads))
+
+        result = execute_weave(
+            _MOCK_SPARK,
+            plan,
+            threads,
+            execution=ExecutionConfig(max_parallel_threads=3),
+        )
+
+        assert result.status == "success"
+        assert len(result.thread_results) == 6
+        assert state["peak"] <= 3
+
+    @patch("weevr.engine.runner.ThreadPoolExecutor", wraps=ThreadPoolExecutor)
+    @patch("weevr.engine.runner.execute_thread")
+    def test_unset_cap_preserves_pool_sizing(self, mock_exec, mock_pool):
+        """No cap anywhere → pool sized to the full group (today's behavior)."""
+        mock_exec.side_effect = lambda spark, thread, **kwargs: _make_result(thread.name)
+        threads = {n: _make_thread(n) for n in "ABCD"}
+        plan = build_plan("uncapped", threads, _entries(*threads))
+
+        result = execute_weave(_MOCK_SPARK, plan, threads)
+
+        assert result.status == "success"
+        assert mock_pool.call_args_list[0].kwargs["max_workers"] == 4
+
+    @patch("weevr.engine.runner.ThreadPoolExecutor", wraps=ThreadPoolExecutor)
+    @patch("weevr.engine.runner.execute_thread")
+    def test_cap_larger_than_group_uses_group_size(self, mock_exec, mock_pool):
+        """Cap 8 over a 2-thread group → pool sized to the group, not the cap."""
+        mock_exec.side_effect = lambda spark, thread, **kwargs: _make_result(thread.name)
+        threads = {n: _make_thread(n) for n in "AB"}
+        plan = build_plan("wide_cap", threads, _entries(*threads))
+
+        result = execute_weave(
+            _MOCK_SPARK,
+            plan,
+            threads,
+            execution=ExecutionConfig(max_parallel_threads=8),
+        )
+
+        assert result.status == "success"
+        assert mock_pool.call_args_list[0].kwargs["max_workers"] == 2
+
+    @patch("weevr.engine.runner.execute_thread")
+    def test_loom_cap_applies_to_weave_groups(self, mock_exec):
+        """A loom-level cap bounds a weave group even when the weave
+        declares a logging-only execution block (field-level merge)."""
+        side_effect, state = self._tracking_side_effect()
+        mock_exec.side_effect = side_effect
+
+        loom = Loom.model_validate(
+            {
+                "name": "nightly",
+                "config_version": "1.0",
+                "weaves": ["facts"],
+                "execution": {"max_parallel_threads": 2},
+            }
+        )
+        weaves = {
+            "facts": Weave.model_validate(
+                {
+                    "config_version": "1.0",
+                    "name": "facts",
+                    "threads": ["A", "B", "C", "D"],
+                    "execution": {"log_level": "verbose"},
+                }
+            )
+        }
+        threads = {"facts": {n: _make_thread(n) for n in "ABCD"}}
+
+        result = execute_loom(_MOCK_SPARK, loom, weaves, threads)
+
+        assert result.status == "success"
+        assert len(result.weave_results[0].thread_results) == 4
+        assert state["peak"] <= 2
+
+    @patch("weevr.engine.runner.execute_thread")
+    def test_cap_attributes_on_weave_span(self, mock_exec):
+        """Weave span records the effective cap and per-group thread counts."""
+        mock_exec.side_effect = lambda spark, thread, **kwargs: _make_result(thread.name)
+        threads = {n: _make_thread(n) for n in "ABC"}
+        plan = build_plan("attr_weave", threads, _entries(*threads))
+
+        from weevr.telemetry.collector import SpanCollector
+        from weevr.telemetry.span import generate_trace_id
+
+        collector = SpanCollector(generate_trace_id())
+        result = execute_weave(
+            _MOCK_SPARK,
+            plan,
+            threads,
+            collector=collector,
+            execution=ExecutionConfig(max_parallel_threads=2),
+        )
+
+        assert result.status == "success"
+        assert result.telemetry is not None
+        assert result.telemetry.span is not None
+        attrs = result.telemetry.span.attributes
+        assert attrs["execution.max_parallel_threads"] == 2
+        assert attrs["execution.group_thread_counts"] == "3"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/weevr/model/test_execution.py
+++ b/tests/weevr/model/test_execution.py
@@ -1,9 +1,9 @@
-"""Tests for ExecutionConfig and LogLevel models."""
+"""Tests for ExecutionConfig, LogLevel, and effective-config resolution."""
 
 import pytest
 from pydantic import ValidationError
 
-from weevr.model.execution import ExecutionConfig, LogLevel
+from weevr.model.execution import ExecutionConfig, LogLevel, resolve_effective_execution
 
 
 class TestLogLevel:
@@ -52,3 +52,92 @@ class TestExecutionConfig:
     def test_round_trip(self) -> None:
         ec = ExecutionConfig(log_level=LogLevel.MINIMAL, trace=False)
         assert ExecutionConfig.model_validate(ec.model_dump()) == ec
+
+    def test_max_parallel_threads_default_none(self) -> None:
+        assert ExecutionConfig().max_parallel_threads is None
+
+    def test_max_parallel_threads_valid(self) -> None:
+        assert ExecutionConfig(max_parallel_threads=1).max_parallel_threads == 1
+        assert ExecutionConfig(max_parallel_threads=8).max_parallel_threads == 8
+
+    def test_max_parallel_threads_zero_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ExecutionConfig(max_parallel_threads=0)
+
+    def test_max_parallel_threads_negative_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ExecutionConfig(max_parallel_threads=-2)
+
+
+class TestResolveEffectiveExecution:
+    """Field-level merge: child-explicitly-set > parent-set > default."""
+
+    def test_both_absent_gives_defaults(self) -> None:
+        eff = resolve_effective_execution(None, None)
+        assert eff.log_level == LogLevel.STANDARD
+        assert eff.trace is True
+        assert eff.max_parallel_threads is None
+
+    def test_parent_only(self) -> None:
+        parent = ExecutionConfig(max_parallel_threads=3, log_level=LogLevel.VERBOSE)
+        eff = resolve_effective_execution(parent, None)
+        assert eff.max_parallel_threads == 3
+        assert eff.log_level == LogLevel.VERBOSE
+        assert eff.trace is True
+
+    def test_child_only(self) -> None:
+        child = ExecutionConfig(log_level=LogLevel.DEBUG)
+        eff = resolve_effective_execution(None, child)
+        assert eff.log_level == LogLevel.DEBUG
+        assert eff.max_parallel_threads is None
+
+    def test_child_overrides_parent_field(self) -> None:
+        parent = ExecutionConfig(log_level=LogLevel.MINIMAL)
+        child = ExecutionConfig(log_level=LogLevel.DEBUG)
+        eff = resolve_effective_execution(parent, child)
+        assert eff.log_level == LogLevel.DEBUG
+
+    def test_partial_child_block_keeps_parent_cap(self) -> None:
+        """A logging-only child block must not drop the parent's cap."""
+        parent = ExecutionConfig(max_parallel_threads=3)
+        child = ExecutionConfig(log_level=LogLevel.VERBOSE)
+        eff = resolve_effective_execution(parent, child)
+        assert eff.max_parallel_threads == 3
+        assert eff.log_level == LogLevel.VERBOSE
+
+    def test_child_default_valued_field_not_treated_as_explicit(self) -> None:
+        """A child block declaring only log_level leaves trace at the
+        parent's value even though trace has a non-None default."""
+        parent = ExecutionConfig(trace=False)
+        child = ExecutionConfig(log_level=LogLevel.VERBOSE)
+        eff = resolve_effective_execution(parent, child)
+        assert eff.trace is False
+
+    def test_child_explicit_default_value_wins(self) -> None:
+        """Explicitly setting a field to its default still counts as set."""
+        parent = ExecutionConfig(log_level=LogLevel.MINIMAL)
+        child = ExecutionConfig(log_level=LogLevel.STANDARD)
+        eff = resolve_effective_execution(parent, child)
+        assert eff.log_level == LogLevel.STANDARD
+
+    def test_child_can_re_enable_trace_field_level(self) -> None:
+        """Pure field-level merge: child trace: true wins over parent
+        false. (The one-directional runtime limitation is enforced at the
+        collector layer, not in the merge.)"""
+        parent = ExecutionConfig(trace=False)
+        child = ExecutionConfig(trace=True)
+        eff = resolve_effective_execution(parent, child)
+        assert eff.trace is True
+
+    def test_returns_execution_config_instance(self) -> None:
+        eff = resolve_effective_execution(ExecutionConfig(), ExecutionConfig())
+        assert isinstance(eff, ExecutionConfig)
+
+    def test_hydrated_from_yaml_dict_partial(self) -> None:
+        """Model_validate'd partial dicts behave like authored YAML."""
+        parent = ExecutionConfig.model_validate({"max_parallel_threads": 2})
+        child = ExecutionConfig.model_validate({"log_level": "debug"})
+        eff = resolve_effective_execution(parent, child)
+        assert eff.max_parallel_threads == 2
+        assert eff.log_level == LogLevel.DEBUG
+        assert eff.trace is True

--- a/tests/weevr/test_context.py
+++ b/tests/weevr/test_context.py
@@ -964,3 +964,89 @@ class TestLogLevelWiring:
         ctx.run("threads/stub.thread", mode="validate")
 
         assert [lv.value for lv in seen] == ["standard"]
+
+
+# ---------------------------------------------------------------------------
+# Trace gating — standalone weave and thread runs
+# ---------------------------------------------------------------------------
+
+
+class TestStandaloneTraceGating:
+    def _project(
+        self, tmp_path: Path, weave_execution: str = "", thread_execution: str = ""
+    ) -> Path:
+        project = tmp_path / "tracing.weevr"
+        project.mkdir()
+        (project / "threads").mkdir()
+        (project / "threads" / "stub.thread").write_text(
+            'config_version: "1.0"\n'
+            "sources:\n  data:\n    type: delta\n    alias: raw\n"
+            "target:\n  alias: out\n" + thread_execution
+        )
+        (project / "stub.weave").write_text(
+            'config_version: "1.0"\nthreads:\n  - ref: threads/stub.thread\n' + weave_execution
+        )
+        return project
+
+    def _weave_result(self):
+        from weevr.engine.result import WeaveResult
+
+        return WeaveResult(
+            status="success",
+            weave_name="stub",
+            thread_results=[],
+            threads_skipped=[],
+            duration_ms=1,
+        )
+
+    def _thread_result(self):
+        from weevr.engine.result import ThreadResult
+
+        return ThreadResult(
+            status="success",
+            thread_name="stub",
+            rows_written=0,
+            write_mode="overwrite",
+            target_path="/data/out",
+        )
+
+    @patch("weevr.context.execute_weave")
+    def test_standalone_weave_trace_false_creates_no_collector(
+        self, mock_weave, tmp_path: Path
+    ) -> None:
+        project = self._project(tmp_path, weave_execution="execution:\n  trace: false\n")
+        mock_weave.return_value = self._weave_result()
+        mock_spark = MagicMock(spec=SparkSession)
+        ctx = Context(spark=mock_spark, project=str(project))
+
+        result = ctx.run("stub.weave")
+
+        assert result.status == "success"
+        assert result.telemetry is None
+        assert mock_weave.call_args.kwargs["collector"] is None
+
+    @patch("weevr.context.execute_weave")
+    def test_standalone_weave_traces_by_default(self, mock_weave, tmp_path: Path) -> None:
+        project = self._project(tmp_path)
+        mock_weave.return_value = self._weave_result()
+        mock_spark = MagicMock(spec=SparkSession)
+        ctx = Context(spark=mock_spark, project=str(project))
+
+        result = ctx.run("stub.weave")
+
+        assert result.status == "success"
+        assert mock_weave.call_args.kwargs["collector"] is not None
+
+    @patch("weevr.context.execute_thread")
+    def test_standalone_thread_always_traces(self, mock_thread, tmp_path: Path) -> None:
+        """Thread-scoped execution is unapplied — even trace: false in the
+        thread's own block never suppresses the collector (DEC-003)."""
+        project = self._project(tmp_path, thread_execution="execution:\n  trace: false\n")
+        mock_thread.return_value = self._thread_result()
+        mock_spark = MagicMock(spec=SparkSession)
+        ctx = Context(spark=mock_spark, project=str(project))
+
+        result = ctx.run("threads/stub.thread")
+
+        assert result.status == "success"
+        assert mock_thread.call_args.kwargs["collector"] is not None

--- a/tests/weevr/test_context.py
+++ b/tests/weevr/test_context.py
@@ -1050,3 +1050,88 @@ class TestStandaloneTraceGating:
 
         assert result.status == "success"
         assert mock_thread.call_args.kwargs["collector"] is not None
+
+
+# ---------------------------------------------------------------------------
+# Execution-scope warnings at config resolution
+# ---------------------------------------------------------------------------
+
+
+class TestExecutionScopeWarnings:
+    def _project(
+        self,
+        tmp_path: Path,
+        loom_extra: str = "",
+        weave_extra: str = "",
+        thread_extra: str = "",
+    ) -> Path:
+        project = tmp_path / "warnings.weevr"
+        project.mkdir()
+        (project / "threads").mkdir()
+        (project / "threads" / "stub.thread").write_text(
+            'config_version: "1.0"\n'
+            "sources:\n  data:\n    type: delta\n    alias: raw\n"
+            "target:\n  alias: out\n" + thread_extra
+        )
+        (project / "stub.weave").write_text(
+            'config_version: "1.0"\nthreads:\n  - ref: threads/stub.thread\n' + weave_extra
+        )
+        (project / "stub.loom").write_text(
+            'config_version: "1.0"\nweaves:\n  - ref: stub.weave\n' + loom_extra
+        )
+        return project
+
+    def _run_validate(self, project: Path, path: str, caplog) -> list[str]:
+        import logging
+
+        mock_spark = MagicMock(spec=SparkSession)
+        ctx = Context(spark=mock_spark, project=str(project))
+        with caplog.at_level(logging.WARNING, logger="weevr.context"):
+            ctx.run(path, mode="validate")
+        return [r.message for r in caplog.records if r.message.startswith("WARN:")]
+
+    def test_defaults_execution_warns_once(self, tmp_path: Path, caplog) -> None:
+        project = self._project(
+            tmp_path, loom_extra="defaults:\n  execution:\n    log_level: debug\n"
+        )
+        warnings = self._run_validate(project, "stub.loom", caplog)
+        scoped = [w for w in warnings if "defaults.execution" in w]
+        assert len(scoped) == 1
+        assert "log_level" in scoped[0]
+
+    def test_authored_thread_block_warns(self, tmp_path: Path, caplog) -> None:
+        project = self._project(tmp_path, thread_extra="execution:\n  log_level: minimal\n")
+        warnings = self._run_validate(project, "stub.loom", caplog)
+        assert any("stub" in w and "execution block" in w for w in warnings)
+
+    def test_trace_true_under_traceless_loom_warns(self, tmp_path: Path, caplog) -> None:
+        project = self._project(
+            tmp_path,
+            loom_extra="execution:\n  trace: false\n",
+            weave_extra="execution:\n  trace: true\n",
+        )
+        warnings = self._run_validate(project, "stub.loom", caplog)
+        assert any("trace: true" in w and "stub" in w for w in warnings)
+
+    def test_clean_project_warns_nothing(self, tmp_path: Path, caplog) -> None:
+        project = self._project(tmp_path)
+        warnings = self._run_validate(project, "stub.loom", caplog)
+        assert warnings == []
+
+    def test_execute_mode_also_warns(self, tmp_path: Path, caplog) -> None:
+        import logging
+
+        project = self._project(tmp_path, loom_extra="defaults:\n  execution:\n    trace: false\n")
+        mock_spark = MagicMock(spec=SparkSession)
+        ctx = Context(spark=mock_spark, project=str(project))
+        with (
+            patch("weevr.context.execute_loom") as mock_loom,
+            caplog.at_level(logging.WARNING, logger="weevr.context"),
+        ):
+            from weevr.engine.result import LoomResult
+
+            mock_loom.return_value = LoomResult(
+                status="success", loom_name="stub", weave_results=[], duration_ms=1
+            )
+            ctx.run("stub.loom", mode="execute")
+        assert any("defaults.execution" in r.message for r in caplog.records)

--- a/tests/weevr/test_context.py
+++ b/tests/weevr/test_context.py
@@ -849,31 +849,33 @@ threads:
 # ---------------------------------------------------------------------------
 
 
+def _stub_execution_project(
+    tmp_path: Path,
+    *,
+    loom_extra: str = "",
+    weave_extra: str = "",
+    thread_extra: str = "",
+) -> Path:
+    """Minimal thread/weave/loom project for execution-settings tests."""
+    project = tmp_path / "stub.weevr"
+    project.mkdir()
+    (project / "threads").mkdir()
+    (project / "threads" / "stub.thread").write_text(
+        'config_version: "1.0"\n'
+        "sources:\n  data:\n    type: delta\n    alias: raw\n"
+        "target:\n  alias: out\n" + thread_extra
+    )
+    (project / "stub.weave").write_text(
+        'config_version: "1.0"\nthreads:\n  - ref: threads/stub.thread\n' + weave_extra
+    )
+    (project / "stub.loom").write_text(
+        'config_version: "1.0"\nweaves:\n  - ref: stub.weave\n' + loom_extra
+    )
+    return project
+
+
 class TestLogLevelWiring:
     """YAML log_level application with Context-argument precedence."""
-
-    def _project(
-        self,
-        tmp_path: Path,
-        weave_execution: str = "",
-        loom_execution: str = "",
-        thread_execution: str = "",
-    ) -> Path:
-        project = tmp_path / "levels.weevr"
-        project.mkdir()
-        (project / "threads").mkdir()
-        (project / "threads" / "stub.thread").write_text(
-            'config_version: "1.0"\n'
-            "sources:\n  data:\n    type: delta\n    alias: raw\n"
-            "target:\n  alias: out\n" + thread_execution
-        )
-        (project / "stub.weave").write_text(
-            'config_version: "1.0"\nthreads:\n  - ref: threads/stub.thread\n' + weave_execution
-        )
-        (project / "stub.loom").write_text(
-            'config_version: "1.0"\nweaves:\n  - ref: stub.weave\n' + loom_execution
-        )
-        return project
 
     def _ctx(self, project: Path, **kwargs) -> Context:
         mock_spark = MagicMock(spec=SparkSession)
@@ -900,7 +902,7 @@ class TestLogLevelWiring:
         monkeypatch.setattr(ctx, "_run_preview", _stub)
 
     def test_omitted_argument_is_provisional_standard(self, tmp_path: Path) -> None:
-        project = self._project(tmp_path)
+        project = _stub_execution_project(tmp_path)
         ctx = self._ctx(project)
         assert ctx.log_level.value == "standard"
 
@@ -912,7 +914,9 @@ class TestLogLevelWiring:
     @pytest.mark.parametrize("mode", ["execute", "validate", "plan", "preview"])
     def test_yaml_applies_in_every_mode(self, tmp_path: Path, monkeypatch, mode: str) -> None:
         """Effective YAML level is applied before mode dispatch, all modes."""
-        project = self._project(tmp_path, weave_execution="execution:\n  log_level: minimal\n")
+        project = _stub_execution_project(
+            tmp_path, weave_extra="execution:\n  log_level: minimal\n"
+        )
         ctx = self._ctx(project)
         seen: list = []
         self._patch_modes(monkeypatch, ctx, seen)
@@ -924,7 +928,9 @@ class TestLogLevelWiring:
 
     @pytest.mark.parametrize("mode", ["execute", "validate", "plan", "preview"])
     def test_argument_beats_yaml(self, tmp_path: Path, monkeypatch, mode: str) -> None:
-        project = self._project(tmp_path, weave_execution="execution:\n  log_level: minimal\n")
+        project = _stub_execution_project(
+            tmp_path, weave_extra="execution:\n  log_level: minimal\n"
+        )
         ctx = self._ctx(project, log_level="verbose")
         seen: list = []
         self._patch_modes(monkeypatch, ctx, seen)
@@ -935,7 +941,7 @@ class TestLogLevelWiring:
         assert ctx.log_level.value == "verbose"
 
     def test_default_when_neither(self, tmp_path: Path, monkeypatch) -> None:
-        project = self._project(tmp_path)
+        project = _stub_execution_project(tmp_path)
         ctx = self._ctx(project)
         seen: list = []
         self._patch_modes(monkeypatch, ctx, seen)
@@ -945,7 +951,7 @@ class TestLogLevelWiring:
         assert [lv.value for lv in seen] == ["standard"]
 
     def test_loom_yaml_level_applies(self, tmp_path: Path, monkeypatch) -> None:
-        project = self._project(tmp_path, loom_execution="execution:\n  log_level: debug\n")
+        project = _stub_execution_project(tmp_path, loom_extra="execution:\n  log_level: debug\n")
         ctx = self._ctx(project)
         seen: list = []
         self._patch_modes(monkeypatch, ctx, seen)
@@ -956,7 +962,9 @@ class TestLogLevelWiring:
 
     def test_thread_scoped_yaml_never_applies(self, tmp_path: Path, monkeypatch) -> None:
         """Standalone thread runs: argument > standard only (DEC-003)."""
-        project = self._project(tmp_path, thread_execution="execution:\n  log_level: minimal\n")
+        project = _stub_execution_project(
+            tmp_path, thread_extra="execution:\n  log_level: minimal\n"
+        )
         ctx = self._ctx(project)
         seen: list = []
         self._patch_modes(monkeypatch, ctx, seen)
@@ -965,6 +973,27 @@ class TestLogLevelWiring:
 
         assert [lv.value for lv in seen] == ["standard"]
 
+    def test_load_applies_effective_level(self, tmp_path: Path) -> None:
+        """load() applies the effective YAML level, same as run()."""
+        project = _stub_execution_project(
+            tmp_path, weave_extra="execution:\n  log_level: minimal\n"
+        )
+        ctx = self._ctx(project)
+
+        ctx.load("stub.weave")
+
+        assert ctx.log_level.value == "minimal"
+
+    def test_load_argument_still_beats_yaml(self, tmp_path: Path) -> None:
+        project = _stub_execution_project(
+            tmp_path, weave_extra="execution:\n  log_level: minimal\n"
+        )
+        ctx = self._ctx(project, log_level="verbose")
+
+        ctx.load("stub.weave")
+
+        assert ctx.log_level.value == "verbose"
+
 
 # ---------------------------------------------------------------------------
 # Trace gating — standalone weave and thread runs
@@ -972,22 +1001,6 @@ class TestLogLevelWiring:
 
 
 class TestStandaloneTraceGating:
-    def _project(
-        self, tmp_path: Path, weave_execution: str = "", thread_execution: str = ""
-    ) -> Path:
-        project = tmp_path / "tracing.weevr"
-        project.mkdir()
-        (project / "threads").mkdir()
-        (project / "threads" / "stub.thread").write_text(
-            'config_version: "1.0"\n'
-            "sources:\n  data:\n    type: delta\n    alias: raw\n"
-            "target:\n  alias: out\n" + thread_execution
-        )
-        (project / "stub.weave").write_text(
-            'config_version: "1.0"\nthreads:\n  - ref: threads/stub.thread\n' + weave_execution
-        )
-        return project
-
     def _weave_result(self):
         from weevr.engine.result import WeaveResult
 
@@ -1014,7 +1027,7 @@ class TestStandaloneTraceGating:
     def test_standalone_weave_trace_false_creates_no_collector(
         self, mock_weave, tmp_path: Path
     ) -> None:
-        project = self._project(tmp_path, weave_execution="execution:\n  trace: false\n")
+        project = _stub_execution_project(tmp_path, weave_extra="execution:\n  trace: false\n")
         mock_weave.return_value = self._weave_result()
         mock_spark = MagicMock(spec=SparkSession)
         ctx = Context(spark=mock_spark, project=str(project))
@@ -1027,7 +1040,7 @@ class TestStandaloneTraceGating:
 
     @patch("weevr.context.execute_weave")
     def test_standalone_weave_traces_by_default(self, mock_weave, tmp_path: Path) -> None:
-        project = self._project(tmp_path)
+        project = _stub_execution_project(tmp_path)
         mock_weave.return_value = self._weave_result()
         mock_spark = MagicMock(spec=SparkSession)
         ctx = Context(spark=mock_spark, project=str(project))
@@ -1041,7 +1054,7 @@ class TestStandaloneTraceGating:
     def test_standalone_thread_always_traces(self, mock_thread, tmp_path: Path) -> None:
         """Thread-scoped execution is unapplied — even trace: false in the
         thread's own block never suppresses the collector (DEC-003)."""
-        project = self._project(tmp_path, thread_execution="execution:\n  trace: false\n")
+        project = _stub_execution_project(tmp_path, thread_extra="execution:\n  trace: false\n")
         mock_thread.return_value = self._thread_result()
         mock_spark = MagicMock(spec=SparkSession)
         ctx = Context(spark=mock_spark, project=str(project))
@@ -1058,29 +1071,6 @@ class TestStandaloneTraceGating:
 
 
 class TestExecutionScopeWarnings:
-    def _project(
-        self,
-        tmp_path: Path,
-        loom_extra: str = "",
-        weave_extra: str = "",
-        thread_extra: str = "",
-    ) -> Path:
-        project = tmp_path / "warnings.weevr"
-        project.mkdir()
-        (project / "threads").mkdir()
-        (project / "threads" / "stub.thread").write_text(
-            'config_version: "1.0"\n'
-            "sources:\n  data:\n    type: delta\n    alias: raw\n"
-            "target:\n  alias: out\n" + thread_extra
-        )
-        (project / "stub.weave").write_text(
-            'config_version: "1.0"\nthreads:\n  - ref: threads/stub.thread\n' + weave_extra
-        )
-        (project / "stub.loom").write_text(
-            'config_version: "1.0"\nweaves:\n  - ref: stub.weave\n' + loom_extra
-        )
-        return project
-
     def _run_validate(self, project: Path, path: str, caplog) -> list[str]:
         import logging
 
@@ -1091,7 +1081,7 @@ class TestExecutionScopeWarnings:
         return [r.message for r in caplog.records if r.message.startswith("WARN:")]
 
     def test_defaults_execution_warns_once(self, tmp_path: Path, caplog) -> None:
-        project = self._project(
+        project = _stub_execution_project(
             tmp_path, loom_extra="defaults:\n  execution:\n    log_level: debug\n"
         )
         warnings = self._run_validate(project, "stub.loom", caplog)
@@ -1100,12 +1090,14 @@ class TestExecutionScopeWarnings:
         assert "log_level" in scoped[0]
 
     def test_authored_thread_block_warns(self, tmp_path: Path, caplog) -> None:
-        project = self._project(tmp_path, thread_extra="execution:\n  log_level: minimal\n")
+        project = _stub_execution_project(
+            tmp_path, thread_extra="execution:\n  log_level: minimal\n"
+        )
         warnings = self._run_validate(project, "stub.loom", caplog)
         assert any("stub" in w and "execution block" in w for w in warnings)
 
     def test_trace_true_under_traceless_loom_warns(self, tmp_path: Path, caplog) -> None:
-        project = self._project(
+        project = _stub_execution_project(
             tmp_path,
             loom_extra="execution:\n  trace: false\n",
             weave_extra="execution:\n  trace: true\n",
@@ -1114,14 +1106,16 @@ class TestExecutionScopeWarnings:
         assert any("trace: true" in w and "stub" in w for w in warnings)
 
     def test_clean_project_warns_nothing(self, tmp_path: Path, caplog) -> None:
-        project = self._project(tmp_path)
+        project = _stub_execution_project(tmp_path)
         warnings = self._run_validate(project, "stub.loom", caplog)
         assert warnings == []
 
     def test_execute_mode_also_warns(self, tmp_path: Path, caplog) -> None:
         import logging
 
-        project = self._project(tmp_path, loom_extra="defaults:\n  execution:\n    trace: false\n")
+        project = _stub_execution_project(
+            tmp_path, loom_extra="defaults:\n  execution:\n    trace: false\n"
+        )
         mock_spark = MagicMock(spec=SparkSession)
         ctx = Context(spark=mock_spark, project=str(project))
         with (
@@ -1135,3 +1129,17 @@ class TestExecutionScopeWarnings:
             )
             ctx.run("stub.loom", mode="execute")
         assert any("defaults.execution" in r.message for r in caplog.records)
+
+    def test_standalone_weave_run_warns_for_authored_thread_block(
+        self, tmp_path: Path, caplog
+    ) -> None:
+        project = _stub_execution_project(tmp_path, thread_extra="execution:\n  trace: false\n")
+        warnings = self._run_validate(project, "stub.weave", caplog)
+        assert any("execution block" in w and "trace" in w for w in warnings)
+
+    def test_standalone_thread_run_warns_for_own_block(self, tmp_path: Path, caplog) -> None:
+        project = _stub_execution_project(
+            tmp_path, thread_extra="execution:\n  log_level: minimal\n"
+        )
+        warnings = self._run_validate(project, "threads/stub.thread", caplog)
+        assert any("execution block" in w and "log_level" in w for w in warnings)

--- a/tests/weevr/test_context.py
+++ b/tests/weevr/test_context.py
@@ -842,3 +842,125 @@ threads:
         output = spark.read.format("delta").load(tgt)
         assert "new_col" in output.columns
         assert "old_col" not in output.columns
+
+
+# ---------------------------------------------------------------------------
+# Execution log-level wiring — argument > effective YAML > standard
+# ---------------------------------------------------------------------------
+
+
+class TestLogLevelWiring:
+    """YAML log_level application with Context-argument precedence."""
+
+    def _project(
+        self,
+        tmp_path: Path,
+        weave_execution: str = "",
+        loom_execution: str = "",
+        thread_execution: str = "",
+    ) -> Path:
+        project = tmp_path / "levels.weevr"
+        project.mkdir()
+        (project / "threads").mkdir()
+        (project / "threads" / "stub.thread").write_text(
+            'config_version: "1.0"\n'
+            "sources:\n  data:\n    type: delta\n    alias: raw\n"
+            "target:\n  alias: out\n" + thread_execution
+        )
+        (project / "stub.weave").write_text(
+            'config_version: "1.0"\nthreads:\n  - ref: threads/stub.thread\n' + weave_execution
+        )
+        (project / "stub.loom").write_text(
+            'config_version: "1.0"\nweaves:\n  - ref: stub.weave\n' + loom_execution
+        )
+        return project
+
+    def _ctx(self, project: Path, **kwargs) -> Context:
+        mock_spark = MagicMock(spec=SparkSession)
+        return Context(spark=mock_spark, project=str(project), **kwargs)
+
+    @staticmethod
+    def _patch_modes(monkeypatch, ctx: Context, seen_levels: list) -> None:
+        """Stub all four mode handlers, recording the applied level on entry."""
+        from weevr.model.execution import LogLevel as LL
+
+        def _stub(*args, **kwargs):
+            seen_levels.append(ctx.log_level)
+            return RunResult(
+                status="success",
+                mode=ExecutionMode.EXECUTE,
+                config_type="weave",
+                config_name="stub",
+            )
+
+        assert isinstance(ctx.log_level, LL)
+        monkeypatch.setattr(ctx, "_run_execute", _stub)
+        monkeypatch.setattr(ctx, "_run_validate", _stub)
+        monkeypatch.setattr(ctx, "_run_plan", _stub)
+        monkeypatch.setattr(ctx, "_run_preview", _stub)
+
+    def test_omitted_argument_is_provisional_standard(self, tmp_path: Path) -> None:
+        project = self._project(tmp_path)
+        ctx = self._ctx(project)
+        assert ctx.log_level.value == "standard"
+
+    def test_invalid_argument_still_raises(self) -> None:
+        mock_spark = MagicMock(spec=SparkSession)
+        with pytest.raises(ValueError, match="log_level"):
+            Context(spark=mock_spark, project="dummy", log_level="nope")
+
+    @pytest.mark.parametrize("mode", ["execute", "validate", "plan", "preview"])
+    def test_yaml_applies_in_every_mode(self, tmp_path: Path, monkeypatch, mode: str) -> None:
+        """Effective YAML level is applied before mode dispatch, all modes."""
+        project = self._project(tmp_path, weave_execution="execution:\n  log_level: minimal\n")
+        ctx = self._ctx(project)
+        seen: list = []
+        self._patch_modes(monkeypatch, ctx, seen)
+
+        ctx.run("stub.weave", mode=mode)
+
+        assert [lv.value for lv in seen] == ["minimal"]
+        assert ctx.log_level.value == "minimal"
+
+    @pytest.mark.parametrize("mode", ["execute", "validate", "plan", "preview"])
+    def test_argument_beats_yaml(self, tmp_path: Path, monkeypatch, mode: str) -> None:
+        project = self._project(tmp_path, weave_execution="execution:\n  log_level: minimal\n")
+        ctx = self._ctx(project, log_level="verbose")
+        seen: list = []
+        self._patch_modes(monkeypatch, ctx, seen)
+
+        ctx.run("stub.weave", mode=mode)
+
+        assert [lv.value for lv in seen] == ["verbose"]
+        assert ctx.log_level.value == "verbose"
+
+    def test_default_when_neither(self, tmp_path: Path, monkeypatch) -> None:
+        project = self._project(tmp_path)
+        ctx = self._ctx(project)
+        seen: list = []
+        self._patch_modes(monkeypatch, ctx, seen)
+
+        ctx.run("stub.weave", mode="validate")
+
+        assert [lv.value for lv in seen] == ["standard"]
+
+    def test_loom_yaml_level_applies(self, tmp_path: Path, monkeypatch) -> None:
+        project = self._project(tmp_path, loom_execution="execution:\n  log_level: debug\n")
+        ctx = self._ctx(project)
+        seen: list = []
+        self._patch_modes(monkeypatch, ctx, seen)
+
+        ctx.run("stub.loom", mode="validate")
+
+        assert [lv.value for lv in seen] == ["debug"]
+
+    def test_thread_scoped_yaml_never_applies(self, tmp_path: Path, monkeypatch) -> None:
+        """Standalone thread runs: argument > standard only (DEC-003)."""
+        project = self._project(tmp_path, thread_execution="execution:\n  log_level: minimal\n")
+        ctx = self._ctx(project)
+        seen: list = []
+        self._patch_modes(monkeypatch, ctx, seen)
+
+        ctx.run("threads/stub.thread", mode="validate")
+
+        assert [lv.value for lv in seen] == ["standard"]


### PR DESCRIPTION
## Summary

- The `execution:` block now does what the docs always said it did. New
  `max_parallel_threads` bounds intra-group thread concurrency, and the
  existing `log_level` / `trace` fields — previously silent no-ops — take
  effect from YAML.

## Why

- Wide parallel groups size their thread pool to the full group, so six
  independent facts contend for the same Spark executors with no way to
  bound concurrency short of restructuring weaves. This is the immediate
  operational lever for capacity-constrained deployments.
- `ExecutionConfig` (`log_level`, `trace`) has been declared on the models
  and documented since v1.0, but no engine code read it from any
  declaration site. Configs that set it were silently ignored.

## What changed

- `execution.max_parallel_threads` (int >= 1, optional) on the loom/weave
  top level; each group's pool is sized `min(cap, len(group))`. Unset
  preserves today's sizing exactly. Groups still run sequentially;
  dependency ordering and failure routing are untouched.
- Loom and weave `execution:` blocks merge **field-level** (an explicitly
  set weave field wins), so a logging-only weave block no longer drops an
  inherited capacity cap. This is a deliberate, documented exception to
  the whole-block cascade rule.
- `log_level` precedence: explicit `Context(log_level=...)` argument >
  effective YAML > `standard`, applied uniformly across execute, validate,
  plan, and preview. Per-weave overrides during loom runs restore in a
  `finally`, including on failure.
- `trace: false` at loom scope runs collector-free (`RunResult.telemetry`
  is `None`); at weave scope it omits that weave's nodes. Composition is
  one-directional — a weave cannot re-enable tracing under a traceless
  loom, and validation warns when it tries. Standalone thread runs always
  trace.
- Thread-scoped `execution:` (authored or via `defaults.execution`) is
  declared but not applied; runs warn once per origin naming the unapplied
  fields and pointing at the top-level block.
- Weave telemetry records the effective cap and per-group thread counts.
- New Execution Settings guide; reconciled observability guide, YAML
  schema pages, configuration-keys reference, and concepts page.

## How to test

- [x] uv sync --dev
- [x] uv run ruff check .
- [x] uv run ruff format .
- [x] uv run pyright .
- [x] uv run pytest (2500+ passed) and uv run pytest -m spark (798 passed)
- [x] uv run mkdocs build --strict && npx markdownlint-cli2 'docs/**/*.md'
- Instrumented concurrency test asserts a 6-thread group under cap 3 never
  exceeds 3 in flight; a regression test pins unset-cap pool sizing.

## Release / Versioning

- [x] PR title follows Conventional Commit format (feat:, fix:, chore:, docs:, ci:, etc.)
- [ ] Breaking change indicated (feat!: / fix!: or BREAKING CHANGE in body)

Not breaking: purely additive. Existing configs run unchanged — the only
behavior shift is for configs that already declare `log_level`/`trace`,
which were documented to work and previously did nothing.

## Notes

- Configs currently declaring `defaults.execution` will start seeing a
  run-start warning (nothing else changes — it was already inert). The
  warning text points at the top-level block.
- Global DAG-level scheduling (dissolving group barriers) was considered
  and deliberately deferred: it is breaking-shaped for weaves relying on
  incidental barrier ordering. The `max_parallel_threads` surface is
  forward-compatible with it.