### PR TITLE
fix(operations): apply on_no_match_source delete and soft_delete clauses

### DIFF
--- a/docs/guides/dimension-modeling.md
+++ b/docs/guides/dimension-modeling.md
@@ -219,6 +219,12 @@ write:
   soft_delete_value: true  # default; boolean
 ```
 
+On versioned dimensions (`track_history: true`), `delete` and `soft_delete`
+apply to the **current row only**. Closed history rows are never deleted and
+never re-stamped — an entity that disappears from the source keeps its full
+version history; only its current row is removed or flagged. Seeded system
+members are always excluded from both actions.
+
 Forbidden fields when `dimension:` is present:
 
 - `write.match_keys` — derived from `business_key`

--- a/packages/weevr/src/weevr/operations/dimension.py
+++ b/packages/weevr/src/weevr/operations/dimension.py
@@ -355,8 +355,16 @@ def _execute_versioned_merge(
     insert_cols = {c: F.col(f"source.{quote_identifier(c)}") for c in source_df.columns}
     merger = merger.whenNotMatchedInsert(values=insert_cols)
 
-    # Handle on_no_match_source
-    merger = _apply_not_matched_by_source(merger, builder)
+    # Handle on_no_match_source. The MERGE condition scopes matching to
+    # current rows, so closed history rows always land in the
+    # not-matched-by-source set — the clauses must be scoped to the current
+    # row or delete would erase history and soft_delete would re-stamp
+    # closed rows on every merge.
+    merger = _apply_not_matched_by_source(
+        merger,
+        builder,
+        scope_condition=f"target.{quote_identifier(scd.is_current)} = true",
+    )
 
     merger.execute()
     return result
@@ -429,17 +437,27 @@ def _execute_standard_merge(
 def _apply_not_matched_by_source(
     merger: object,  # DeltaMergeBuilder — avoid import
     builder: DimensionMergeBuilder,
+    scope_condition: str | None = None,
 ) -> object:
     """Apply on_no_match_source clauses with system member exclusion.
 
     DeltaMergeBuilder is immutable — each ``when*`` call returns a new
     builder, so the result must be returned and reassigned by the caller.
+
+    Args:
+        merger: The Delta merge builder under construction.
+        builder: Dimension merge builder providing write config and SK values.
+        scope_condition: Extra SQL predicate ANDed onto the clause condition.
+            The versioned path passes an ``is_current`` scope; the standard
+            path (one row per entity, no history to protect) passes none.
     """
     write_config = builder.build_write_config()
     sk_col = builder.config.surrogate_key.name
     system_member_sks = builder.get_system_member_sk_values()
 
     conditions: list[str] = []
+    if scope_condition:
+        conditions.append(scope_condition)
     if system_member_sks:
         # Compare as strings: the SK column is a hex string under the default
         # sha256 algorithm (seeds store sentinel SKs as "-1"/"-2" there), and

--- a/packages/weevr/src/weevr/operations/dimension.py
+++ b/packages/weevr/src/weevr/operations/dimension.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from functools import reduce
+from typing import Any
 
 from pyspark.sql import Column, DataFrame, SparkSession
 from pyspark.sql import functions as F
@@ -435,10 +436,10 @@ def _execute_standard_merge(
 
 
 def _apply_not_matched_by_source(
-    merger: object,  # DeltaMergeBuilder — avoid import
+    merger: Any,  # DeltaMergeBuilder — avoid import
     builder: DimensionMergeBuilder,
     scope_condition: str | None = None,
-) -> object:
+) -> Any:
     """Apply on_no_match_source clauses with system member exclusion.
 
     DeltaMergeBuilder is immutable — each ``when*`` call returns a new
@@ -460,9 +461,12 @@ def _apply_not_matched_by_source(
         conditions.append(scope_condition)
     if system_member_sks:
         # Compare as strings: the SK column is a hex string under the default
-        # sha256 algorithm (seeds store sentinel SKs as "-1"/"-2" there), and
-        # a bare `string_col != -1` null-compares in Spark, silently protecting
-        # every row. Casting the column covers integer SK columns identically.
+        # sha256 algorithm (seeds store system-member SKs as "-1"/"-2" there),
+        # and a bare `string_col != -1` null-compares in Spark, silently
+        # protecting every row. Casting the column covers integer SK columns
+        # identically. A NULL SK would also null-compare and be protected —
+        # safe only because engine-generated SKs are never null
+        # (hashing._build_concat_expr coalesces nulls before hashing).
         conditions.append(
             " AND ".join(
                 f"CAST(target.{quote_identifier(sk_col)} AS STRING) != '{v}'"
@@ -472,13 +476,13 @@ def _apply_not_matched_by_source(
 
     if write_config.on_no_match_source == "delete":
         condition = " AND ".join(conditions) if conditions else None
-        merger = merger.whenNotMatchedBySourceDelete(condition=condition)  # type: ignore[attr-defined]
+        merger = merger.whenNotMatchedBySourceDelete(condition=condition)
     elif write_config.on_no_match_source == "soft_delete":
         sd_col = write_config.soft_delete_column
         sd_val = write_config.soft_delete_value
         if sd_col:
             condition = " AND ".join(conditions) if conditions else None
-            merger = merger.whenNotMatchedBySourceUpdate(  # type: ignore[attr-defined]
+            merger = merger.whenNotMatchedBySourceUpdate(
                 condition=condition, set={sd_col: F.lit(sd_val)}
             )
     return merger

--- a/packages/weevr/src/weevr/operations/dimension.py
+++ b/packages/weevr/src/weevr/operations/dimension.py
@@ -356,7 +356,7 @@ def _execute_versioned_merge(
     merger = merger.whenNotMatchedInsert(values=insert_cols)
 
     # Handle on_no_match_source
-    _apply_not_matched_by_source(merger, builder)
+    merger = _apply_not_matched_by_source(merger, builder)
 
     merger.execute()
     return result
@@ -420,7 +420,7 @@ def _execute_standard_merge(
         merger = merger.whenMatchedUpdate(condition=change_cond, set=update_set)
 
     merger = merger.whenNotMatchedInsertAll()
-    _apply_not_matched_by_source(merger, builder)
+    merger = _apply_not_matched_by_source(merger, builder)
     merger.execute()
 
     return result
@@ -429,29 +429,38 @@ def _execute_standard_merge(
 def _apply_not_matched_by_source(
     merger: object,  # DeltaMergeBuilder — avoid import
     builder: DimensionMergeBuilder,
-) -> None:
-    """Apply on_no_match_source clauses with system member exclusion."""
+) -> object:
+    """Apply on_no_match_source clauses with system member exclusion.
+
+    DeltaMergeBuilder is immutable — each ``when*`` call returns a new
+    builder, so the result must be returned and reassigned by the caller.
+    """
     write_config = builder.build_write_config()
     sk_col = builder.config.surrogate_key.name
     system_member_sks = builder.get_system_member_sk_values()
 
-    if write_config.on_no_match_source == "delete":
-        if system_member_sks:
-            exclusion = " AND ".join(
-                f"target.{quote_identifier(sk_col)} != {v}" for v in system_member_sks
+    conditions: list[str] = []
+    if system_member_sks:
+        # Compare as strings: the SK column is a hex string under the default
+        # sha256 algorithm (seeds store sentinel SKs as "-1"/"-2" there), and
+        # a bare `string_col != -1` null-compares in Spark, silently protecting
+        # every row. Casting the column covers integer SK columns identically.
+        conditions.append(
+            " AND ".join(
+                f"CAST(target.{quote_identifier(sk_col)} AS STRING) != '{v}'"
+                for v in system_member_sks
             )
-            merger.whenNotMatchedBySourceDelete(condition=exclusion)  # type: ignore[union-attr]
-        else:
-            merger.whenNotMatchedBySourceDelete()  # type: ignore[union-attr]
+        )
+
+    if write_config.on_no_match_source == "delete":
+        condition = " AND ".join(conditions) if conditions else None
+        merger = merger.whenNotMatchedBySourceDelete(condition=condition)  # type: ignore[attr-defined]
     elif write_config.on_no_match_source == "soft_delete":
         sd_col = write_config.soft_delete_column
         sd_val = write_config.soft_delete_value
         if sd_col:
-            condition = None
-            if system_member_sks:
-                condition = " AND ".join(
-                    f"target.{quote_identifier(sk_col)} != {v}" for v in system_member_sks
-                )
-            merger.whenNotMatchedBySourceUpdate(  # type: ignore[union-attr]
+            condition = " AND ".join(conditions) if conditions else None
+            merger = merger.whenNotMatchedBySourceUpdate(  # type: ignore[attr-defined]
                 condition=condition, set={sd_col: F.lit(sd_val)}
             )
+    return merger

--- a/tests/weevr/operations/test_dimension_merge.py
+++ b/tests/weevr/operations/test_dimension_merge.py
@@ -31,6 +31,11 @@ def _prepare_source(spark, rows, dim_config, run_ts="2026-01-01"):
     return df
 
 
+def _write_overrides(**kwargs):  # type: ignore[no-untyped-def]
+    base = {"mode": "merge", "match_keys": ["customer_id"]}
+    return WriteConfig(**{**base, **kwargs})
+
+
 @pytest.mark.spark
 class TestFirstWrite:
     """First-write behavior: all rows inserted."""
@@ -464,16 +469,11 @@ class TestAdditionalKeys:
 class TestNoMatchSourceStandard:
     """on_no_match_source delete/soft_delete on the standard (Type 1) path."""
 
-    @staticmethod
-    def _overrides(**kwargs):  # type: ignore[no-untyped-def]
-        base = {"mode": "merge", "match_keys": ["customer_id"]}
-        return WriteConfig(**{**base, **kwargs})
-
     def test_delete_removes_absent_entity(self, spark: SparkSession, tmp_delta_path) -> None:
         path = tmp_delta_path("dim_nms_delete")
         dim = _make_dim()
         builder = DimensionMergeBuilder(
-            dim, write_overrides=self._overrides(on_no_match_source="delete")
+            dim, write_overrides=_write_overrides(on_no_match_source="delete")
         )
 
         rows = [
@@ -496,7 +496,7 @@ class TestNoMatchSourceStandard:
         dim = _make_dim()
         builder = DimensionMergeBuilder(
             dim,
-            write_overrides=self._overrides(
+            write_overrides=_write_overrides(
                 on_no_match_source="soft_delete", soft_delete_column="deleted"
             ),
         )
@@ -534,7 +534,7 @@ class TestNoMatchSourceStandard:
             ],
         )
         builder = DimensionMergeBuilder(
-            dim, write_overrides=self._overrides(on_no_match_source="delete")
+            dim, write_overrides=_write_overrides(on_no_match_source="delete")
         )
 
         rows = [{"customer_id": "C1", "name": "Alice"}]
@@ -583,11 +583,6 @@ class TestNoMatchSourceVersioned:
     """delete/soft_delete on the SCD2 path act on current rows only."""
 
     @staticmethod
-    def _overrides(**kwargs):  # type: ignore[no-untyped-def]
-        base = {"mode": "merge", "match_keys": ["customer_id"]}
-        return WriteConfig(**{**base, **kwargs})
-
-    @staticmethod
     def _dim(**extra):  # type: ignore[no-untyped-def]
         return _make_dim(
             track_history=True,
@@ -617,7 +612,7 @@ class TestNoMatchSourceVersioned:
         path = tmp_delta_path("dim_nms_v_delete")
         dim = self._dim()
         builder = DimensionMergeBuilder(
-            dim, write_overrides=self._overrides(on_no_match_source="delete")
+            dim, write_overrides=_write_overrides(on_no_match_source="delete")
         )
         self._seed_history(spark, path, dim, builder)
 
@@ -648,7 +643,7 @@ class TestNoMatchSourceVersioned:
         dim = self._dim()
         builder = DimensionMergeBuilder(
             dim,
-            write_overrides=self._overrides(
+            write_overrides=_write_overrides(
                 on_no_match_source="soft_delete", soft_delete_column="deleted"
             ),
         )
@@ -687,7 +682,7 @@ class TestNoMatchSourceVersioned:
             ],
         )
         builder = DimensionMergeBuilder(
-            dim, write_overrides=self._overrides(on_no_match_source="delete")
+            dim, write_overrides=_write_overrides(on_no_match_source="delete")
         )
         self._seed_history(spark, path, dim, builder)
 
@@ -716,3 +711,102 @@ class TestNoMatchSourceVersioned:
         assert "__unknown__" in remaining
         assert "C2" not in remaining
         assert "C1" in remaining
+
+
+@pytest.mark.spark
+class TestNoMatchSourceSystemMemberSoftDelete:
+    """soft_delete never stamps system-member rows on either merge path."""
+
+    def test_standard_path_flag_untouched(self, spark: SparkSession, tmp_delta_path) -> None:
+        path = tmp_delta_path("dim_nms_soft_sysmember")
+        dim = _make_dim(
+            seed_system_members=True,
+            system_members=[  # type: ignore[arg-type]
+                {"sk": -1, "code": "UNKNOWN", "label": "Unknown"},
+            ],
+        )
+        builder = DimensionMergeBuilder(
+            dim,
+            write_overrides=_write_overrides(
+                on_no_match_source="soft_delete", soft_delete_column="deleted"
+            ),
+        )
+
+        rows = [{"customer_id": "C1", "name": "Alice", "deleted": False}]
+        src1 = _prepare_source(spark, rows, dim, "2026-01-01")
+        execute_dimension_merge(spark, src1, builder, path, "2026-01-01")
+
+        sk_type = dict(src1.dtypes)["_sk"]
+        sentinel = _prepare_source(
+            spark,
+            [{"customer_id": "__unknown__", "name": "Unknown", "deleted": False}],
+            dim,
+            "2026-01-01",
+        ).withColumn("_sk", F.lit(-1).cast(sk_type))
+        sentinel.write.format("delta").mode("append").save(path)
+
+        # Neither C1 nor the system member is in the new source
+        src2 = _prepare_source(
+            spark, [{"customer_id": "C9", "name": "Nadia", "deleted": False}], dim, "2026-01-02"
+        )
+        execute_dimension_merge(spark, src2, builder, path, "2026-01-02")
+
+        flags = {
+            r["customer_id"]: r["deleted"] for r in spark.read.format("delta").load(path).collect()
+        }
+        assert flags["__unknown__"] is False  # system member never stamped
+        assert flags["C1"] is True
+        assert flags["C9"] is False
+
+    def test_versioned_path_current_row_flag_untouched(
+        self, spark: SparkSession, tmp_delta_path
+    ) -> None:
+        path = tmp_delta_path("dim_nms_v_soft_sysmember")
+        dim = _make_dim(
+            track_history=True,
+            change_detection={  # type: ignore[arg-type]
+                "names": {"columns": ["name"], "on_change": "version"},
+            },
+            seed_system_members=True,
+            system_members=[  # type: ignore[arg-type]
+                {"sk": -1, "code": "UNKNOWN", "label": "Unknown"},
+            ],
+        )
+        builder = DimensionMergeBuilder(
+            dim,
+            write_overrides=_write_overrides(
+                on_no_match_source="soft_delete", soft_delete_column="deleted"
+            ),
+        )
+
+        rows = [
+            {"customer_id": "C1", "name": "Alice", "deleted": False},
+            {"customer_id": "C2", "name": "Bob", "deleted": False},
+        ]
+        src1 = _prepare_source(spark, rows, dim, "2026-01-01")
+        execute_dimension_merge(spark, src1, builder, path, "2026-01-01")
+
+        sk_type = dict(src1.dtypes)["_sk"]
+        sentinel = _prepare_source(
+            spark,
+            [{"customer_id": "__unknown__", "name": "Unknown", "deleted": False}],
+            dim,
+            "2026-01-01",
+        ).withColumn("_sk", F.lit(-1).cast(sk_type))
+        sentinel.write.format("delta").mode("append").save(path)
+
+        # C2 and the system member both vanish from the source; only C2
+        # (a plain entity's current row) may be stamped
+        src2 = _prepare_source(
+            spark, [{"customer_id": "C1", "name": "Alice", "deleted": False}], dim, "2026-02-01"
+        )
+        execute_dimension_merge(spark, src2, builder, path, "2026-02-01")
+
+        current = {
+            r["customer_id"]: r["deleted"]
+            for r in spark.read.format("delta").load(path).collect()
+            if r["_is_current"]
+        }
+        assert current["__unknown__"] is False  # system member's current row never stamped
+        assert current["C2"] is True
+        assert current["C1"] is False

--- a/tests/weevr/operations/test_dimension_merge.py
+++ b/tests/weevr/operations/test_dimension_merge.py
@@ -6,6 +6,7 @@ from pyspark.sql import functions as F
 from pyspark.sql.types import StringType, StructField, StructType
 
 from weevr.model.dimension import DimensionConfig
+from weevr.model.write import WriteConfig
 from weevr.operations.dimension import (
     DimensionMergeBuilder,
     execute_dimension_merge,
@@ -457,3 +458,121 @@ class TestAdditionalKeys:
         target = spark.read.format("delta").load(path)
         assert "_version_sk" in target.columns
         assert "_sk" in target.columns
+
+
+@pytest.mark.spark
+class TestNoMatchSourceStandard:
+    """on_no_match_source delete/soft_delete on the standard (Type 1) path."""
+
+    @staticmethod
+    def _overrides(**kwargs):  # type: ignore[no-untyped-def]
+        base = {"mode": "merge", "match_keys": ["customer_id"]}
+        return WriteConfig(**{**base, **kwargs})
+
+    def test_delete_removes_absent_entity(self, spark: SparkSession, tmp_delta_path) -> None:
+        path = tmp_delta_path("dim_nms_delete")
+        dim = _make_dim()
+        builder = DimensionMergeBuilder(
+            dim, write_overrides=self._overrides(on_no_match_source="delete")
+        )
+
+        rows = [
+            {"customer_id": "C1", "name": "Alice"},
+            {"customer_id": "C2", "name": "Bob"},
+        ]
+        src1 = _prepare_source(spark, rows, dim, "2026-01-01")
+        execute_dimension_merge(spark, src1, builder, path, "2026-01-01")
+
+        # C2 disappears from the source — declared delete must remove it
+        src2 = _prepare_source(spark, rows[:1], dim, "2026-01-02")
+        execute_dimension_merge(spark, src2, builder, path, "2026-01-02")
+
+        target = spark.read.format("delta").load(path)
+        remaining = {r["customer_id"] for r in target.collect()}
+        assert remaining == {"C1"}
+
+    def test_soft_delete_flags_absent_entity(self, spark: SparkSession, tmp_delta_path) -> None:
+        path = tmp_delta_path("dim_nms_soft")
+        dim = _make_dim()
+        builder = DimensionMergeBuilder(
+            dim,
+            write_overrides=self._overrides(
+                on_no_match_source="soft_delete", soft_delete_column="deleted"
+            ),
+        )
+
+        rows = [
+            {"customer_id": "C1", "name": "Alice", "deleted": False},
+            {"customer_id": "C2", "name": "Bob", "deleted": False},
+        ]
+        src1 = _prepare_source(spark, rows, dim, "2026-01-01")
+        execute_dimension_merge(spark, src1, builder, path, "2026-01-01")
+
+        src2 = _prepare_source(spark, rows[:1], dim, "2026-01-02")
+        execute_dimension_merge(spark, src2, builder, path, "2026-01-02")
+
+        target = spark.read.format("delta").load(path)
+        flags = {r["customer_id"]: r["deleted"] for r in target.collect()}
+        assert flags == {"C1": False, "C2": True}
+
+    @pytest.mark.parametrize("algorithm", ["sha256", "xxhash64"])
+    def test_system_member_rows_survive(
+        self, spark: SparkSession, tmp_delta_path, algorithm: str
+    ) -> None:
+        # sha256 → string SK (the default); xxhash64 → integer SK. The
+        # exclusion must protect sentinels and still delete plain rows on both.
+        path = tmp_delta_path(f"dim_nms_sysmember_{algorithm}")
+        dim = _make_dim(
+            surrogate_key={  # type: ignore[arg-type]
+                "name": "_sk",
+                "columns": ["customer_id"],
+                "algorithm": algorithm,
+            },
+            seed_system_members=True,
+            system_members=[  # type: ignore[arg-type]
+                {"sk": -1, "code": "UNKNOWN", "label": "Unknown"},
+            ],
+        )
+        builder = DimensionMergeBuilder(
+            dim, write_overrides=self._overrides(on_no_match_source="delete")
+        )
+
+        rows = [{"customer_id": "C1", "name": "Alice"}]
+        src1 = _prepare_source(spark, rows, dim, "2026-01-01")
+        execute_dimension_merge(spark, src1, builder, path, "2026-01-01")
+
+        # Seed a sentinel row the way execute_seeds would: same schema, SK = -1
+        sk_type = dict(src1.dtypes)["_sk"]
+        sentinel = _prepare_source(
+            spark, [{"customer_id": "__unknown__", "name": "Unknown"}], dim, "2026-01-01"
+        ).withColumn("_sk", F.lit(-1).cast(sk_type))
+        sentinel.write.format("delta").mode("append").save(path)
+
+        # Neither the sentinel nor C1 is in the new source; only C1 may be deleted
+        src2 = _prepare_source(spark, [{"customer_id": "C9", "name": "Nadia"}], dim, "2026-01-02")
+        execute_dimension_merge(spark, src2, builder, path, "2026-01-02")
+
+        target = spark.read.format("delta").load(path)
+        remaining = {r["customer_id"] for r in target.collect()}
+        assert "__unknown__" in remaining
+        assert "C1" not in remaining
+        assert "C9" in remaining
+
+    def test_ignore_default_remains_noop(self, spark: SparkSession, tmp_delta_path) -> None:
+        path = tmp_delta_path("dim_nms_ignore")
+        dim = _make_dim()
+        builder = DimensionMergeBuilder(dim)
+
+        rows = [
+            {"customer_id": "C1", "name": "Alice"},
+            {"customer_id": "C2", "name": "Bob"},
+        ]
+        src1 = _prepare_source(spark, rows, dim, "2026-01-01")
+        execute_dimension_merge(spark, src1, builder, path, "2026-01-01")
+
+        src2 = _prepare_source(spark, rows[:1], dim, "2026-01-02")
+        execute_dimension_merge(spark, src2, builder, path, "2026-01-02")
+
+        target = spark.read.format("delta").load(path)
+        remaining = {r["customer_id"] for r in target.collect()}
+        assert remaining == {"C1", "C2"}

--- a/tests/weevr/operations/test_dimension_merge.py
+++ b/tests/weevr/operations/test_dimension_merge.py
@@ -576,3 +576,143 @@ class TestNoMatchSourceStandard:
         target = spark.read.format("delta").load(path)
         remaining = {r["customer_id"] for r in target.collect()}
         assert remaining == {"C1", "C2"}
+
+
+@pytest.mark.spark
+class TestNoMatchSourceVersioned:
+    """delete/soft_delete on the SCD2 path act on current rows only."""
+
+    @staticmethod
+    def _overrides(**kwargs):  # type: ignore[no-untyped-def]
+        base = {"mode": "merge", "match_keys": ["customer_id"]}
+        return WriteConfig(**{**base, **kwargs})
+
+    @staticmethod
+    def _dim(**extra):  # type: ignore[no-untyped-def]
+        return _make_dim(
+            track_history=True,
+            change_detection={  # type: ignore[arg-type]
+                "names": {"columns": ["name"], "on_change": "version"},
+            },
+            **extra,
+        )
+
+    def _seed_history(self, spark, path, dim, builder):  # type: ignore[no-untyped-def]
+        """Two writes: C1 gains a closed v1 + current v2; C2 stays single-version."""
+        rows1 = [
+            {"customer_id": "C1", "name": "Alice", "deleted": False},
+            {"customer_id": "C2", "name": "Bob", "deleted": False},
+        ]
+        src1 = _prepare_source(spark, rows1, dim, "2026-01-01")
+        execute_dimension_merge(spark, src1, builder, path, "2026-01-01")
+
+        rows2 = [
+            {"customer_id": "C1", "name": "Alicia", "deleted": False},
+            {"customer_id": "C2", "name": "Bob", "deleted": False},
+        ]
+        src2 = _prepare_source(spark, rows2, dim, "2026-02-01")
+        execute_dimension_merge(spark, src2, builder, path, "2026-02-01")
+
+    def test_delete_spares_closed_history_rows(self, spark: SparkSession, tmp_delta_path) -> None:
+        path = tmp_delta_path("dim_nms_v_delete")
+        dim = self._dim()
+        builder = DimensionMergeBuilder(
+            dim, write_overrides=self._overrides(on_no_match_source="delete")
+        )
+        self._seed_history(spark, path, dim, builder)
+
+        # C2 disappears; C1 continues unchanged
+        src3 = _prepare_source(
+            spark, [{"customer_id": "C1", "name": "Alicia", "deleted": False}], dim, "2026-03-01"
+        )
+        execute_dimension_merge(spark, src3, builder, path, "2026-03-01")
+
+        target = spark.read.format("delta").load(path).collect()
+        by_key = {}
+        for r in target:
+            by_key.setdefault(r["customer_id"], []).append(r)
+
+        # C2's current row is gone entirely
+        assert "C2" not in by_key
+        # C1's closed v1 AND current v2 both survive
+        c1_current = [r for r in by_key["C1"] if r["_is_current"]]
+        c1_closed = [r for r in by_key["C1"] if not r["_is_current"]]
+        assert len(c1_current) == 1
+        assert len(c1_closed) == 1
+        assert c1_closed[0]["name"] == "Alice"
+
+    def test_soft_delete_stamps_current_only_and_is_idempotent(
+        self, spark: SparkSession, tmp_delta_path
+    ) -> None:
+        path = tmp_delta_path("dim_nms_v_soft")
+        dim = self._dim()
+        builder = DimensionMergeBuilder(
+            dim,
+            write_overrides=self._overrides(
+                on_no_match_source="soft_delete", soft_delete_column="deleted"
+            ),
+        )
+        self._seed_history(spark, path, dim, builder)
+
+        def _merge_without_c2(run_ts: str) -> None:
+            src = _prepare_source(
+                spark,
+                [{"customer_id": "C1", "name": "Alicia", "deleted": False}],
+                dim,
+                run_ts,
+            )
+            execute_dimension_merge(spark, src, builder, path, run_ts)
+
+        _merge_without_c2("2026-03-01")
+        _merge_without_c2("2026-04-01")  # rerun: closed rows must not be re-stamped
+
+        target = spark.read.format("delta").load(path).collect()
+        by_row = {(r["customer_id"], bool(r["_is_current"])): r for r in target}
+
+        # C2's current row is stamped
+        assert by_row[("C2", True)]["deleted"] is True
+        # C1's closed row keeps its original flag across both merges
+        assert by_row[("C1", False)]["deleted"] is False
+        # C1's current row untouched
+        assert by_row[("C1", True)]["deleted"] is False
+
+    def test_system_member_current_row_survives_delete(
+        self, spark: SparkSession, tmp_delta_path
+    ) -> None:
+        path = tmp_delta_path("dim_nms_v_sysmember")
+        dim = self._dim(
+            seed_system_members=True,
+            system_members=[  # type: ignore[arg-type]
+                {"sk": -1, "code": "UNKNOWN", "label": "Unknown"},
+            ],
+        )
+        builder = DimensionMergeBuilder(
+            dim, write_overrides=self._overrides(on_no_match_source="delete")
+        )
+        self._seed_history(spark, path, dim, builder)
+
+        src1 = _prepare_source(
+            spark,
+            [{"customer_id": "C1", "name": "Alicia", "deleted": False}],
+            dim,
+            "2026-02-15",
+        )
+        sk_type = dict(src1.dtypes)["_sk"]
+        sentinel = _prepare_source(
+            spark,
+            [{"customer_id": "__unknown__", "name": "Unknown", "deleted": False}],
+            dim,
+            "2026-01-01",
+        ).withColumn("_sk", F.lit(-1).cast(sk_type))
+        sentinel.write.format("delta").mode("append").save(path)
+
+        src3 = _prepare_source(
+            spark, [{"customer_id": "C1", "name": "Alicia", "deleted": False}], dim, "2026-03-01"
+        )
+        execute_dimension_merge(spark, src3, builder, path, "2026-03-01")
+
+        remaining = {r["customer_id"] for r in spark.read.format("delta").load(path).collect()}
+        # Sentinel (current, sk=-1) survives; C2 (current, no source match) is gone
+        assert "__unknown__" in remaining
+        assert "C2" not in remaining
+        assert "C1" in remaining


### PR DESCRIPTION
## Summary

- `on_no_match_source: delete` and `soft_delete` on dimension merges never executed:
  `DeltaMergeBuilder` is immutable and the helper discarded the builder returned by
  `whenNotMatchedBySourceDelete()` / `...Update()`. Declared deletes silently did
  nothing, so entities removed from the source persisted in the target forever.
- Closes #187

## Why

- Both merge paths (standard and versioned) called the helper for its side effect,
  but the file reassigns the builder correctly everywhere else — an asymmetric
  defect, not intent. Reproduced in the June runtime review on both paths, with 0%
  test coverage on the clause code.

## What changed

- `_apply_not_matched_by_source` returns the resulting builder; both call sites
  reassign it.
- The versioned (SCD2) path scopes both clauses to `is_current = true`. The merge
  condition matches current rows only, so closed history rows always fall in the
  not-matched-by-source set — without the scope, `delete` would erase history and
  `soft_delete` would re-stamp closed rows on every run. History rows are never
  deleted, never re-stamped; only the absent entity's current row is acted on.
- System-member exclusion now compares surrogate keys as strings
  (`CAST(... AS STRING) != '-1'`). Under the default sha256 algorithm the SK column
  is a hex string, and the old bare `!= -1` null-compared — it would have protected
  every row from deletion. Covered by tests for both string and integer SK types.
- Tests: delete / soft_delete / default-ignore on both merge paths, closed-history
  survival, soft-delete rerun idempotency, and system-member exclusion for both
  actions on both paths.
- Docs: dimension-modeling guide notes the current-row semantics on versioned
  dimensions.

## How to test

- [x] uv sync --dev
- [x] uv run ruff check .
- [x] uv run ruff format .
- [x] uv run pyright .
- [x] uv run pytest (2531 passed) and the full Spark-marked suite (exit 0)

## Release / Versioning

- [x] PR title follows Conventional Commit format (feat:, fix:, chore:, docs:, ci:, etc.)
- [ ] Breaking change indicated (feat!: / fix!: or BREAKING CHANGE in body) — not breaking

## Notes

- Upgrade callout for release notes: threads that already declare
  `delete`/`soft_delete` will begin acting on the next run after upgrade — removed
  entities start disappearing (or being flagged). The prior behavior was
  non-functional, so this is a fix, not a behavior break.