### PR TITLE
fix(config): guard incremental_watermark against overwrite writes

### DIFF
--- a/docs/concepts/execution-modes.md
+++ b/docs/concepts/execution-modes.md
@@ -278,11 +278,19 @@ load:
   mode: incremental_watermark
   watermark_column: modified_date
   watermark_type: timestamp
+
+write:
+  mode: append
 ```
 
 On the first run, all rows are read (no prior watermark exists). On
 subsequent runs, only rows where `modified_date` exceeds the stored
 watermark are read.
+
+Watermark loads require an explicit `write.mode` of `append` or `merge`.
+The default (`overwrite`) is rejected at validation time: each run would
+replace the whole target with only the incremental slice, silently
+discarding all previously loaded history.
 
 The watermark is persisted in a configurable state store -- either as a
 Delta table property on the target or in a dedicated metadata table.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -112,12 +112,17 @@ load:
   mode: incremental_watermark
   watermark_column: modified_date
   watermark_type: timestamp
+
+write:
+  mode: append
 ```
 
 On the first run, all rows are read. On subsequent runs, weevr reads only
 rows where the watermark column exceeds the stored high-water mark. The
 watermark state is persisted either as a Delta table property or in a
-dedicated metadata table.
+dedicated metadata table. An explicit `write.mode` of `append` or `merge`
+is required — the `overwrite` default fails validation because it would
+replace the target with each incremental slice.
 
 Supported watermark types: `timestamp`, `date`, `int`, `long`.
 

--- a/packages/weevr-core/src/weevr/config/validation.py
+++ b/packages/weevr-core/src/weevr/config/validation.py
@@ -155,6 +155,9 @@ def validate_incremental_config(thread_config: dict[str, Any]) -> list[str]:
     - ``incremental_parameter`` mode should reference at least one ``${param.*}``
       variable in steps or sources (WARN if missing).
     - ``cdc`` mode requires ``write.mode: merge`` (ERROR if not).
+    - ``incremental_watermark`` mode with an effective ``write.mode: overwrite``
+      (explicit or defaulted) would replace the target with each incremental
+      slice (ERROR).
     - ``watermark_inclusive=True`` with ``write.mode: append`` is risky (WARN).
     """
     diagnostics: list[str] = []
@@ -183,6 +186,14 @@ def validate_incremental_config(thread_config: dict[str, Any]) -> list[str]:
 
     if mode == "cdc" and write_mode != "merge":
         diagnostics.append(f"ERROR: cdc mode requires write.mode='merge', got '{write_mode}'")
+
+    if mode == "incremental_watermark" and write_mode == "overwrite":
+        diagnostics.append(
+            "ERROR: incremental_watermark mode requires write.mode='append' or "
+            "'merge', got 'overwrite' (the default): each run would overwrite "
+            "the target with only the incremental slice, permanently losing "
+            "prior history"
+        )
 
     if load.get("watermark_inclusive") and write_mode == "append":
         diagnostics.append(

--- a/packages/weevr-core/src/weevr/config/validation.py
+++ b/packages/weevr-core/src/weevr/config/validation.py
@@ -188,11 +188,10 @@ def validate_incremental_config(thread_config: dict[str, Any]) -> list[str]:
         diagnostics.append(f"ERROR: cdc mode requires write.mode='merge', got '{write_mode}'")
 
     if mode == "incremental_watermark" and write_mode == "overwrite":
+        provenance = "" if "mode" in write else " (the default)"
         diagnostics.append(
             "ERROR: incremental_watermark mode requires write.mode='append' or "
-            "'merge', got 'overwrite' (the default): each run would overwrite "
-            "the target with only the incremental slice, permanently losing "
-            "prior history"
+            f"'merge', got 'overwrite'{provenance}"
         )
 
     if load.get("watermark_inclusive") and write_mode == "append":

--- a/tests/weevr/config/test_incremental_validation.py
+++ b/tests/weevr/config/test_incremental_validation.py
@@ -59,7 +59,10 @@ class TestValidateIncrementalConfig:
             "target": {"alias": "out"},
         }
         diags = validate_incremental_config(config)
-        assert any("ERROR" in d and "incremental_watermark" in d for d in diags)
+        errors = [d for d in diags if "ERROR" in d and "incremental_watermark" in d]
+        assert errors
+        # Explicitly configured overwrite must not be blamed on the default
+        assert all("(the default)" not in d for d in errors)
 
     def test_incremental_watermark_with_defaulted_overwrite_errors(self):
         """incremental_watermark with no write block (defaulted overwrite) produces error."""
@@ -69,7 +72,9 @@ class TestValidateIncrementalConfig:
             "target": {"alias": "out"},
         }
         diags = validate_incremental_config(config)
-        assert any("ERROR" in d and "incremental_watermark" in d for d in diags)
+        assert any(
+            "ERROR" in d and "incremental_watermark" in d and "(the default)" in d for d in diags
+        )
 
     def test_incremental_watermark_with_append_no_error(self):
         """incremental_watermark with write.mode=append produces no error."""

--- a/tests/weevr/config/test_incremental_validation.py
+++ b/tests/weevr/config/test_incremental_validation.py
@@ -50,6 +50,49 @@ class TestValidateIncrementalConfig:
         diags = validate_incremental_config(config)
         assert any("ERROR" in d and "cdc" in d and "merge" in d for d in diags)
 
+    def test_incremental_watermark_with_explicit_overwrite_errors(self):
+        """incremental_watermark with write.mode=overwrite produces error."""
+        config = {
+            "load": {"mode": "incremental_watermark", "watermark_column": "updated_at"},
+            "write": {"mode": "overwrite"},
+            "sources": {"src": {"type": "delta", "alias": "t"}},
+            "target": {"alias": "out"},
+        }
+        diags = validate_incremental_config(config)
+        assert any("ERROR" in d and "incremental_watermark" in d for d in diags)
+
+    def test_incremental_watermark_with_defaulted_overwrite_errors(self):
+        """incremental_watermark with no write block (defaulted overwrite) produces error."""
+        config = {
+            "load": {"mode": "incremental_watermark", "watermark_column": "updated_at"},
+            "sources": {"src": {"type": "delta", "alias": "t"}},
+            "target": {"alias": "out"},
+        }
+        diags = validate_incremental_config(config)
+        assert any("ERROR" in d and "incremental_watermark" in d for d in diags)
+
+    def test_incremental_watermark_with_append_no_error(self):
+        """incremental_watermark with write.mode=append produces no error."""
+        config = {
+            "load": {"mode": "incremental_watermark", "watermark_column": "updated_at"},
+            "write": {"mode": "append"},
+            "sources": {"src": {"type": "delta", "alias": "t"}},
+            "target": {"alias": "out"},
+        }
+        diags = validate_incremental_config(config)
+        assert not any("ERROR" in d for d in diags)
+
+    def test_incremental_watermark_with_merge_no_error(self):
+        """incremental_watermark with write.mode=merge produces no error."""
+        config = {
+            "load": {"mode": "incremental_watermark", "watermark_column": "updated_at"},
+            "write": {"mode": "merge", "match_keys": ["id"]},
+            "sources": {"src": {"type": "delta", "alias": "t"}},
+            "target": {"alias": "out"},
+        }
+        diags = validate_incremental_config(config)
+        assert not any("ERROR" in d for d in diags)
+
     def test_watermark_inclusive_with_append_warns(self):
         """watermark_inclusive=True with append produces warning."""
         config = {

--- a/tests/weevr/engine/test_watermark_integration.py
+++ b/tests/weevr/engine/test_watermark_integration.py
@@ -4,11 +4,12 @@ from typing import Literal
 from unittest.mock import MagicMock, patch
 
 import pytest
+from delta.tables import DeltaTable
 from pyspark.sql import SparkSession
 
 from spark_helpers import create_delta_table
 from weevr.engine.executor import execute_thread
-from weevr.errors.exceptions import StateError
+from weevr.errors.exceptions import ExecutionError, StateError
 from weevr.model.load import LoadConfig, WatermarkStoreConfig
 from weevr.model.source import Source
 from weevr.model.target import Target
@@ -28,7 +29,7 @@ def _make_watermark_thread(
     watermark_column: str = "ts",
     watermark_type: str = "int",
     watermark_inclusive: bool = False,
-    write_mode: Literal["overwrite", "append", "merge"] = "overwrite",
+    write_mode: Literal["overwrite", "append", "merge"] = "append",
 ) -> Thread:
     """Build a thread with incremental_watermark load config."""
     return Thread(
@@ -117,13 +118,13 @@ class TestWatermarkSecondRun:
         new_data = spark.createDataFrame([{"id": 3, "ts": 30}, {"id": 4, "ts": 40}])
         new_data.write.format("delta").mode("append").save(src)
 
-        # Second run: should only process ts > 20
+        # Second run: should only process ts > 20, appending to prior rows
         result = execute_thread(spark, thread)
 
         assert result.rows_written == 2
         written = spark.read.format("delta").load(tgt)
         ids = sorted([r["id"] for r in written.collect()])
-        assert ids == [3, 4]
+        assert ids == [1, 2, 3, 4]
 
     def test_second_run_telemetry_not_first_run(self, spark: SparkSession, tmp_delta_path) -> None:
         """Second run telemetry reports watermark_first_run=False."""
@@ -192,11 +193,13 @@ class TestWatermarkInclusive:
         thread = _make_watermark_thread("t1", src, tgt, wm, watermark_inclusive=True)
         execute_thread(spark, thread)
 
-        # Re-run without adding new data — HWM=20, filter ts >= 20 → 1 row
+        # Re-run without adding new data — HWM=20, filter ts >= 20 → 1 row,
+        # appended alongside the first run's boundary row (the duplicate the
+        # inclusive+append WARN exists to call out)
         result = execute_thread(spark, thread)
         assert result.rows_written == 1
         written = spark.read.format("delta").load(tgt)
-        assert written.collect()[0]["ts"] == 20
+        assert sorted(r["ts"] for r in written.collect()) == [10, 20, 20]
 
 
 class TestWatermarkHwmFromSource:
@@ -230,7 +233,7 @@ class TestWatermarkHwmFromSource:
             sources={"main": Source(type="delta", alias=src)},
             steps=[FilterStep(filter=FilterParams(expr=SparkExpr("keep = true")))],
             target=Target(path=tgt),
-            write=WriteConfig(mode="overwrite"),
+            write=WriteConfig(mode="append"),
             load=LoadConfig(
                 mode="incremental_watermark",
                 watermark_column="ts",
@@ -252,6 +255,25 @@ class TestWatermarkHwmFromSource:
         state = store.read(spark, "t1")
         assert state is not None
         assert state.last_value == "30"
+
+
+class TestWatermarkOverwriteRejected:
+    """incremental_watermark + overwrite fails fast at executor entry."""
+
+    def test_overwrite_write_mode_raises_before_any_write(
+        self, spark: SparkSession, tmp_delta_path
+    ) -> None:
+        """The destructive combination raises ExecutionError; no target is created."""
+        src = tmp_delta_path("wm_ow_src")
+        tgt = tmp_delta_path("wm_ow_tgt")
+        wm = tmp_delta_path("wm_ow_store")
+        create_delta_table(spark, src, [{"id": 1, "ts": 10}])
+
+        thread = _make_watermark_thread("t1", src, tgt, wm, write_mode="overwrite")
+        with pytest.raises(ExecutionError, match="incremental_watermark"):
+            execute_thread(spark, thread)
+
+        assert not DeltaTable.isDeltaTable(spark, tgt)
 
 
 class TestWatermarkPersistenceFailure:


### PR DESCRIPTION
## Summary

- Validation now rejects `load.mode: incremental_watermark` combined with an
  effective `write.mode` of `overwrite` — whether declared explicitly or
  arrived at via the default. The error states the accepted modes and, when
  the write mode was omitted, that the default is what triggered it.
- The docs examples that demonstrated the destructive combination
  (execution-modes walkthrough, FAQ) now declare `write: {mode: append}` and
  explain the requirement.

Closes #184.

## Why

A thread with `load.mode: incremental_watermark` and no `write:` block
defaulted to `overwrite`. Run 1 writes everything; run 2 reads only the rows
past the stored high-water mark and overwrites the whole target with that
incremental slice — history permanently and silently lost. The validator
already guarded `cdc` + non-merge with an ERROR but never extended the same
reasoning to watermark loads, and the docs walkthrough showed exactly the
destructive config.

## What changed

- `validate_incremental_config` gains an ERROR rule beside the CDC guard:
  `incremental_watermark` requires `write.mode` of `append` or `merge`. The
  existing executor-entry wiring turns the diagnostic into a fail-fast
  `ExecutionError` before any read or write — no executor changes needed.
- New unit tests: explicit overwrite, defaulted overwrite (no `write:`
  block), and append/merge pass-through, with per-case message wording
  pinned.
- The watermark integration suite previously built its test threads on the
  destructive default; fixtures now use `append`, with two assertions
  updated to append semantics (the second-run target accumulates rows; the
  inclusive-boundary test asserts the appended duplicate the existing
  inclusive+append warning describes). A new test locks that the rejected
  combination raises at executor entry with no target table created.
- Docs: `concepts/execution-modes.md` and `faq.md` examples declare
  `write: {mode: append}` with a sentence on why overwrite is rejected.

## How to test

- [x] uv sync --dev
- [x] uv run ruff check .
- [x] uv run ruff format .
- [x] uv run pyright .
- [x] uv run pytest — 2526 passed; spark suite:
      `uv run pytest tests/weevr/engine/test_watermark_integration.py -m spark`
      → 12 passed

## Release / Versioning

- [x] PR title follows Conventional Commit format (feat:, fix:, chore:, docs:, ci:, etc.)
- [ ] Breaking change indicated (feat!: / fix!: or BREAKING CHANGE in body)

Not a breaking change — every configuration this rejects was silently
destroying history on each run. Worth a release-notes callout: watermark
loads now require an explicit `write.mode` of `append` or `merge`; add a
`write:` block to affected threads before upgrading.

## Notes

- `incremental_parameter` + overwrite is intentionally not guarded: ranges
  are caller-managed and overwriting can be legitimate there (e.g.
  partition-style reloads).
- Boundary-row dedup semantics for inclusive watermarks are a separate known
  finding and unchanged here.