### PR TITLE
fix(operations): merge CDC change windows to latest state per key

### DIFF
--- a/docs/concepts/execution-modes.md
+++ b/docs/concepts/execution-modes.md
@@ -343,19 +343,30 @@ load:
     insert_value: "I"
     update_value: "U"
     delete_value: "D"
-  # Optional: compose with a watermark column to narrow reads on
-  # append-only history tables (see below).
-  # watermark_column: updated_at
-  # watermark_type: timestamp
+  # Required for update/delete mappings: the column that orders
+  # same-key changes.
+  watermark_column: updated_at
+  watermark_type: timestamp
 ```
 
-The explicit path may be combined with `watermark_column` and
-`watermark_type` to narrow the read window for append-only CDC history
+An explicit mapping that declares `update_value` or `delete_value` must
+also declare `watermark_column` — it is the ordering signal that decides
+which change wins when one key changes more than once in a window.
+Insert-only mappings (event feeds) have no same-key collisions and need
+no watermark. The `delta_cdf` preset orders by commit version natively
+and rejects `watermark_column`.
+
+The watermark also narrows the read window for append-only CDC history
 tables — for example, SAP data landed by Fabric Open Database Mirror,
 where every change row carries a change timestamp like `AEDATTM`. Without
-the watermark, weevr re-reads the full history on every run. The
-`delta_cdf` preset tracks progress via commit versions and rejects
-`watermark_column`.
+it, weevr would re-read the full history on every run.
+
+Before merging, weevr reduces each change window to the latest state per
+key: the `delta_cdf` preset orders changes by commit version; explicit
+mappings order by the watermark column. Ties at the same position resolve
+by operation precedence — a delete outranks an update, which outranks an
+insert — so a key that changes many times between runs merges cleanly to
+its final state.
 
 ### String-typed watermark columns (`watermark_format`)
 
@@ -415,8 +426,9 @@ no functional benefit and would defeat file skipping.
 | Full snapshot refresh | `full` | `overwrite` |
 | Accumulating event log | `incremental_watermark` | `append` |
 | Dimension table with updates | `full` or `incremental_watermark` | `merge` |
-| CDC from upstream system | `cdc` | `merge` |
-| CDC from append-only history table | `cdc` + `watermark_column` | `merge` |
+| CDC from upstream system | `cdc` + `watermark_column` | `merge` |
+| CDC insert-only event feed | `cdc` (insert mapping only) | `merge` |
+| CDC via Delta Change Data Feed | `cdc` (`preset: delta_cdf`) | `merge` |
 | Externally bounded batch | `incremental_parameter` | `append` or `merge` |
 
 ## Next steps

--- a/docs/concepts/execution-modes.md
+++ b/docs/concepts/execution-modes.md
@@ -368,6 +368,10 @@ by operation precedence — a delete outranks an update, which outranks an
 insert — so a key that changes many times between runs merges cleanly to
 its final state.
 
+A change row whose ordering value is NULL (or unparseable under
+`watermark_format`) fails the merge with a clear error: a change that
+cannot be placed in the sequence cannot be merged safely.
+
 ### String-typed watermark columns (`watermark_format`)
 
 When a source lands the watermark column as a string rather than a native

--- a/docs/reference/configuration-keys.md
+++ b/docs/reference/configuration-keys.md
@@ -275,7 +275,7 @@ Incremental load mode and watermark tracking.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `mode` | `"full" \| "incremental_watermark" \| "incremental_parameter" \| "cdc"` | `"full"` | Load strategy |
-| `watermark_column` | `str` | `None` | Column for watermark comparison. Required for `incremental_watermark`; optional for `cdc` mode when `cdc.operation_column` is set (rejected when `cdc.preset` is `"delta_cdf"`). |
+| `watermark_column` | `str` | `None` | Column for watermark comparison. Required for `incremental_watermark`; required for generic `cdc` mappings that declare `update_value` or `delete_value` (orders same-key changes; insert-only mappings exempt); rejected when `cdc.preset` is `"delta_cdf"`. |
 | `watermark_type` | `"timestamp" \| "date" \| "int" \| "long"` | `None` | Watermark column data type. Required whenever `watermark_column` is set. |
 | `watermark_inclusive` | `bool` | `False` | Include rows equal to last watermark |
 | `watermark_store` | `WatermarkStoreConfig` | `None` | Watermark persistence backend |

--- a/packages/weevr-core/src/weevr/config/validation.py
+++ b/packages/weevr-core/src/weevr/config/validation.py
@@ -155,6 +155,10 @@ def validate_incremental_config(thread_config: dict[str, Any]) -> list[str]:
     - ``incremental_parameter`` mode should reference at least one ``${param.*}``
       variable in steps or sources (WARN if missing).
     - ``cdc`` mode requires ``write.mode: merge`` (ERROR if not).
+    - ``cdc`` mode with an explicit mapping declaring ``update_value`` or
+      ``delete_value`` requires ``watermark_column`` — same-key changes have
+      no defined order without it (ERROR). Insert-only mappings and the
+      ``delta_cdf`` preset are exempt.
     - ``incremental_watermark`` mode with an effective ``write.mode: overwrite``
       (explicit or defaulted) would replace the target with each incremental
       slice (ERROR).
@@ -186,6 +190,16 @@ def validate_incremental_config(thread_config: dict[str, Any]) -> list[str]:
 
     if mode == "cdc" and write_mode != "merge":
         diagnostics.append(f"ERROR: cdc mode requires write.mode='merge', got '{write_mode}'")
+
+    if mode == "cdc":
+        cdc = load.get("cdc") or {}
+        is_generic = cdc.get("operation_column") is not None
+        has_collision_ops = cdc.get("update_value") or cdc.get("delete_value")
+        if is_generic and has_collision_ops and not load.get("watermark_column"):
+            diagnostics.append(
+                "ERROR: cdc mode with update_value/delete_value requires "
+                "load.watermark_column to order same-key changes"
+            )
 
     if mode == "incremental_watermark" and write_mode == "overwrite":
         provenance = "" if "mode" in write else " (the default)"

--- a/packages/weevr/src/weevr/engine/executor.py
+++ b/packages/weevr/src/weevr/engine/executor.py
@@ -563,7 +563,9 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
                 with contextlib.suppress(Exception):
                     output_sample = df.limit(10).toPandas().to_dict("records")
                 cdc_write = _validate_cdc_write_config(thread)
-                cdc_counts = execute_cdc_merge(spark, df, target_path, cdc_write, thread.load.cdc)
+                cdc_counts = execute_cdc_merge(
+                    spark, df, target_path, cdc_write, thread.load.cdc, load_config=thread.load
+                )
                 rows_written = sum(cdc_counts.values())
 
             else:

--- a/packages/weevr/src/weevr/engine/executor.py
+++ b/packages/weevr/src/weevr/engine/executor.py
@@ -1002,7 +1002,13 @@ def _validate_incremental(thread: Thread, load_mode: str) -> None:
     """Run cross-cutting incremental config validation at executor entry."""
     from weevr.config.validation import validate_incremental_config
 
-    raw = {"load": {"mode": load_mode}}
+    load_raw: dict[str, object] = {"mode": load_mode}
+    if thread.load is not None:
+        if thread.load.watermark_column is not None:
+            load_raw["watermark_column"] = thread.load.watermark_column
+        if thread.load.cdc is not None:
+            load_raw["cdc"] = thread.load.cdc.model_dump()
+    raw: dict[str, object] = {"load": load_raw}
     if thread.write is not None:
         raw["write"] = {"mode": thread.write.mode}
     diagnostics = validate_incremental_config(raw)

--- a/packages/weevr/src/weevr/engine/executor.py
+++ b/packages/weevr/src/weevr/engine/executor.py
@@ -1006,6 +1006,7 @@ def _validate_incremental(thread: Thread, load_mode: str) -> None:
 
     load_raw: dict[str, object] = {"mode": load_mode}
     if thread.load is not None:
+        load_raw["watermark_inclusive"] = thread.load.watermark_inclusive
         if thread.load.watermark_column is not None:
             load_raw["watermark_column"] = thread.load.watermark_column
         if thread.load.cdc is not None:

--- a/packages/weevr/src/weevr/operations/readers.py
+++ b/packages/weevr/src/weevr/operations/readers.py
@@ -205,7 +205,7 @@ def _parse_order_col(order_by: str):  # type: ignore[return]
     return col.desc() if direction == "DESC" else col.asc()
 
 
-def _typed_watermark_col(
+def typed_watermark_col(
     watermark_column: str,
     watermark_type: str | None,
     watermark_format: str | None,
@@ -255,7 +255,7 @@ def build_watermark_filter(
     Returns:
         A Spark Column expression suitable for ``df.filter()``.
     """
-    typed = _typed_watermark_col(watermark_column, watermark_type, watermark_format)
+    typed = typed_watermark_col(watermark_column, watermark_type, watermark_format)
     if watermark_type in ("timestamp", "date"):
         lit_val = F.lit(last_value).cast(watermark_type)
     elif watermark_type == "long":
@@ -312,7 +312,7 @@ def read_source_incremental(
     # Capture HWM before dedup (from filtered source)
     new_hwm: str | None = None
     if load_config.watermark_column is not None:
-        typed = _typed_watermark_col(
+        typed = typed_watermark_col(
             load_config.watermark_column,
             load_config.watermark_type,
             load_config.watermark_format,
@@ -420,7 +420,7 @@ def read_cdc_source(
     # so D rows still advance the window (DEC-003).
     new_hwm: str | None = None
     if load_config is not None and load_config.watermark_column is not None:
-        typed = _typed_watermark_col(
+        typed = typed_watermark_col(
             load_config.watermark_column,
             load_config.watermark_type,
             load_config.watermark_format,

--- a/packages/weevr/src/weevr/operations/writers.py
+++ b/packages/weevr/src/weevr/operations/writers.py
@@ -245,6 +245,21 @@ def resolve_cdc_columns(cdc_config: CdcConfig) -> dict[str, str | None]:
     }
 
 
+def _require_non_null_ordering(df: DataFrame, ordering: Column, column_name: str) -> None:
+    """Raise when the CDC ordering column is NULL anywhere in the change window.
+
+    A NULL (or, for formatted watermarks, unparseable) ordering value cannot
+    be placed in the change sequence — ranking it silently as oldest or
+    newest risks keeping a stale row, so the merge fails fast instead.
+    """
+    if df.filter(ordering.isNull()).limit(1).count() > 0:
+        raise ExecutionError(
+            f"CDC ordering column '{column_name}' contains NULL (or unparseable) "
+            f"values in the change window; every change row must carry a valid "
+            f"ordering value"
+        )
+
+
 def _reduce_to_latest_per_key(
     df: DataFrame,
     match_keys: list[str],
@@ -258,7 +273,9 @@ def _reduce_to_latest_per_key(
     with the operation type as the final tiebreaker — later entries in
     ``op_precedence`` outrank earlier ones (e.g. a delete outranks an update
     from the same commit). Rows whose ordering and operation all tie are
-    indistinguishable; an arbitrary representative is kept.
+    indistinguishable; an arbitrary representative is kept. Callers must
+    reject NULL ordering values first (``_require_non_null_ordering``) —
+    an unordered change row cannot be ranked safely.
     """
     precedence: Column = F.lit(0)
     for rank, value in enumerate(op_precedence, start=1):
@@ -349,6 +366,7 @@ def execute_cdc_merge(
                 "Delta CDF merge requires the '_commit_version' column to order "
                 "same-key changes; do not drop CDF metadata columns in pipeline steps"
             )
+        _require_non_null_ordering(df, F.col("_commit_version"), "_commit_version")
         df = _reduce_to_latest_per_key(
             df,
             write_config.match_keys,
@@ -366,6 +384,7 @@ def execute_cdc_merge(
             load_config.watermark_type,
             load_config.watermark_format,
         )
+        _require_non_null_ordering(df, ordering, load_config.watermark_column)
         df = _reduce_to_latest_per_key(
             df,
             write_config.match_keys,
@@ -378,13 +397,16 @@ def execute_cdc_merge(
     target_exists = delta_table_exists(spark, target_path)
 
     try:
-        # Count operations
+        # Count operations in a single pass over the (reduced) window
+        op_counts: dict[str, int] = {
+            row[0]: row[1] for row in df.groupBy(F.col(op_col)).count().collect()
+        }
         if insert_val:
-            counts["inserts"] = df.filter(F.col(op_col) == insert_val).count()
+            counts["inserts"] = op_counts.get(insert_val, 0)
         if update_val:
-            counts["updates"] = df.filter(F.col(op_col) == update_val).count()
+            counts["updates"] = op_counts.get(update_val, 0)
         if delete_val:
-            counts["deletes"] = df.filter(F.col(op_col) == delete_val).count()
+            counts["deletes"] = op_counts.get(delete_val, 0)
 
         if not target_exists:
             # First CDC write — insert all non-delete rows

--- a/packages/weevr/src/weevr/operations/writers.py
+++ b/packages/weevr/src/weevr/operations/writers.py
@@ -8,9 +8,10 @@ from pyspark.sql.window import Window
 
 from weevr.delta import delta_table_exists, is_table_alias, resolve_delta_table
 from weevr.errors.exceptions import ExecutionError
-from weevr.model.load import CdcConfig
+from weevr.model.load import CdcConfig, LoadConfig
 from weevr.model.target import Target
 from weevr.model.write import WriteConfig
+from weevr.operations.readers import typed_watermark_col
 
 
 def quote_identifier(name: str) -> str:
@@ -279,11 +280,19 @@ def execute_cdc_merge(
     target_path: str,
     write_config: WriteConfig,
     cdc_config: CdcConfig,
+    *,
+    load_config: LoadConfig | None = None,
 ) -> dict[str, int]:
     """Execute a CDC merge operation, routing rows by operation type.
 
     Rows are classified by the ``operation_column`` and merged against
     the target table using the ``match_keys`` from ``write_config``.
+
+    Before counting and merging, the change window is reduced to the
+    latest state per key: the CDF preset orders by ``_commit_version``;
+    generic CDC orders by the watermark column carried on ``load_config``.
+    A generic mapping without a watermark column (insert-only feeds) is
+    not reduced — every row is treated as an event.
 
     Args:
         spark: Active SparkSession.
@@ -291,6 +300,8 @@ def execute_cdc_merge(
         target_path: Path to the Delta target table.
         write_config: Write configuration (must be merge mode with match_keys).
         cdc_config: CDC configuration (preset or explicit mapping).
+        load_config: Thread-level load configuration; supplies the
+            watermark ordering for generic CDC reduction.
 
     Returns:
         Dict with counts: ``{"inserts": N, "updates": N, "deletes": N}``.
@@ -344,6 +355,23 @@ def execute_cdc_merge(
             op_col,
             op_precedence,
             [F.col("_commit_version")],
+        )
+    elif (
+        load_config is not None
+        and load_config.watermark_column is not None
+        and load_config.watermark_type is not None
+    ):
+        ordering = typed_watermark_col(
+            load_config.watermark_column,
+            load_config.watermark_type,
+            load_config.watermark_format,
+        )
+        df = _reduce_to_latest_per_key(
+            df,
+            write_config.match_keys,
+            op_col,
+            op_precedence,
+            [ordering],
         )
 
     counts: dict[str, int] = {"inserts": 0, "updates": 0, "deletes": 0}

--- a/packages/weevr/src/weevr/operations/writers.py
+++ b/packages/weevr/src/weevr/operations/writers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pyspark.sql import Column, DataFrame, SparkSession
 from pyspark.sql import functions as F
+from pyspark.sql.window import Window
 
 from weevr.delta import delta_table_exists, is_table_alias, resolve_delta_table
 from weevr.errors.exceptions import ExecutionError
@@ -243,6 +244,35 @@ def resolve_cdc_columns(cdc_config: CdcConfig) -> dict[str, str | None]:
     }
 
 
+def _reduce_to_latest_per_key(
+    df: DataFrame,
+    match_keys: list[str],
+    op_col: str,
+    op_precedence: list[str],
+    ordering_cols: list[Column],
+) -> DataFrame:
+    """Reduce a CDC change window to one row per key: the latest state.
+
+    Rows are ranked per match-key group by the ordering columns (descending),
+    with the operation type as the final tiebreaker — later entries in
+    ``op_precedence`` outrank earlier ones (e.g. a delete outranks an update
+    from the same commit). Rows whose ordering and operation all tie are
+    indistinguishable; an arbitrary representative is kept.
+    """
+    precedence: Column = F.lit(0)
+    for rank, value in enumerate(op_precedence, start=1):
+        precedence = F.when(F.col(op_col) == value, F.lit(rank)).otherwise(precedence)
+
+    window = Window.partitionBy(*match_keys).orderBy(
+        *[c.desc() for c in ordering_cols], precedence.desc()
+    )
+    return (
+        df.withColumn("__cdc_rn__", F.row_number().over(window))
+        .filter(F.col("__cdc_rn__") == 1)
+        .drop("__cdc_rn__")
+    )
+
+
 def execute_cdc_merge(
     spark: SparkSession,
     df: DataFrame,
@@ -295,6 +325,26 @@ def execute_cdc_merge(
     recognized_ops = [v for v in (insert_val, update_val, delete_val) if v]
     if recognized_ops:
         df = df.filter(F.col(op_col).isin(recognized_ops))
+
+    # Reduce the window to the latest state per key — Delta MERGE rejects
+    # multiple source rows matching one target row, and a key changing more
+    # than once per window is the normal CDF/OLTP case. Operation precedence
+    # (insert < update < delete) breaks same-position ties: the terminal
+    # state wins.
+    op_precedence = [v for v in (insert_val, update_val, delete_val) if v]
+    if cdc_config.preset == "delta_cdf":
+        if "_commit_version" not in df.columns:
+            raise ExecutionError(
+                "Delta CDF merge requires the '_commit_version' column to order "
+                "same-key changes; do not drop CDF metadata columns in pipeline steps"
+            )
+        df = _reduce_to_latest_per_key(
+            df,
+            write_config.match_keys,
+            op_col,
+            op_precedence,
+            [F.col("_commit_version")],
+        )
 
     counts: dict[str, int] = {"inserts": 0, "updates": 0, "deletes": 0}
     target_exists = delta_table_exists(spark, target_path)

--- a/tests/weevr/config/test_incremental_validation.py
+++ b/tests/weevr/config/test_incremental_validation.py
@@ -98,6 +98,75 @@ class TestValidateIncrementalConfig:
         diags = validate_incremental_config(config)
         assert not any("ERROR" in d for d in diags)
 
+    def test_cdc_update_value_without_watermark_errors(self):
+        """Generic CDC with update_value but no watermark_column produces error."""
+        config = {
+            "load": {
+                "mode": "cdc",
+                "cdc": {"operation_column": "op", "insert_value": "I", "update_value": "U"},
+            },
+            "write": {"mode": "merge", "match_keys": ["id"]},
+            "sources": {"src": {"type": "delta", "alias": "t"}},
+            "target": {"alias": "out"},
+        }
+        diags = validate_incremental_config(config)
+        assert any("ERROR" in d and "watermark_column" in d for d in diags)
+
+    def test_cdc_delete_value_without_watermark_errors(self):
+        """Generic CDC with delete_value but no watermark_column produces error."""
+        config = {
+            "load": {
+                "mode": "cdc",
+                "cdc": {"operation_column": "op", "insert_value": "I", "delete_value": "D"},
+            },
+            "write": {"mode": "merge", "match_keys": ["id"]},
+            "sources": {"src": {"type": "delta", "alias": "t"}},
+            "target": {"alias": "out"},
+        }
+        diags = validate_incremental_config(config)
+        assert any("ERROR" in d and "watermark_column" in d for d in diags)
+
+    def test_cdc_insert_only_without_watermark_no_error(self):
+        """Insert-only generic CDC needs no ordering column."""
+        config = {
+            "load": {
+                "mode": "cdc",
+                "cdc": {"operation_column": "op", "insert_value": "I"},
+            },
+            "write": {"mode": "merge", "match_keys": ["id"]},
+            "sources": {"src": {"type": "delta", "alias": "t"}},
+            "target": {"alias": "out"},
+        }
+        diags = validate_incremental_config(config)
+        assert not any("ERROR" in d and "watermark_column" in d for d in diags)
+
+    def test_cdc_update_value_with_watermark_no_error(self):
+        """Generic CDC with update_value and a watermark_column passes."""
+        config = {
+            "load": {
+                "mode": "cdc",
+                "watermark_column": "updated_at",
+                "watermark_type": "timestamp",
+                "cdc": {"operation_column": "op", "insert_value": "I", "update_value": "U"},
+            },
+            "write": {"mode": "merge", "match_keys": ["id"]},
+            "sources": {"src": {"type": "delta", "alias": "t"}},
+            "target": {"alias": "out"},
+        }
+        diags = validate_incremental_config(config)
+        assert not any("ERROR" in d and "watermark_column" in d for d in diags)
+
+    def test_cdc_cdf_preset_without_watermark_no_error(self):
+        """The delta_cdf preset orders by commit version; no watermark needed."""
+        config = {
+            "load": {"mode": "cdc", "cdc": {"preset": "delta_cdf"}},
+            "write": {"mode": "merge", "match_keys": ["id"]},
+            "sources": {"src": {"type": "delta", "alias": "t"}},
+            "target": {"alias": "out"},
+        }
+        diags = validate_incremental_config(config)
+        assert not any("ERROR" in d and "watermark_column" in d for d in diags)
+
     def test_watermark_inclusive_with_append_warns(self):
         """watermark_inclusive=True with append produces warning."""
         config = {

--- a/tests/weevr/engine/test_cdc_integration.py
+++ b/tests/weevr/engine/test_cdc_integration.py
@@ -302,6 +302,132 @@ class TestCdcInsertOnly:
         assert result.count() == 2
 
 
+class TestCdcMultiChangeWindowGeneric:
+    """Generic CDC windows with multiple changes per key reduce by watermark order."""
+
+    @staticmethod
+    def _config() -> tuple[CdcConfig, WriteConfig, LoadConfig]:
+        cdc_config = CdcConfig(
+            operation_column="op",
+            insert_value="I",
+            update_value="U",
+            delete_value="D",
+            on_delete="hard_delete",
+        )
+        write_config = WriteConfig(mode="merge", match_keys=["id"])
+        load_config = LoadConfig(
+            mode="cdc",
+            cdc=cdc_config,
+            watermark_column="seq",
+            watermark_type="int",
+        )
+        return cdc_config, write_config, load_config
+
+    def test_reverse_order_updates_latest_watermark_wins(
+        self, spark: SparkSession, tmp_delta_path
+    ) -> None:
+        """The row with the greater watermark wins regardless of DataFrame order."""
+        tgt = tmp_delta_path("gen_mc_tgt")
+        create_delta_table(spark, tgt, [{"id": 1, "name": "Alice", "seq": 0}])
+
+        cdc_df = spark.createDataFrame(
+            [
+                {"id": 1, "name": "Cara", "op": "U", "seq": 2},
+                {"id": 1, "name": "Bea", "op": "U", "seq": 1},
+            ]
+        )
+        cdc_config, write_config, load_config = self._config()
+
+        counts = execute_cdc_merge(
+            spark, cdc_df, tgt, write_config, cdc_config, load_config=load_config
+        )
+
+        assert counts["updates"] == 1
+        result = spark.read.format("delta").load(tgt)
+        assert result.collect()[0]["name"] == "Cara"
+
+    def test_delete_first_in_frame_still_terminal(
+        self, spark: SparkSession, tmp_delta_path
+    ) -> None:
+        """update then delete (by watermark) removes the row even when the
+        delete row appears first in the DataFrame."""
+        tgt = tmp_delta_path("gen_ud_tgt")
+        create_delta_table(
+            spark, tgt, [{"id": 1, "name": "Alice", "seq": 0}, {"id": 2, "name": "Bob", "seq": 0}]
+        )
+
+        cdc_df = spark.createDataFrame(
+            [
+                {"id": 1, "name": "Bea", "op": "D", "seq": 2},
+                {"id": 1, "name": "Bea", "op": "U", "seq": 1},
+            ]
+        )
+        cdc_config, write_config, load_config = self._config()
+
+        execute_cdc_merge(spark, cdc_df, tgt, write_config, cdc_config, load_config=load_config)
+
+        result = spark.read.format("delta").load(tgt)
+        assert {r["id"] for r in result.collect()} == {2}
+
+    def test_watermark_tie_delete_wins(self, spark: SparkSession, tmp_delta_path) -> None:
+        """Equal watermark values resolve by op precedence: delete is terminal."""
+        tgt = tmp_delta_path("gen_tie_tgt")
+        create_delta_table(spark, tgt, [{"id": 1, "name": "Alice", "seq": 0}])
+
+        cdc_df = spark.createDataFrame(
+            [
+                {"id": 1, "name": "Bea", "op": "U", "seq": 5},
+                {"id": 1, "name": "Bea", "op": "D", "seq": 5},
+            ]
+        )
+        cdc_config, write_config, load_config = self._config()
+
+        execute_cdc_merge(spark, cdc_df, tgt, write_config, cdc_config, load_config=load_config)
+
+        result = spark.read.format("delta").load(tgt)
+        assert result.count() == 0
+
+    def test_first_write_reduces_to_one_row_per_key(
+        self, spark: SparkSession, tmp_delta_path
+    ) -> None:
+        """First write of a multi-change window creates one row per key at final state."""
+        tgt = tmp_delta_path("gen_fw_tgt")
+
+        cdc_df = spark.createDataFrame(
+            [
+                {"id": 1, "name": "A", "op": "I", "seq": 1},
+                {"id": 1, "name": "B", "op": "U", "seq": 2},
+            ]
+        )
+        cdc_config, write_config, load_config = self._config()
+
+        execute_cdc_merge(spark, cdc_df, tgt, write_config, cdc_config, load_config=load_config)
+
+        result = spark.read.format("delta").load(tgt)
+        rows = {r["id"]: r["name"] for r in result.collect()}
+        assert rows == {1: "B"}
+
+    def test_insert_only_feed_not_reduced(self, spark: SparkSession, tmp_delta_path) -> None:
+        """Without an ordering column, insert-only feeds keep appending every event."""
+        tgt = tmp_delta_path("gen_insonly_tgt")
+        create_delta_table(spark, tgt, [{"id": 1, "val": "a"}])
+
+        cdc_df = spark.createDataFrame(
+            [
+                {"id": 2, "val": "b", "op": "I"},
+                {"id": 2, "val": "b2", "op": "I"},
+            ]
+        )
+        cdc_config = CdcConfig(operation_column="op", insert_value="I")
+        write_config = WriteConfig(mode="merge", match_keys=["id"])
+
+        counts = execute_cdc_merge(spark, cdc_df, tgt, write_config, cdc_config)
+
+        assert counts["inserts"] == 2
+        result = spark.read.format("delta").load(tgt)
+        assert result.count() == 3
+
+
 class TestCdcDeltaCdf:
     """CDC with Delta Change Data Feed preset."""
 

--- a/tests/weevr/engine/test_cdc_integration.py
+++ b/tests/weevr/engine/test_cdc_integration.py
@@ -407,6 +407,98 @@ class TestCdcMultiChangeWindowGeneric:
         rows = {r["id"]: r["name"] for r in result.collect()}
         assert rows == {1: "B"}
 
+    def test_null_watermark_row_raises(self, spark: SparkSession, tmp_delta_path) -> None:
+        """A NULL ordering value in the window fails loudly instead of mis-ranking."""
+        from weevr.errors.exceptions import ExecutionError
+
+        tgt = tmp_delta_path("gen_null_tgt")
+        create_delta_table(spark, tgt, [{"id": 1, "name": "Alice", "seq": 0}])
+
+        cdc_df = spark.createDataFrame(
+            [(1, "Bea", "U", 1), (1, "Cara", "U", None)],
+            "id INT, name STRING, op STRING, seq INT",
+        )
+        cdc_config, write_config, load_config = self._config()
+
+        with pytest.raises(ExecutionError, match="seq"):
+            execute_cdc_merge(spark, cdc_df, tgt, write_config, cdc_config, load_config=load_config)
+
+    def test_composite_match_keys_reduce_independently(
+        self, spark: SparkSession, tmp_delta_path
+    ) -> None:
+        """Reduction partitions by the full composite key, not a prefix of it."""
+        tgt = tmp_delta_path("gen_comp_tgt")
+        create_delta_table(
+            spark,
+            tgt,
+            [
+                {"id": 1, "region": "east", "name": "A", "seq": 0},
+                {"id": 1, "region": "west", "name": "B", "seq": 0},
+            ],
+        )
+
+        cdc_df = spark.createDataFrame(
+            [
+                {"id": 1, "region": "east", "name": "A2", "op": "U", "seq": 2},
+                {"id": 1, "region": "east", "name": "A1", "op": "U", "seq": 1},
+                {"id": 1, "region": "west", "name": "B1", "op": "U", "seq": 1},
+            ]
+        )
+        cdc_config = CdcConfig(
+            operation_column="op",
+            insert_value="I",
+            update_value="U",
+            delete_value="D",
+            on_delete="hard_delete",
+        )
+        write_config = WriteConfig(mode="merge", match_keys=["id", "region"])
+        load_config = LoadConfig(
+            mode="cdc", cdc=cdc_config, watermark_column="seq", watermark_type="int"
+        )
+
+        counts = execute_cdc_merge(
+            spark, cdc_df, tgt, write_config, cdc_config, load_config=load_config
+        )
+
+        assert counts["updates"] == 2
+        result = spark.read.format("delta").load(tgt)
+        rows = {(r["id"], r["region"]): r["name"] for r in result.collect()}
+        assert rows == {(1, "east"): "A2", (1, "west"): "B1"}
+
+    def test_formatted_watermark_orders_multi_change_window(
+        self, spark: SparkSession, tmp_delta_path
+    ) -> None:
+        """A string watermark with watermark_format orders same-key changes correctly."""
+        tgt = tmp_delta_path("gen_fmt_tgt")
+        create_delta_table(spark, tgt, [{"id": 1, "name": "Alice", "chg_dt": "20260101"}])
+
+        cdc_df = spark.createDataFrame(
+            [
+                {"id": 1, "name": "Cara", "op": "U", "chg_dt": "20260302"},
+                {"id": 1, "name": "Bea", "op": "U", "chg_dt": "20260301"},
+            ]
+        )
+        cdc_config = CdcConfig(
+            operation_column="op",
+            insert_value="I",
+            update_value="U",
+            delete_value="D",
+            on_delete="hard_delete",
+        )
+        write_config = WriteConfig(mode="merge", match_keys=["id"])
+        load_config = LoadConfig(
+            mode="cdc",
+            cdc=cdc_config,
+            watermark_column="chg_dt",
+            watermark_type="date",
+            watermark_format="yyyyMMdd",
+        )
+
+        execute_cdc_merge(spark, cdc_df, tgt, write_config, cdc_config, load_config=load_config)
+
+        result = spark.read.format("delta").load(tgt)
+        assert result.collect()[0]["name"] == "Cara"
+
     def test_insert_only_feed_not_reduced(self, spark: SparkSession, tmp_delta_path) -> None:
         """Without an ordering column, insert-only feeds keep appending every event."""
         tgt = tmp_delta_path("gen_insonly_tgt")
@@ -663,6 +755,25 @@ class TestCdcMultiChangeWindowCdf:
         assert counts["updates"] == 1
         result = spark.read.format("delta").load(tgt)
         assert result.collect()[0]["name"] == "Cara"
+
+    def test_null_commit_version_raises_clear_error(
+        self, spark: SparkSession, tmp_delta_path
+    ) -> None:
+        """A NULL _commit_version value fails loudly instead of mis-ranking."""
+        from weevr.errors.exceptions import ExecutionError
+
+        tgt = tmp_delta_path("cdf_nullcv_tgt")
+        create_delta_table(spark, tgt, [{"id": 1, "name": "Alice"}])
+
+        cdf_df = spark.createDataFrame(
+            [(1, "Bea", "update_postimage", 5), (1, "Cara", "update_postimage", None)],
+            "id INT, name STRING, _change_type STRING, _commit_version INT",
+        )
+        cdc_config = CdcConfig(preset="delta_cdf", on_delete="hard_delete")
+        write_config = WriteConfig(mode="merge", match_keys=["id"])
+
+        with pytest.raises(ExecutionError, match="_commit_version"):
+            execute_cdc_merge(spark, cdf_df, tgt, write_config, cdc_config)
 
     def test_missing_commit_version_raises_clear_error(
         self, spark: SparkSession, tmp_delta_path

--- a/tests/weevr/engine/test_cdc_integration.py
+++ b/tests/weevr/engine/test_cdc_integration.py
@@ -390,6 +390,173 @@ class TestCdcDeltaCdf:
         assert rows[1] == "Alice"  # unchanged
 
 
+class TestCdcMultiChangeWindowCdf:
+    """CDF windows with multiple changes per key reduce to final state."""
+
+    @staticmethod
+    def _enable_cdf(spark: SparkSession, path: str) -> None:
+        spark.sql(
+            f"ALTER TABLE delta.`{path}` SET TBLPROPERTIES ('delta.enableChangeDataFeed' = 'true')"
+        )
+
+    def test_two_updates_one_key_merge_to_final_state(
+        self, spark: SparkSession, tmp_delta_path
+    ) -> None:
+        """Two updates to one key between runs merge cleanly to the later state."""
+        src = tmp_delta_path("cdf_mc_src")
+        tgt = tmp_delta_path("cdf_mc_tgt")
+
+        create_delta_table(spark, src, [{"id": 1, "name": "Alice"}])
+        create_delta_table(spark, tgt, [{"id": 1, "name": "Alice"}])
+        self._enable_cdf(spark, src)
+
+        initial_version = (
+            DeltaTable.forPath(spark, src).history(1).select("version").collect()[0]["version"]
+        )
+
+        dt = DeltaTable.forPath(spark, src)
+        dt.update(condition="id = 1", set={"name": "'Bea'"})
+        dt.update(condition="id = 1", set={"name": "'Cara'"})
+
+        source = Source(type="delta", alias=src)
+        cdc_config = CdcConfig(preset="delta_cdf", on_delete="hard_delete")
+        cdf_df, _ = read_cdc_source(spark, source, cdc_config, last_version=initial_version)
+
+        write_config = WriteConfig(mode="merge", match_keys=["id"])
+        counts = execute_cdc_merge(spark, cdf_df, tgt, write_config, cdc_config)
+
+        assert counts["updates"] == 1
+        result = spark.read.format("delta").load(tgt)
+        rows = {r["id"]: r["name"] for r in result.collect()}
+        assert rows[1] == "Cara"
+
+    def test_update_then_delete_removes_row(self, spark: SparkSession, tmp_delta_path) -> None:
+        """An update followed by a delete in one window removes the row."""
+        tgt = tmp_delta_path("cdf_ud_tgt")
+        create_delta_table(spark, tgt, [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}])
+
+        cdf_df = spark.createDataFrame(
+            [
+                {"id": 1, "name": "Bea", "_change_type": "update_postimage", "_commit_version": 5},
+                {"id": 1, "name": "Bea", "_change_type": "delete", "_commit_version": 6},
+            ]
+        )
+        cdc_config = CdcConfig(preset="delta_cdf", on_delete="hard_delete")
+        write_config = WriteConfig(mode="merge", match_keys=["id"])
+
+        execute_cdc_merge(spark, cdf_df, tgt, write_config, cdc_config)
+
+        result = spark.read.format("delta").load(tgt)
+        ids = {r["id"] for r in result.collect()}
+        assert ids == {2}
+
+    def test_insert_update_delete_nets_absent(self, spark: SparkSession, tmp_delta_path) -> None:
+        """insert + update + delete for one key in one window nets to no row."""
+        tgt = tmp_delta_path("cdf_iud_tgt")
+        create_delta_table(spark, tgt, [{"id": 1, "name": "Alice"}])
+
+        cdf_df = spark.createDataFrame(
+            [
+                {"id": 9, "name": "New", "_change_type": "insert", "_commit_version": 5},
+                {
+                    "id": 9,
+                    "name": "Newer",
+                    "_change_type": "update_postimage",
+                    "_commit_version": 6,
+                },
+                {"id": 9, "name": "Newer", "_change_type": "delete", "_commit_version": 7},
+            ]
+        )
+        cdc_config = CdcConfig(preset="delta_cdf", on_delete="hard_delete")
+        write_config = WriteConfig(mode="merge", match_keys=["id"])
+
+        execute_cdc_merge(spark, cdf_df, tgt, write_config, cdc_config)
+
+        result = spark.read.format("delta").load(tgt)
+        ids = {r["id"] for r in result.collect()}
+        assert ids == {1}
+
+    def test_same_commit_tie_delete_wins(self, spark: SparkSession, tmp_delta_path) -> None:
+        """Within one commit version, delete outranks update_postimage."""
+        tgt = tmp_delta_path("cdf_tie_tgt")
+        create_delta_table(spark, tgt, [{"id": 1, "name": "Alice"}])
+
+        cdf_df = spark.createDataFrame(
+            [
+                {"id": 1, "name": "Bea", "_change_type": "update_postimage", "_commit_version": 5},
+                {"id": 1, "name": "Bea", "_change_type": "delete", "_commit_version": 5},
+            ]
+        )
+        cdc_config = CdcConfig(preset="delta_cdf", on_delete="hard_delete")
+        write_config = WriteConfig(mode="merge", match_keys=["id"])
+
+        execute_cdc_merge(spark, cdf_df, tgt, write_config, cdc_config)
+
+        result = spark.read.format("delta").load(tgt)
+        assert result.count() == 0
+
+    def test_first_write_reduces_to_one_row_per_key(
+        self, spark: SparkSession, tmp_delta_path
+    ) -> None:
+        """First write of a multi-change window creates one row per key at final state."""
+        tgt = tmp_delta_path("cdf_fw_tgt")
+
+        cdf_df = spark.createDataFrame(
+            [
+                {"id": 1, "name": "A", "_change_type": "insert", "_commit_version": 1},
+                {"id": 1, "name": "B", "_change_type": "update_postimage", "_commit_version": 2},
+                {"id": 2, "name": "X", "_change_type": "insert", "_commit_version": 1},
+                {"id": 2, "name": "X", "_change_type": "delete", "_commit_version": 2},
+            ]
+        )
+        cdc_config = CdcConfig(preset="delta_cdf", on_delete="hard_delete")
+        write_config = WriteConfig(mode="merge", match_keys=["id"])
+
+        execute_cdc_merge(spark, cdf_df, tgt, write_config, cdc_config)
+
+        result = spark.read.format("delta").load(tgt)
+        rows = {r["id"]: r["name"] for r in result.collect()}
+        assert rows == {1: "B"}
+
+    def test_counts_reflect_reduced_window(self, spark: SparkSession, tmp_delta_path) -> None:
+        """Counts report the applied (reduced) operations, not raw window rows."""
+        tgt = tmp_delta_path("cdf_cnt_tgt")
+        create_delta_table(spark, tgt, [{"id": 1, "name": "Alice"}])
+
+        cdf_df = spark.createDataFrame(
+            [
+                {"id": 1, "name": "Bea", "_change_type": "update_postimage", "_commit_version": 5},
+                {"id": 1, "name": "Cara", "_change_type": "update_postimage", "_commit_version": 6},
+            ]
+        )
+        cdc_config = CdcConfig(preset="delta_cdf", on_delete="hard_delete")
+        write_config = WriteConfig(mode="merge", match_keys=["id"])
+
+        counts = execute_cdc_merge(spark, cdf_df, tgt, write_config, cdc_config)
+
+        assert counts["updates"] == 1
+        result = spark.read.format("delta").load(tgt)
+        assert result.collect()[0]["name"] == "Cara"
+
+    def test_missing_commit_version_raises_clear_error(
+        self, spark: SparkSession, tmp_delta_path
+    ) -> None:
+        """A CDF frame without _commit_version fails with a named error."""
+        from weevr.errors.exceptions import ExecutionError
+
+        tgt = tmp_delta_path("cdf_nocv_tgt")
+        create_delta_table(spark, tgt, [{"id": 1, "name": "Alice"}])
+
+        cdf_df = spark.createDataFrame(
+            [{"id": 1, "name": "Bea", "_change_type": "update_postimage"}]
+        )
+        cdc_config = CdcConfig(preset="delta_cdf", on_delete="hard_delete")
+        write_config = WriteConfig(mode="merge", match_keys=["id"])
+
+        with pytest.raises(ExecutionError, match="_commit_version"):
+            execute_cdc_merge(spark, cdf_df, tgt, write_config, cdc_config)
+
+
 class TestCdcWatermarkComposition:
     """End-to-end tests for generic CDC composed with watermark filter.
 

--- a/tests/weevr/engine/test_telemetry_incremental.py
+++ b/tests/weevr/engine/test_telemetry_incremental.py
@@ -23,17 +23,17 @@ class TestCdcTelemetry:
         tgt = tmp_delta_path("cdc_tel_tgt")
         wm = tmp_delta_path("cdc_tel_store")
 
-        # Create source with CDC change flags
+        # Create source with CDC change flags and an ordering column
         create_delta_table(
             spark,
             src,
             [
-                {"id": 1, "name": "Alice", "op": "I"},
-                {"id": 2, "name": "Bobby", "op": "U"},
+                {"id": 1, "name": "Alice", "op": "I", "seq": 1},
+                {"id": 2, "name": "Bobby", "op": "U", "seq": 2},
             ],
         )
         # Pre-create target so merge works
-        create_delta_table(spark, tgt, [{"id": 2, "name": "Bob"}])
+        create_delta_table(spark, tgt, [{"id": 2, "name": "Bob", "seq": 0}])
 
         thread = Thread(
             name="cdc_tel",
@@ -49,6 +49,8 @@ class TestCdcTelemetry:
                     insert_value="I",
                     update_value="U",
                 ),
+                watermark_column="seq",
+                watermark_type="int",
                 watermark_store=WatermarkStoreConfig(
                     type="metadata_table",
                     table_path=wm,

--- a/tests/weevr/operations/test_readers.py
+++ b/tests/weevr/operations/test_readers.py
@@ -15,12 +15,12 @@ from weevr.model.connection import OneLakeConnection
 from weevr.model.load import CdcConfig, LoadConfig
 from weevr.model.source import DedupConfig, Source
 from weevr.operations.readers import (
-    _typed_watermark_col,
     build_watermark_filter,
     read_cdc_source,
     read_source,
     read_source_incremental,
     read_sources,
+    typed_watermark_col,
 )
 from weevr.state.watermark import WatermarkState
 
@@ -1037,21 +1037,21 @@ class TestReadCdcSourceGenericWatermark:
 
 
 class TestTypedWatermarkCol:
-    """Unit tests for the ``_typed_watermark_col`` helper."""
+    """Unit tests for the ``typed_watermark_col`` helper."""
 
     def test_passthrough_when_format_is_none(self, spark: SparkSession) -> None:
-        col = _typed_watermark_col("AEDATTM", "timestamp", None)
+        col = typed_watermark_col("AEDATTM", "timestamp", None)
         # Bare column reference — no parse wrapper.
         assert str(col) == str(F.col("AEDATTM"))
 
     def test_wraps_in_to_timestamp_for_timestamp_type(self, spark: SparkSession) -> None:
-        col = _typed_watermark_col("AEDATTM", "timestamp", "yyyy-MM-dd HH:mm:ss.SSSSSX")
+        col = typed_watermark_col("AEDATTM", "timestamp", "yyyy-MM-dd HH:mm:ss.SSSSSX")
         rendered = str(col)
         assert "to_timestamp(" in rendered
         assert "AEDATTM" in rendered
 
     def test_wraps_in_to_date_for_date_type(self, spark: SparkSession) -> None:
-        col = _typed_watermark_col("event_date", "date", "yyyyMMdd")
+        col = typed_watermark_col("event_date", "date", "yyyyMMdd")
         rendered = str(col)
         assert "to_date(" in rendered
         assert "event_date" in rendered
@@ -1065,7 +1065,7 @@ class TestTypedWatermarkCol:
         route to ``to_date``.
         """
         with pytest.raises(ValueError, match="watermark_format is only valid"):
-            _typed_watermark_col("col", bad_type, "yyyy-MM-dd")
+            typed_watermark_col("col", bad_type, "yyyy-MM-dd")
 
 
 class TestBuildWatermarkFilter:


### PR DESCRIPTION
## Summary

- CDC merges now reduce each change window to the latest state per key
  before merging, so a key that changes more than once between runs — the
  normal CDF/OLTP case — merges cleanly to its final state instead of
  failing the thread with
  `DELTA_MULTIPLE_SOURCE_ROW_MATCHING_TARGET_ROW_IN_MERGE`.
- Generic CDC mappings that declare `update_value` or `delete_value` now
  require `load.watermark_column` as the ordering signal; insert-only
  mappings and the `delta_cdf` preset are unaffected.

Closes #185.

## Why

`execute_cdc_merge` built the Delta MERGE from the full change window with
no per-key reduction. Two changes for one key in a window raised the Delta
cardinality error and failed the thread; the first-write path didn't crash
but wrote duplicate keys. The CDF preset couldn't be configured around it,
and generic CDC was equally exposed. The single pre-existing end-to-end
test did one change per key, which masked the defect.

Ordering is intrinsic to CDC — "the final state of key X" is only defined
given an order. Delta CDF carries its own (`_commit_version`); generic CDC
delegates ordering to the data, so configs with collision-capable
operations must name the column. Requiring it upfront turns a
data-dependent production crash into a config-time error with a one-line
fix.

## What changed

- `writers.py`: `_reduce_to_latest_per_key` ranks each key's changes and
  keeps the terminal row — CDF ordered by `_commit_version`, generic by
  the typed watermark column, ties resolved by operation precedence
  (delete > update > insert). Applied before counts, the first-write path,
  and the merge. Change rows whose ordering value is NULL (or unparseable
  under `watermark_format`) fail with a clear error rather than being
  silently mis-ranked; a CDF frame missing `_commit_version` likewise
  fails with a named error.
- `validation.py`: new ERROR when a generic mapping declares
  `update_value`/`delete_value` without `watermark_column`; the executor
  now passes the cdc block through to validation so the guard fires
  before any data is read.
- Operation counts are computed in a single aggregation pass over the
  reduced window, so they report what the merge actually applied.
- `readers.py`: the typed-watermark-column helper is now public and shared
  with the merge path. The executor also threads `watermark_inclusive`
  into validation, making the existing inclusive+append warning reachable.
- 19 new tests: multi-change windows (update+update, update+delete,
  insert+update+delete, same-position ties) on both paths including a
  real-CDF reproduction, first-write reduction, composite match keys,
  formatted watermarks, NULL ordering rejection, insert-only feeds
  unchanged, and the five validation-guard cases.
- Docs: the execution-modes CDC section documents the ordering
  requirement, the reduction, tie precedence, and the NULL policy; the
  explicit-mapping example now declares the watermark; configuration-keys
  and the load/write combination table updated.

## How to test

- [x] uv sync --dev
- [x] uv run ruff check .
- [x] uv run ruff format .
- [x] uv run pyright .
- [x] uv run pytest — 2531 passed; spark suites:
      `uv run pytest tests/weevr/engine/test_cdc_integration.py -m spark`
      → 31 passed;
      `uv run pytest tests/weevr/engine/test_watermark_integration.py -m spark`
      → 12 passed

## Release / Versioning

- [x] PR title follows Conventional Commit format (feat:, fix:, chore:, docs:, ci:, etc.)
- [ ] Breaking change indicated (feat!: / fix!: or BREAKING CHANGE in body)

Not a breaking change — multi-change windows previously crashed the thread
or wrote duplicate keys. Two release-notes callouts: (1) multi-change
windows now merge cleanly to final state; (2) generic CDC with
update/delete values now requires `load.watermark_column` — add the
change-timestamp/sequence column the source already carries. Operation
counts on multi-change windows now reflect applied operations; those
windows previously failed, so no working config sees different numbers.

## Notes

- Insert-only mappings keep append-every-event semantics — no reduction,
  no watermark requirement (`whenNotMatchedInsert` has no cardinality
  constraint).
- Same-operation rows tied at the same ordering position keep an arbitrary
  representative (documented) — no further signal exists to break the tie.
- HWM-capture ordering and CDC operation telemetry are separate known
  findings, untouched here.