### PR TITLE
fix(engine): reject unordered same-target threads at plan time

### DIFF
--- a/docs/concepts/execution-modes.md
+++ b/docs/concepts/execution-modes.md
@@ -79,7 +79,7 @@ preview_phase -> preview_stop: {style.stroke-dash: 3; style.stroke: "#6A1B9A"}
 | Mode | What happens | Result contains |
 |------|-------------|-----------------|
 | `execute` | Full execution: read, transform, write (default) | Status, row counts, telemetry |
-| `validate` | Parse config, resolve references, check DAG — no data touched | `validation_errors` list |
+| `validate` | Parse config, resolve references, check DAG (cycles, duplicate targets) — no data touched | `validation_errors` list |
 | `plan` | Build the execution plan and return it without running | `execution_plan` list, `summary()` with cache markers, `explain()` for detailed breakdown |
 | `preview` | Run transforms against sampled data, skip writes | `preview_data` DataFrames |
 

--- a/docs/guides/engine-internals.md
+++ b/docs/guides/engine-internals.md
@@ -65,18 +65,24 @@ execute -> aggregate: results + telemetry
 
 The planner builds a DAG from thread configurations:
 
-1. **Infer dependencies** — If thread B reads from thread A's target path, B
+1. **Check target ownership** — Each target may have only one writing thread,
+   unless explicit dependencies fully serialize the writers into a chain.
+   Unordered threads sharing a target are rejected with a `ConfigError` naming
+   the target and every writer — running them concurrently would corrupt the
+   table. For an ordered chain, downstream consumers depend on the *last*
+   writer, so they always see the target's final state.
+2. **Infer dependencies** — If thread B reads from thread A's target path, B
    depends on A. This happens automatically by matching source paths/aliases
    to target paths/aliases across all threads.
-2. **Merge explicit dependencies** — Weave entries can declare additional
+3. **Merge explicit dependencies** — Weave entries can declare additional
    dependencies that are not data-based (e.g., ordering constraints).
-3. **Detect cycles** — DFS with three-color marking (white/gray/black) finds
+4. **Detect cycles** — DFS with three-color marking (white/gray/black) finds
    back edges. If a cycle exists, execution fails immediately with a clear
    error showing the cycle path.
-4. **Topological sort** — Kahn's algorithm produces a sequence of parallel
+5. **Topological sort** — Kahn's algorithm produces a sequence of parallel
    groups. Threads within a group have no mutual dependencies and can run
    concurrently.
-5. **Analyze cache targets** — Threads with two or more downstream dependents
+6. **Analyze cache targets** — Threads with two or more downstream dependents
    are flagged for caching, unless the thread explicitly sets `cache: false`.
    Setting `cache: true` is a no-op — it only prevents `cache: false`
    suppression but does not force caching for threads with fewer than two

--- a/packages/weevr-core/src/weevr/engine/planner.py
+++ b/packages/weevr-core/src/weevr/engine/planner.py
@@ -111,54 +111,24 @@ def _extract_source_paths(thread: Thread) -> set[str]:
     return paths
 
 
-def _build_target_index(threads: dict[str, Thread]) -> dict[str, str]:
-    """Build a mapping of normalized target path to thread name.
-
-    Used by the dependency graph builder and lookup dependency inference to
-    identify which thread produces a given data path.
-
-    Args:
-        threads: Mapping of thread name to Thread config.
-
-    Returns:
-        A dict mapping normalized target path to the producing thread's name.
-    """
-    target_index: dict[str, str] = {}
-    for name, thread in threads.items():
-        path = _extract_target_path(thread)
-        if path is not None:
-            target_index[path] = name
-    return target_index
-
-
-def _build_dependency_graph(
+def _build_explicit_index(
     threads: dict[str, Thread],
     thread_entries: list[ThreadEntry],
-    target_index: dict[str, str] | None = None,
-) -> tuple[dict[str, list[str]], dict[str, list[str]]]:
-    """Build inferred and explicit dependency dicts.
-
-    For each thread, auto-infers an edge when another thread's target path
-    appears in this thread's source paths. Also merges explicit dependencies
-    declared on ThreadEntry objects.
+) -> dict[str, list[str]]:
+    """Build the explicit dependency index from ThreadEntry declarations.
 
     Args:
         threads: Mapping of thread name to Thread config.
         thread_entries: Ordered thread entries from the weave config.
-        target_index: Pre-built target path index. Built internally when ``None``.
 
     Returns:
-        A ``(inferred_deps, explicit_deps)`` tuple where each is a
-        ``dict[thread_name, list[upstream_thread_name]]``.
+        A dict mapping each thread name to its explicitly declared upstream
+        thread names (empty list when none are declared).
 
     Raises:
         ConfigError: If a thread referenced in explicit dependencies does not
             exist in the ``threads`` dict.
     """
-    if target_index is None:
-        target_index = _build_target_index(threads)
-
-    # Build explicit deps index from ThreadEntry list
     explicit_index: dict[str, list[str]] = {name: [] for name in threads}
     for entry in thread_entries:
         effective_name = entry.as_ or entry.name or (Path(entry.ref).stem if entry.ref else "")
@@ -170,8 +140,74 @@ def _build_dependency_graph(
                         f"but '{dep}' is not defined in the weave"
                     )
             explicit_index[effective_name] = list(entry.dependencies)
+    return explicit_index
 
-    # Infer dependencies from path matching
+
+def _build_target_index(
+    threads: dict[str, Thread],
+    explicit_index: dict[str, list[str]] | None = None,
+    weave_name: str = "",
+) -> dict[str, str]:
+    """Build a mapping of normalized target path to producing thread name.
+
+    Used by the dependency graph builder and lookup dependency inference to
+    identify which thread produces a given data path.
+
+    A target written by two or more threads is rejected: the planner would
+    otherwise place the writers in one parallel group and race concurrent
+    writes against a single table.
+
+    Args:
+        threads: Mapping of thread name to Thread config.
+        explicit_index: Explicit dependency index, used to check whether
+            same-target writers are serialized by declared dependencies.
+        weave_name: Weave name for error messages.
+
+    Returns:
+        A dict mapping normalized target path to the producing thread's name.
+
+    Raises:
+        ConfigError: If two or more threads write the same target without
+            explicit dependencies ordering them.
+    """
+    writers_by_path: dict[str, list[str]] = {}
+    for name, thread in threads.items():
+        path = _extract_target_path(thread)
+        if path is not None:
+            writers_by_path.setdefault(path, []).append(name)
+
+    target_index: dict[str, str] = {}
+    for path, writers in writers_by_path.items():
+        if len(writers) == 1:
+            target_index[path] = writers[0]
+        else:
+            names = ", ".join(f"'{n}'" for n in sorted(writers))
+            in_weave = f" in weave '{weave_name}'" if weave_name else ""
+            raise ConfigError(
+                f"Threads {names} all write target '{path}'{in_weave} but are not "
+                f"ordered by explicit dependencies — concurrent writes to one target "
+                f"corrupt data. Declare explicit dependencies to serialize the "
+                f"writers, or give each thread its own target."
+            )
+    return target_index
+
+
+def _infer_dependencies(
+    threads: dict[str, Thread],
+    target_index: dict[str, str],
+) -> dict[str, list[str]]:
+    """Build the inferred dependency dict from source/target path matching.
+
+    For each thread, auto-infers an edge when another thread's target path
+    appears in this thread's source paths.
+
+    Args:
+        threads: Mapping of thread name to Thread config.
+        target_index: Pre-built target path index.
+
+    Returns:
+        A ``dict[thread_name, list[upstream_thread_name]]`` of inferred edges.
+    """
     inferred: dict[str, list[str]] = {name: [] for name in threads}
     for name, thread in threads.items():
         source_paths = _extract_source_paths(thread)
@@ -179,8 +215,7 @@ def _build_dependency_graph(
             producer = target_index.get(src_path)
             if producer is not None and producer != name and producer not in inferred[name]:
                 inferred[name].append(producer)
-
-    return inferred, explicit_index
+    return inferred
 
 
 def _merge_dependencies(
@@ -450,16 +485,21 @@ def build_plan(
 
     Raises:
         ConfigError: If a circular dependency is detected (with cycle path in
-            the message), or if an explicit dependency references a thread that
-            does not exist in ``threads``.
+            the message), if an explicit dependency references a thread that
+            does not exist in ``threads``, or if two or more threads write the
+            same target without explicit dependencies ordering them.
     """
     thread_names = list(threads.keys())
 
-    # 0. Build shared target index
-    target_index = _build_target_index(threads)
+    # 0. Build the explicit dependency index first — the target index needs it
+    #    to decide whether same-target writers are serialized.
+    explicit = _build_explicit_index(threads, thread_entries)
 
-    # 1. Build inferred and explicit dependency graphs
-    inferred, explicit = _build_dependency_graph(threads, thread_entries, target_index)
+    # 0b. Build shared target index (rejects unordered duplicate targets)
+    target_index = _build_target_index(threads, explicit, weave_name)
+
+    # 1. Infer data-based dependencies from source/target path matching
+    inferred = _infer_dependencies(threads, target_index)
 
     # 1b. Infer lookup-mediated dependencies when lookups are provided
     lookup_deps: dict[str, list[str]] | None = None

--- a/packages/weevr-core/src/weevr/engine/planner.py
+++ b/packages/weevr-core/src/weevr/engine/planner.py
@@ -180,13 +180,13 @@ def _resolve_writer_chain(
 
 def _build_target_index(
     threads: dict[str, Thread],
-    explicit_index: dict[str, list[str]] | None = None,
-    weave_name: str = "",
+    explicit_index: dict[str, list[str]],
+    weave_name: str,
 ) -> dict[str, str]:
     """Build a mapping of normalized target path to producing thread name.
 
-    Used by the dependency graph builder and lookup dependency inference to
-    identify which thread produces a given data path.
+    Used by thread and lookup dependency inference to identify which thread
+    produces a given data path.
 
     A target written by two or more threads is rejected unless explicit
     dependencies totally order the writers: unordered writers would land in
@@ -198,7 +198,6 @@ def _build_target_index(
         threads: Mapping of thread name to Thread config.
         explicit_index: Explicit dependency index, used to check whether
             same-target writers are serialized by declared dependencies.
-            ``None`` means no explicit ordering exists.
         weave_name: Weave name for error messages.
 
     Returns:
@@ -219,15 +218,15 @@ def _build_target_index(
         if len(writers) == 1:
             target_index[path] = writers[0]
             continue
-        last_writer = _resolve_writer_chain(writers, explicit_index or {})
+        last_writer = _resolve_writer_chain(writers, explicit_index)
         if last_writer is None:
             names = ", ".join(f"'{n}'" for n in sorted(writers))
-            in_weave = f" in weave '{weave_name}'" if weave_name else ""
             raise ConfigError(
-                f"Threads {names} all write target '{path}'{in_weave} but are not "
-                f"ordered by explicit dependencies — concurrent writes to one target "
-                f"corrupt data. Declare explicit dependencies to serialize the "
-                f"writers, or give each thread its own target."
+                f"Threads {names} all write target '{path}' in weave "
+                f"'{weave_name}' but are not ordered by explicit dependencies, "
+                f"so concurrent writes would corrupt the target. Declare "
+                f"explicit dependencies to serialize the writers, or give each "
+                f"thread its own target."
             )
         target_index[path] = last_writer
     return target_index

--- a/packages/weevr-core/src/weevr/engine/planner.py
+++ b/packages/weevr-core/src/weevr/engine/planner.py
@@ -143,6 +143,41 @@ def _build_explicit_index(
     return explicit_index
 
 
+def _upstream_closure(start: str, explicit_index: dict[str, list[str]]) -> set[str]:
+    """Return every thread reachable upstream from ``start`` via explicit deps."""
+    seen: set[str] = set()
+    stack = list(explicit_index.get(start, []))
+    while stack:
+        node = stack.pop()
+        if node in seen:
+            continue
+        seen.add(node)
+        stack.extend(explicit_index.get(node, []))
+    return seen
+
+
+def _resolve_writer_chain(
+    writers: list[str],
+    explicit_index: dict[str, list[str]],
+) -> str | None:
+    """Return the last writer if explicit dependencies totally order ``writers``.
+
+    Writers are totally ordered when every pair is comparable via the
+    transitive explicit-dependency relation (possibly through intermediate
+    threads) and exactly one writer sits downstream of all the others.
+    Returns ``None`` when the writers are not totally ordered.
+    """
+    closures = {w: _upstream_closure(w, explicit_index) for w in writers}
+    for i, a in enumerate(writers):
+        for b in writers[i + 1 :]:
+            if a not in closures[b] and b not in closures[a]:
+                return None
+    terminals = [w for w in writers if all(o in closures[w] for o in writers if o != w)]
+    if len(terminals) != 1:
+        return None
+    return terminals[0]
+
+
 def _build_target_index(
     threads: dict[str, Thread],
     explicit_index: dict[str, list[str]] | None = None,
@@ -153,14 +188,17 @@ def _build_target_index(
     Used by the dependency graph builder and lookup dependency inference to
     identify which thread produces a given data path.
 
-    A target written by two or more threads is rejected: the planner would
-    otherwise place the writers in one parallel group and race concurrent
-    writes against a single table.
+    A target written by two or more threads is rejected unless explicit
+    dependencies totally order the writers: unordered writers would land in
+    one parallel group and race concurrent writes against a single table.
+    For an ordered writer chain, the target resolves to the last writer, so
+    downstream consumers run after the target's final state exists.
 
     Args:
         threads: Mapping of thread name to Thread config.
         explicit_index: Explicit dependency index, used to check whether
             same-target writers are serialized by declared dependencies.
+            ``None`` means no explicit ordering exists.
         weave_name: Weave name for error messages.
 
     Returns:
@@ -168,7 +206,7 @@ def _build_target_index(
 
     Raises:
         ConfigError: If two or more threads write the same target without
-            explicit dependencies ordering them.
+            explicit dependencies totally ordering them.
     """
     writers_by_path: dict[str, list[str]] = {}
     for name, thread in threads.items():
@@ -180,7 +218,9 @@ def _build_target_index(
     for path, writers in writers_by_path.items():
         if len(writers) == 1:
             target_index[path] = writers[0]
-        else:
+            continue
+        last_writer = _resolve_writer_chain(writers, explicit_index or {})
+        if last_writer is None:
             names = ", ".join(f"'{n}'" for n in sorted(writers))
             in_weave = f" in weave '{weave_name}'" if weave_name else ""
             raise ConfigError(
@@ -189,6 +229,7 @@ def _build_target_index(
                 f"corrupt data. Declare explicit dependencies to serialize the "
                 f"writers, or give each thread its own target."
             )
+        target_index[path] = last_writer
     return target_index
 
 

--- a/tests/weevr/engine/test_planner.py
+++ b/tests/weevr/engine/test_planner.py
@@ -640,6 +640,94 @@ class TestDuplicateTargets:
         plan = build_plan("w", threads, _entries("A", "B"))
         assert plan.execution_order == [["A"], ["B"]]
 
+    def test_explicitly_ordered_pair_allowed(self):
+        """An explicit dependency serializing the writers makes the plan legal."""
+        threads = {
+            "load_jan": _make_thread("load_jan", target_alias="sales.monthly"),
+            "load_feb": _make_thread("load_feb", target_alias="sales.monthly"),
+        }
+        entries = [ThreadEntry(name="load_jan"), _entry_with_deps("load_feb", ["load_jan"])]
+        plan = build_plan("w", threads, entries)
+        assert plan.execution_order == [["load_jan"], ["load_feb"]]
+
+    def test_consumer_depends_on_last_writer(self):
+        """A downstream consumer of the shared target depends on the chain tail."""
+        threads = {
+            "load_jan": _make_thread("load_jan", target_alias="sales.monthly"),
+            "load_feb": _make_thread("load_feb", target_alias="sales.monthly"),
+            "report": _make_thread("report", source_aliases=["sales.monthly"]),
+        }
+        entries = [
+            ThreadEntry(name="load_jan"),
+            _entry_with_deps("load_feb", ["load_jan"]),
+            ThreadEntry(name="report"),
+        ]
+        plan = build_plan("w", threads, entries)
+        assert plan.inferred_dependencies["report"] == ["load_feb"]
+        assert plan.execution_order == [["load_jan"], ["load_feb"], ["report"]]
+
+    def test_three_writer_chain_allowed(self):
+        """A three-writer chain via explicit deps plans with the tail as producer."""
+        threads = {
+            "A": _make_thread("A", target_alias="dup_x"),
+            "B": _make_thread("B", target_alias="dup_x"),
+            "C": _make_thread("C", target_alias="dup_x"),
+            "reader": _make_thread("reader", source_aliases=["dup_x"]),
+        }
+        entries = [
+            ThreadEntry(name="A"),
+            _entry_with_deps("B", ["A"]),
+            _entry_with_deps("C", ["B"]),
+            ThreadEntry(name="reader"),
+        ]
+        plan = build_plan("w", threads, entries)
+        assert plan.inferred_dependencies["reader"] == ["C"]
+        assert plan.execution_order == [["A"], ["B"], ["C"], ["reader"]]
+
+    def test_chain_through_intermediate_thread_allowed(self):
+        """Ordering may pass transitively through a thread that writes elsewhere."""
+        threads = {
+            "A": _make_thread("A", target_alias="dup_x"),
+            "X": _make_thread("X", target_alias="out_x"),
+            "B": _make_thread("B", target_alias="dup_x"),
+        }
+        entries = [
+            ThreadEntry(name="A"),
+            _entry_with_deps("X", ["A"]),
+            _entry_with_deps("B", ["X"]),
+        ]
+        plan = build_plan("w", threads, entries)
+        assert plan.execution_order == [["A"], ["X"], ["B"]]
+
+    def test_partial_order_still_raises(self):
+        """Ordering only some of the writers is not enough — all must be chained."""
+        threads = {
+            "A": _make_thread("A", target_alias="dup_x"),
+            "B": _make_thread("B", target_alias="dup_x"),
+            "C": _make_thread("C", target_alias="dup_x"),
+        }
+        entries = [
+            ThreadEntry(name="A"),
+            _entry_with_deps("B", ["A"]),
+            ThreadEntry(name="C"),
+        ]
+        with pytest.raises(ConfigError) as exc_info:
+            build_plan("w", threads, entries)
+        message = str(exc_info.value)
+        assert "A" in message and "B" in message and "C" in message
+
+    def test_lookup_producer_resolves_to_last_writer(self):
+        """A lookup sourced from a duplicated target names the chain tail."""
+        threads = {
+            "load_jan": _make_thread("load_jan", target_alias="sales.monthly"),
+            "load_feb": _make_thread("load_feb", target_alias="sales.monthly"),
+        }
+        entries = [ThreadEntry(name="load_jan"), _entry_with_deps("load_feb", ["load_jan"])]
+        lookups = {"monthly": _make_lookup("sales.monthly")}
+        plan = build_plan("w", threads, entries, lookups=lookups)
+        assert plan.lookup_producers is not None
+        assert plan.lookup_producers["monthly"] == "load_feb"
+
 
 class TestExecutionPlanDisplay:
     """Tests for dag() and _repr_html_() on ExecutionPlan."""

--- a/tests/weevr/engine/test_planner.py
+++ b/tests/weevr/engine/test_planner.py
@@ -572,6 +572,75 @@ class TestLookupDependencyInference:
         assert plan.execution_order == [["A"], ["B"]]
 
 
+# ---------------------------------------------------------------------------
+# Duplicate-target detection tests
+# ---------------------------------------------------------------------------
+
+
+class TestDuplicateTargets:
+    """Two threads writing the same target must never race (GH #183)."""
+
+    def test_unordered_duplicate_alias_raises(self):
+        """Two no-dependency threads with the same target alias are rejected."""
+        threads = {
+            "load_jan": _make_thread("load_jan", target_alias="sales.monthly"),
+            "load_feb": _make_thread("load_feb", target_alias="sales.monthly"),
+        }
+        with pytest.raises(ConfigError, match=r"load_feb.*load_jan"):
+            build_plan("w", threads, _entries("load_jan", "load_feb"))
+
+    def test_error_names_target_weave_and_remediation(self):
+        """The error message carries the shared target, weave name, and guidance."""
+        threads = {
+            "load_jan": _make_thread("load_jan", target_alias="sales.monthly"),
+            "load_feb": _make_thread("load_feb", target_alias="sales.monthly"),
+        }
+        with pytest.raises(ConfigError) as exc_info:
+            build_plan("nightly", threads, _entries("load_jan", "load_feb"))
+        message = str(exc_info.value)
+        assert "sales.monthly" in message
+        assert "nightly" in message
+        assert "explicit dependencies" in message
+
+    def test_alias_vs_path_duplicate_raises(self):
+        """A target alias on one thread and an identical path on another collide."""
+        path_only_target = Thread.model_validate(
+            {
+                "name": "B",
+                "config_version": "1.0",
+                "sources": {"_default": {"type": "delta", "alias": "_default_src"}},
+                "target": {"path": "sales.monthly"},
+            }
+        )
+        threads = {
+            "A": _make_thread("A", target_alias="sales.monthly"),
+            "B": path_only_target,
+        }
+        with pytest.raises(ConfigError, match="sales.monthly"):
+            build_plan("w", threads, _entries("A", "B"))
+
+    def test_three_unordered_writers_all_named(self):
+        """Every writer of the shared target appears in the error message."""
+        threads = {
+            "A": _make_thread("A", target_alias="dup_x"),
+            "B": _make_thread("B", target_alias="dup_x"),
+            "C": _make_thread("C", target_alias="dup_x"),
+        }
+        with pytest.raises(ConfigError) as exc_info:
+            build_plan("w", threads, _entries("A", "B", "C"))
+        message = str(exc_info.value)
+        assert "A" in message and "B" in message and "C" in message
+
+    def test_distinct_targets_unaffected(self):
+        """Weaves without duplicate targets plan exactly as before."""
+        threads = {
+            "A": _make_thread("A", target_alias="out_a"),
+            "B": _make_thread("B", source_aliases=["out_a"], target_alias="out_b"),
+        }
+        plan = build_plan("w", threads, _entries("A", "B"))
+        assert plan.execution_order == [["A"], ["B"]]
+
+
 class TestExecutionPlanDisplay:
     """Tests for dag() and _repr_html_() on ExecutionPlan."""
 

--- a/tests/weevr/test_context.py
+++ b/tests/weevr/test_context.py
@@ -681,6 +681,26 @@ class TestValidateMode:
         assert result.status == "success"
         assert result.validation_errors is None
 
+    def test_validate_duplicate_target_threads(self, spark: SparkSession, tmp_path: Path) -> None:
+        """Two unordered threads writing one target fail validation, not execution."""
+        src = str(tmp_path / "src_dup")
+        tgt = str(tmp_path / "tgt_dup")
+        spark.createDataFrame([{"id": 1}]).write.format("delta").save(src)
+
+        project = _project_dir(tmp_path)
+        _create_thread_yaml(project, "load_jan", src, tgt)
+        _create_thread_yaml(project, "load_feb", src, tgt)
+        weave_yaml = _create_weave_yaml(project, "vdup", ["load_jan", "load_feb"])
+        ctx = Context(spark=spark, project=project)
+        result = ctx.run(weave_yaml, mode="validate")
+
+        assert result.status == "failure"
+        assert result.validation_errors is not None
+        assert any(
+            "load_jan" in e and "load_feb" in e and "DAG validation failed" in e
+            for e in result.validation_errors
+        )
+
     def test_validate_missing_source(self, spark: SparkSession, tmp_path: Path) -> None:
         tgt = str(tmp_path / "tgt_miss")
         yaml_path = _create_thread_yaml(tmp_path, "vmiss", "/nonexistent/path", tgt)


### PR DESCRIPTION
## Summary

- The execution planner now rejects a weave in which two or more threads write
  the same target without explicit dependencies ordering them, instead of
  fanning the writers out into one parallel group.
- Writers that *are* fully serialized by explicit dependencies remain legal:
  the target index resolves to the last writer in the chain, so downstream
  consumers and lookups deterministically depend on the target's final state.

Closes #183.

## Why

The plan DAG was built from data dependencies only. Two threads declaring the
same `target.alias` (or path) with no dependency between them landed in the
same execution group and ran concurrently against one Delta table — producing
`ConcurrentAppendException`, lost rows, and racing watermark
(`ALTER TABLE SET TBLPROPERTIES`) commits. The target index also collapsed the
duplicate silently, so a downstream consumer depended on only one of the
writers, non-deterministically.

## What changed

- `planner.py`: the explicit-dependency index is now built before the target
  index. Building the target index detects multi-writer targets; unordered
  writers raise a `ConfigError` naming the weave, the target, every writer,
  and the remediation. Writers totally ordered by explicit dependencies
  (transitively, including through intermediate threads) resolve the target to
  the unique terminal writer.
- Validate mode (`mode="validate"`) reports the violation in
  `validation_errors` rather than raising — locked with a Spark-backed
  regression test.
- New planner test suite covering the unordered rejection, alias-vs-path
  collisions, ordered chains, partial orders, consumer resolution, and
  lookup-producer resolution.
- Docs: the engine-internals planning pipeline documents the target-ownership
  rule; the execution-modes page mentions duplicate-target detection under
  validate.

## How to test

- [x] uv sync --dev
- [x] uv run ruff check .
- [x] uv run ruff format .
- [x] uv run pyright .
- [x] uv run pytest — 2522 passed; new suites:
      `tests/weevr/engine/test_planner.py::TestDuplicateTargets` (11 tests) and
      `tests/weevr/test_context.py::TestValidateMode::test_validate_duplicate_target_threads`
      (`-m spark`)

## Release / Versioning

- [x] PR title follows Conventional Commit format (feat:, fix:, chore:, docs:, ci:, etc.)
- [ ] Breaking change indicated (feat!: / fix!: or BREAKING CHANGE in body)

Not a breaking change — configs that now fail validation were racing concurrent
writes and corrupting data. Worth a release-notes callout: weaves with
unordered same-target threads fail plan/validate time after this change. The
previously documented workaround (declare an explicit dependency between the
writers) continues to work.

## Notes

- Detection is string-based on the normalized resolved target path, matching
  the existing dependency-inference behavior; it does not attempt physical
  identity resolution (e.g. an alias and an `abfss://` path pointing at the
  same table).
- Cross-run concurrency (two simultaneous loom runs) is a known separate issue
  and out of scope here.