### PR TITLE
feat(engine): collect pipeline step statistics lazily via observations

### DIFF
--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -276,6 +276,15 @@ depends on what was executed:
   successfully persisted after write
 - **watermark_first_run** -- Whether this is the first run with
   no prior watermark state
+- **step_stats** -- Per-step pipeline statistics (resolve match
+  rates, validate-mode map counts), keyed `<scope>.<step>.<name>`.
+  Collected as a byproduct of the write rather than by extra Spark
+  jobs, and harvested best-effort: a failed harvest logs a warning
+  and leaves the field absent, never failing the thread. This field
+  is engine-internal — its key set and value shapes are unstable
+  and may change without notice. In preview mode the values are
+  sample-scoped (they reflect the sampled rows, not the full
+  source), and are present only when sample capture succeeded.
 
 ### Weave telemetry fields
 

--- a/docs/guides/resolve.md
+++ b/docs/guides/resolve.md
@@ -276,8 +276,8 @@ assertions:
 
 ## Resolution statistics
 
-Each resolve step records per-FK statistics in the step
-result metadata:
+Each resolve step records per-FK statistics, surfaced on thread
+telemetry after the write (`step_stats`, engine-internal):
 
 - `total` — total fact rows processed
 - `matched` — rows with a successful FK match
@@ -285,3 +285,13 @@ result metadata:
 - `invalid` — rows assigned `on_invalid` sentinel
 - `duplicates` — rows with multiple matches (before dedup)
 - `match_rate` — percentage of matched rows
+
+The statistics are computed as a byproduct of the write — resolve
+steps no longer execute extra Spark jobs per step, so deep resolve
+chains no longer pay a per-step recompute of the full pipeline.
+Duplicate handling is likewise decided by a dimension-sized check
+against the lookup side: when the lookup's join keys are
+duplicate-free (the common case), the per-row duplicate machinery
+is skipped entirely. `on_duplicate` outcomes are unchanged —
+`error` still fires only when a fact row actually matches a
+duplicated key, before the write.

--- a/packages/weevr-core/src/weevr/telemetry/results.py
+++ b/packages/weevr-core/src/weevr/telemetry/results.py
@@ -97,6 +97,9 @@ class ThreadTelemetry(FrozenBase):
             DataFrame for this thread.
         export_results: Per-export write results, one per export configured
             on the thread.
+        step_stats: Per-step pipeline statistics harvested after the write,
+            keyed ``<scope>.<step>.<name>``. Engine-internal — the key set
+            and value shapes are unstable and may change without notice.
     """
 
     span: ExecutionSpan
@@ -125,6 +128,7 @@ class ThreadTelemetry(FrozenBase):
     drift_columns: list[str] = []
     drift_mode: str | None = None
     drift_action_taken: str | None = None
+    step_stats: dict[str, dict[str, Any]] | None = None
 
 
 class ColumnSetResult(FrozenBase):

--- a/packages/weevr/src/weevr/context.py
+++ b/packages/weevr/src/weevr/context.py
@@ -730,7 +730,7 @@ class Context:
         import contextlib
 
         from weevr.operations.hashing import compute_keys
-        from weevr.operations.pipeline import run_pipeline
+        from weevr.operations.pipeline import ObservationRegistry, run_pipeline
         from weevr.operations.readers import read_sources
         from weevr.operations.validation import validate_dataframe
         from weevr.operations.writers import apply_target_mapping
@@ -755,7 +755,8 @@ class Context:
                     sources_map[key] = sources_map[key].limit(sample_rows)
 
                 df = next(iter(sources_map.values()))
-                df = run_pipeline(df, thread.steps, sources_map)
+                obs_registry = ObservationRegistry(scope="main")
+                df = run_pipeline(df, thread.steps, sources_map, observations=obs_registry)
 
                 if thread.validations:
                     outcome = validate_dataframe(df, thread.validations)
@@ -774,6 +775,23 @@ class Context:
                 }
                 with contextlib.suppress(Exception):
                     meta["samples"] = {"output": df.limit(10).toPandas().to_dict("records")}
+                # Harvest step stats after the sampling action fulfilled the
+                # observations. Sample-scoped by construction (no write in
+                # preview). Deliberately OUTSIDE the samples suppress with
+                # its own guard: a harvest failure warns and degrades — it
+                # must never demote the thread to errors. Skipped entirely
+                # when the sample capture failed: no action executed the
+                # plan, so every observation would just time out.
+                if "samples" in meta:
+                    try:
+                        step_stats = obs_registry.harvest()
+                        if step_stats:
+                            meta["step_stats"] = step_stats
+                    except Exception:
+                        logger.warning(
+                            "Preview step-statistics harvest failed for thread '%s'",
+                            thread_name,
+                        )
                 preview_metadata[thread_name] = meta
             except Exception as exc:
                 errors.append(f"Preview failed for thread '{thread_name}': {exc}")

--- a/packages/weevr/src/weevr/engine/executor.py
+++ b/packages/weevr/src/weevr/engine/executor.py
@@ -451,7 +451,12 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
                 lookup_meta=lookup_meta,
             )
 
-            # Capture intermediate row count for waterfall visualization
+            # Capture intermediate row count for waterfall visualization.
+            # This count is also the FIRST action over the pipeline plan:
+            # Spark observations are fixed by the first completed execution,
+            # so the step statistics harvested later carry the values from
+            # this full-scale execution — removing or reordering this count
+            # changes which action fixes them.
             rows_after_transforms = df.count()
 
             # Step 7 — run validation rules

--- a/packages/weevr/src/weevr/engine/executor.py
+++ b/packages/weevr/src/weevr/engine/executor.py
@@ -14,7 +14,12 @@ from pyspark.sql import SparkSession
 from weevr.delta import read_delta
 from weevr.engine.column_sets import materialize_column_sets
 from weevr.engine.hooks import run_hook_steps
-from weevr.engine.lookups import cleanup_lookups, materialize_lookups, resolve_thread_lookups
+from weevr.engine.lookups import (
+    build_lookup_meta,
+    cleanup_lookups,
+    materialize_lookups,
+    resolve_thread_lookups,
+)
 from weevr.engine.resources import merge_resource_dicts
 from weevr.engine.result import ThreadResult
 from weevr.engine.variables import VariableContext
@@ -40,7 +45,7 @@ from weevr.operations.exports import resolve_exports, write_export
 from weevr.operations.fact import check_fact_sentinels, validate_fact_schema
 from weevr.operations.hashing import compute_dimension_keys, compute_keys
 from weevr.operations.naming import normalize_columns
-from weevr.operations.pipeline import run_pipeline
+from weevr.operations.pipeline import LookupMeta, ObservationRegistry, run_pipeline
 from weevr.operations.quarantine import write_quarantine
 from weevr.operations.readers import (
     read_cdc_source,
@@ -78,6 +83,7 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
     column_sets: dict[str, dict[str, str]] | None = None,
     column_set_defs: dict[str, ColumnSet] | None = None,
     connections: dict[str, OneLakeConnection] | None = None,
+    lookup_meta: dict[str, LookupMeta] | None = None,
 ) -> ThreadResult:
     """Execute a single thread from sources through transforms to a Delta target.
 
@@ -131,6 +137,8 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
             When provided, source reads, lookup materialization, target path
             resolution, and export writes use connection-based paths where
             configured.
+        lookup_meta: Materialization-time lookup facts inherited from the
+            weave/loom scope; thread-level facts merge on top.
 
     Returns:
         :class:`ThreadResult` with status, row count, write mode, target path,
@@ -190,7 +198,7 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
     try:  # noqa: PLR0912 — outer try/finally for thread-level lookup cleanup
         # Materialize thread-level lookups and merge with weave-level
         if thread.lookups:
-            thread_cached_lookups, _ = materialize_lookups(
+            thread_cached_lookups, thread_lookup_results = materialize_lookups(
                 spark, thread.lookups, connections=connections
             )
             all_cached: dict[str, Any] = {}
@@ -198,6 +206,9 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
                 all_cached.update(cached_lookups)
             all_cached.update(thread_cached_lookups)  # thread wins
             effective_cached_lookups = all_cached or None
+            # Thread-scoped materialization facts join the inherited map so
+            # resolve steps can reuse unique-key outcomes at every scope
+            lookup_meta = build_lookup_meta(thread_lookup_results, base=lookup_meta)
             # Merge lookup definitions so resolve_thread_lookups sees both
             effective_weave_lookups = merge_resource_dicts(
                 weave_lookups, thread.lookups, "lookup", "weave", "thread"
@@ -422,7 +433,9 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
             df = next(iter(sources_map.values()))
             rows_read = df.count()
 
-            # Step 6 — run pipeline steps
+            # Step 6 — run pipeline steps. Step statistics attach as
+            # Observations and are harvested after the write.
+            obs_registry = ObservationRegistry(scope="main")
             df = run_pipeline(
                 df,
                 thread.steps,
@@ -430,6 +443,8 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
                 effective_column_sets,
                 effective_column_set_defs,
                 lookups=lookup_dfs or None,
+                observations=obs_registry,
+                lookup_meta=lookup_meta,
             )
 
             # Capture intermediate row count for waterfall visualization
@@ -721,6 +736,10 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
                 if quarantine_sample:
                     samples["quarantine"] = quarantine_sample
 
+            # Harvest step observations — fulfilled by the write (or the
+            # last action that executed the plan). Best-effort by design.
+            step_stats = obs_registry.harvest() or None
+
             telemetry = _build_telemetry(
                 span_builder,
                 validation_results,
@@ -729,6 +748,7 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
                 rows_written,
                 rows_quarantined,
                 collector=collector,
+                step_stats=step_stats,
                 load_mode=load_mode,
                 watermark_column=thread.load.watermark_column if thread.load else None,
                 watermark_previous_value=prior_state.last_value if prior_state else None,
@@ -1068,6 +1088,7 @@ def _build_telemetry(
     drift_columns: list[str] | None = None,
     drift_mode: str | None = None,
     drift_action_taken: str | None = None,
+    step_stats: dict[str, dict[str, Any]] | None = None,
 ) -> ThreadTelemetry:
     """Build ThreadTelemetry and finalize the span if a builder is active."""
     if span_builder is not None:
@@ -1111,4 +1132,5 @@ def _build_telemetry(
         drift_columns=drift_columns or [],
         drift_mode=drift_mode,
         drift_action_taken=drift_action_taken,
+        step_stats=step_stats,
     )

--- a/packages/weevr/src/weevr/engine/executor.py
+++ b/packages/weevr/src/weevr/engine/executor.py
@@ -420,6 +420,10 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
                 sources_map = read_sources(spark, normal_sources, connections=connections)
                 sources_map.update(lookup_dfs)
 
+            # Step statistics attach as Observations (harvested after the
+            # write); CTE sub-pipelines contribute under their own scopes.
+            obs_registry = ObservationRegistry(scope="main")
+
             # Resolve with: block CTEs before the primary DataFrame is set
             if thread.with_:
                 sources_map = _resolve_with_block(
@@ -427,15 +431,15 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
                     sources_map,
                     collector=collector if span_builder else None,
                     parent_span_id=span_builder.span_id if span_builder else None,
+                    observations=obs_registry,
+                    lookup_meta=lookup_meta,
                 )
 
             # Step 5 — primary DataFrame is the first declared source
             df = next(iter(sources_map.values()))
             rows_read = df.count()
 
-            # Step 6 — run pipeline steps. Step statistics attach as
-            # Observations and are harvested after the write.
-            obs_registry = ObservationRegistry(scope="main")
+            # Step 6 — run pipeline steps
             df = run_pipeline(
                 df,
                 thread.steps,
@@ -862,6 +866,8 @@ def _resolve_with_block(
     sources_map: dict[str, Any],
     collector: SpanCollector | None = None,
     parent_span_id: str | None = None,
+    observations: ObservationRegistry | None = None,
+    lookup_meta: dict[str, LookupMeta] | None = None,
 ) -> dict[str, Any]:
     """Resolve with: block CTEs, registering each result in the source registry.
 
@@ -877,6 +883,9 @@ def _resolve_with_block(
         sources_map: Current source registry (sources + lookup DataFrames).
         collector: Optional span collector for telemetry.
         parent_span_id: Parent span ID to link CTE spans into the thread span.
+        observations: Thread-level registry; each CTE's observations attach
+            under its own scope and merge in for plan-wide unique names.
+        lookup_meta: Materialization-time lookup facts for resolve steps.
 
     Returns:
         An enriched copy of ``sources_map`` with each CTE result registered
@@ -895,7 +904,16 @@ def _resolve_with_block(
                 f"Available: {sorted(enriched)}"
             )
         cte_df = enriched[cte.from_]
-        cte_df = run_pipeline(cte_df, cte.steps, enriched)
+        cte_registry = ObservationRegistry(scope=cte_name) if observations is not None else None
+        cte_df = run_pipeline(
+            cte_df,
+            cte.steps,
+            enriched,
+            observations=cte_registry,
+            lookup_meta=lookup_meta,
+        )
+        if observations is not None and cte_registry is not None:
+            observations.merge(cte_registry)
         row_count = cte_df.count()
         enriched[cte_name] = cte_df
 

--- a/packages/weevr/src/weevr/engine/lookups.py
+++ b/packages/weevr/src/weevr/engine/lookups.py
@@ -14,6 +14,7 @@ from weevr.model.base import FrozenBase
 from weevr.model.connection import OneLakeConnection
 from weevr.model.lookup import Lookup
 from weevr.model.source import Source
+from weevr.operations.pipeline._lookup_meta import LookupMeta
 from weevr.operations.readers import read_source
 from weevr.telemetry.span import SpanStatus
 
@@ -51,6 +52,31 @@ class LookupResult(FrozenBase):
     filter_applied: bool = False
     unique_key_checked: bool = False
     unique_key_passed: bool | None = None
+
+
+def build_lookup_meta(
+    results: list[LookupResult],
+    base: dict[str, LookupMeta] | None = None,
+) -> dict[str, LookupMeta]:
+    """Reduce materialization results to per-lookup facts for resolve steps.
+
+    Args:
+        results: Materialization results to convert, keyed into the map by
+            lookup name (later entries win on collision).
+        base: Facts inherited from a parent scope (e.g. loom-level), copied
+            first so scope precedence matches the cached-DataFrame maps.
+
+    Returns:
+        Mapping of lookup name to reduced facts.
+    """
+    meta: dict[str, LookupMeta] = dict(base or {})
+    for r in results:
+        meta[r.name] = LookupMeta(
+            key_columns=tuple(r.key_columns) if r.key_columns else None,
+            unique_key_checked=r.unique_key_checked,
+            unique_key_passed=r.unique_key_passed,
+        )
+    return meta
 
 
 def _validate_columns(df: DataFrame, columns: list[str], lookup_name: str) -> None:

--- a/packages/weevr/src/weevr/engine/lookups.py
+++ b/packages/weevr/src/weevr/engine/lookups.py
@@ -40,6 +40,8 @@ class LookupResult(FrozenBase):
         filter_applied: Whether a filter expression was applied.
         unique_key_checked: Whether a unique-key check was performed.
         unique_key_passed: Result of the unique-key check, if performed.
+        source_size_bytes: Delta snapshot size of the source table, when
+            resolvable — evidence for the broadcast hint policy.
     """
 
     name: str
@@ -52,6 +54,49 @@ class LookupResult(FrozenBase):
     filter_applied: bool = False
     unique_key_checked: bool = False
     unique_key_passed: bool | None = None
+    source_size_bytes: int | None = None
+
+
+def _delta_source_size(
+    spark: SparkSession,
+    source: Source,
+    connections: dict[str, OneLakeConnection] | None,
+) -> int | None:
+    """Best-effort Delta snapshot size for a lookup source, in bytes.
+
+    A driver-side Delta log read — no Spark jobs. Returns None for
+    non-Delta sources or any resolution failure; absence of evidence
+    simply means no size-based broadcast hint.
+    """
+    try:
+        from delta.tables import DeltaTable
+
+        if source.connection:
+            if not connections or source.connection not in connections:
+                return None
+            from weevr.config.paths import build_onelake_path
+
+            conn = connections[source.connection]
+            if source.table is None:
+                return None
+            location = build_onelake_path(conn, source.schema_override, source.table)
+            table = DeltaTable.forPath(spark, location)
+        elif source.type == "delta" and source.alias is not None:
+            from weevr.config.paths import resolve_fuse_path
+            from weevr.delta import is_table_alias
+
+            if is_table_alias(source.alias):
+                table = DeltaTable.forName(spark, source.alias)
+            else:
+                table = DeltaTable.forPath(spark, resolve_fuse_path(source.alias, spark))
+        else:
+            return None
+        detail = table.detail().collect()[0]
+        size = detail["sizeInBytes"]
+        return int(size) if size is not None else None
+    except Exception:
+        logger.debug("Could not resolve Delta size for lookup source", exc_info=True)
+        return None
 
 
 def build_lookup_meta(
@@ -75,6 +120,8 @@ def build_lookup_meta(
             key_columns=tuple(r.key_columns) if r.key_columns else None,
             unique_key_checked=r.unique_key_checked,
             unique_key_passed=r.unique_key_passed,
+            size_in_bytes=r.source_size_bytes,
+            broadcast_declared=r.materialized and r.strategy == "broadcast",
         )
     return meta
 
@@ -221,6 +268,7 @@ def materialize_lookups(
         start = time.monotonic()
         try:
             df = read_source(spark, name, lookup.source, connections=connections)
+            source_size = _delta_source_size(spark, lookup.source, connections)
 
             # Apply narrow pipeline (filter → project → unique_key)
             df, filter_applied, uk_checked, uk_passed = _apply_narrow_pipeline(df, lookup, name)
@@ -250,6 +298,7 @@ def materialize_lookups(
                     filter_applied=filter_applied,
                     unique_key_checked=uk_checked,
                     unique_key_passed=uk_passed,
+                    source_size_bytes=source_size,
                 )
             )
 

--- a/packages/weevr/src/weevr/engine/runner.py
+++ b/packages/weevr/src/weevr/engine/runner.py
@@ -16,7 +16,12 @@ from weevr.engine.column_sets import materialize_column_sets
 from weevr.engine.conditions import evaluate_condition
 from weevr.engine.executor import execute_thread
 from weevr.engine.hooks import HookResult, run_hook_steps
-from weevr.engine.lookups import LookupResult, cleanup_lookups, materialize_lookups
+from weevr.engine.lookups import (
+    LookupResult,
+    build_lookup_meta,
+    cleanup_lookups,
+    materialize_lookups,
+)
 from weevr.engine.planner import ExecutionPlan, build_plan
 from weevr.engine.resources import merge_resource_dicts
 from weevr.engine.result import LoomResult, ThreadResult, WeaveResult
@@ -31,6 +36,7 @@ from weevr.model.loom import Loom
 from weevr.model.thread import Thread
 from weevr.model.variable import VariableSpec
 from weevr.model.weave import ConditionSpec, Weave
+from weevr.operations.pipeline._lookup_meta import LookupMeta
 from weevr.telemetry.collector import SpanCollector
 from weevr.telemetry.logging import configure_logging
 from weevr.telemetry.results import (
@@ -89,6 +95,7 @@ def execute_weave(
     pre_cached_lookups: dict[str, Any] | None = None,
     connections: dict[str, OneLakeConnection] | None = None,
     execution: ExecutionConfig | None = None,
+    pre_lookup_meta: dict[str, LookupMeta] | None = None,
 ) -> WeaveResult:
     """Execute threads according to the execution plan.
 
@@ -140,6 +147,8 @@ def execute_weave(
             merged by the caller — see ``resolve_effective_execution``).
             ``max_parallel_threads`` caps each group's pool; unset means
             the pool is sized to the group.
+        pre_lookup_meta: Materialization-time lookup facts from the parent
+            scope (loom), merged under weave-level facts at dispatch.
 
     Returns:
         :class:`~weevr.engine.result.WeaveResult` with aggregate status and
@@ -324,6 +333,10 @@ def execute_weave(
                                 collector=tc,
                                 parent_span_id=weave_span_id,
                                 cached_lookups=cached_lookup_dfs or None,
+                                lookup_meta=build_lookup_meta(
+                                    all_lookup_results, base=pre_lookup_meta
+                                )
+                                or None,
                                 weave_lookups=lookups,
                                 resolved_params=params,
                                 loom_name=loom_name,
@@ -340,6 +353,10 @@ def execute_weave(
                                 spark,
                                 threads[name],
                                 cached_lookups=cached_lookup_dfs or None,
+                                lookup_meta=build_lookup_meta(
+                                    all_lookup_results, base=pre_lookup_meta
+                                )
+                                or None,
                                 weave_lookups=lookups,
                                 resolved_params=params,
                                 loom_name=loom_name,
@@ -626,9 +643,10 @@ def execute_loom(
             )
 
         # Materialize loom-level lookups (shared across all weaves)
+        loom_lookup_results: list[LookupResult] = []
         loom_connections = dict(loom.connections) if loom.connections else None
         if loom.lookups:
-            loom_cached_lookup_dfs, _ = materialize_lookups(
+            loom_cached_lookup_dfs, loom_lookup_results = materialize_lookups(
                 spark,
                 dict(loom.lookups),
                 collector=collector,
@@ -732,6 +750,7 @@ def execute_loom(
                     loom_name=loom.name,
                     weave_name=weave_name,
                     column_set_defs=merged_column_set_defs,
+                    pre_lookup_meta=build_lookup_meta(loom_lookup_results) or None,
                     pre_cached_lookups=loom_cached_lookup_dfs or None,
                     connections=merged_connections or None,
                     execution=effective_execution,

--- a/packages/weevr/src/weevr/operations/pipeline/__init__.py
+++ b/packages/weevr/src/weevr/operations/pipeline/__init__.py
@@ -35,6 +35,8 @@ from weevr.model.pipeline import (
     UnpivotStep,
     WindowStep,
 )
+from weevr.operations.pipeline._lookup_meta import LookupMeta
+from weevr.operations.pipeline._observations import ObservationRegistry
 from weevr.operations.pipeline._result import StepResult
 from weevr.operations.pipeline.analytical import (
     apply_aggregate,
@@ -60,7 +62,7 @@ from weevr.operations.pipeline.transforms import (
 )
 from weevr.operations.pipeline.value_mapping import apply_map
 
-__all__ = ["StepResult", "run_pipeline"]
+__all__ = ["LookupMeta", "ObservationRegistry", "StepResult", "run_pipeline"]
 
 _logger = logging.getLogger(__name__)
 
@@ -107,6 +109,8 @@ def run_pipeline(
     column_sets: dict[str, dict[str, str]] | None = None,
     column_set_defs: dict[str, ColumnSet] | None = None,
     lookups: dict[str, DataFrame] | None = None,
+    observations: ObservationRegistry | None = None,
+    lookup_meta: dict[str, LookupMeta] | None = None,
 ) -> DataFrame:
     """Execute a sequence of pipeline steps against a working DataFrame.
 
@@ -128,6 +132,13 @@ def run_pipeline(
             that reference a column set.
         lookups: Cached lookup DataFrames keyed by name. Required for
             resolve steps that reference named lookups.
+        observations: Registry for lazily observed step statistics. When
+            provided, stat-producing handlers attach Observations instead
+            of running eager aggregations; the caller harvests after its
+            terminal action.
+        lookup_meta: Materialization-time lookup facts keyed by lookup
+            name; resolve steps reuse unique-key outcomes to skip their
+            duplicate pre-check when valid.
 
     Returns:
         Final DataFrame after all steps have been applied.
@@ -155,7 +166,13 @@ def run_pipeline(
         resolve_lookups = lookups or {}
         params = step.resolve
         if params.batch is not None:
-            return apply_resolve_batch(result, params, resolve_lookups)
+            return apply_resolve_batch(
+                result,
+                params,
+                resolve_lookups,
+                observations=observations,
+                lookup_meta=lookup_meta,
+            )
         # Single mode — look up the named lookup DataFrame
         lookup_name = params.lookup
         if lookup_name is None:
@@ -192,7 +209,13 @@ def run_pipeline(
             raise ExecutionError(
                 f"Lookup '{lookup_name}' not found for resolve step '{params.name}'",
             )
-        return apply_resolve(result, params, lookup_df)
+        return apply_resolve(
+            result,
+            params,
+            lookup_df,
+            observations=observations,
+            lookup_meta=(lookup_meta or {}).get(lookup_name),
+        )
 
     result = df
     for i, step in enumerate(steps):

--- a/packages/weevr/src/weevr/operations/pipeline/__init__.py
+++ b/packages/weevr/src/weevr/operations/pipeline/__init__.py
@@ -97,7 +97,6 @@ _STEP_HANDLERS: dict[type, StepHandler] = {
     DateOpsStep: lambda df, step, _src: StepResult(apply_date_ops(df, step.date_ops)),
     # Transform step extensions
     ConcatStep: lambda df, step, _src: apply_concat(df, step.concat),
-    MapStep: lambda df, step, _src: apply_map(df, step.map),
     FormatStep: lambda df, step, _src: apply_format(df, step.format),
 }
 
@@ -190,6 +189,24 @@ def run_pipeline(
                     params.on_unknown,
                 )
                 fallback_df = result.withColumn(params.name, F.lit(params.on_unknown))
+                if observations is not None:
+                    # Total arrives with the terminal action; every row is
+                    # unknown by construction, the rest of the stats are
+                    # zeros derived from it.
+                    obs = observations.create(
+                        step="resolve",
+                        name=params.name,
+                        derive=lambda v: {
+                            "total": int(v.get("total") or 0),
+                            "matched": 0,
+                            "unknown": int(v.get("total") or 0),
+                            "invalid": 0,
+                            "duplicates": 0,
+                            "match_rate": 0.0,
+                        },
+                    )
+                    fallback_df = fallback_df.observe(obs, F.count(F.lit(1)).alias("total"))
+                    return StepResult(fallback_df, metadata={})
                 total = fallback_df.count()
                 return StepResult(
                     fallback_df,
@@ -225,6 +242,9 @@ def run_pipeline(
                 result = step_result.df
             elif isinstance(step, ResolveStep):
                 step_result = _dispatch_resolve(result, step)
+                result = step_result.df
+            elif isinstance(step, MapStep):
+                step_result = apply_map(result, step.map, observations=observations)
                 result = step_result.df
             else:
                 handler = _STEP_HANDLERS.get(type(step))

--- a/packages/weevr/src/weevr/operations/pipeline/_lookup_meta.py
+++ b/packages/weevr/src/weevr/operations/pipeline/_lookup_meta.py
@@ -1,0 +1,31 @@
+"""Lookup metadata carrier — materialization-time facts for resolve steps.
+
+The engine learns things about a lookup when it materializes it (declared
+key columns, unique-key check outcome, source size). Resolve steps can
+reuse those facts to skip redundant work — but only the reduced facts
+travel, not the engine's ``LookupResult``, keeping the operations layer
+free of engine imports.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class LookupMeta:
+    """Reduced materialization facts for one lookup.
+
+    Attributes:
+        key_columns: The lookup's declared ``key`` columns, if any.
+        unique_key_checked: Whether a unique-key check ran at
+            materialization.
+        unique_key_passed: The check's outcome, when it ran.
+        size_in_bytes: Delta snapshot size of the lookup's source table,
+            when known — evidence for the broadcast hint policy.
+    """
+
+    key_columns: tuple[str, ...] | None = None
+    unique_key_checked: bool = False
+    unique_key_passed: bool | None = None
+    size_in_bytes: int | None = None

--- a/packages/weevr/src/weevr/operations/pipeline/_lookup_meta.py
+++ b/packages/weevr/src/weevr/operations/pipeline/_lookup_meta.py
@@ -23,9 +23,12 @@ class LookupMeta:
         unique_key_passed: The check's outcome, when it ran.
         size_in_bytes: Delta snapshot size of the lookup's source table,
             when known — evidence for the broadcast hint policy.
+        broadcast_declared: Whether the user declared ``strategy:
+            broadcast`` on a materialized lookup.
     """
 
     key_columns: tuple[str, ...] | None = None
     unique_key_checked: bool = False
     unique_key_passed: bool | None = None
     size_in_bytes: int | None = None
+    broadcast_declared: bool = False

--- a/packages/weevr/src/weevr/operations/pipeline/_observations.py
+++ b/packages/weevr/src/weevr/operations/pipeline/_observations.py
@@ -1,0 +1,147 @@
+"""Observation registry — lazy per-step statistics collection.
+
+Step handlers attach :class:`pyspark.sql.Observation` objects to their
+output DataFrames instead of running eager fact-scale aggregations. The
+observations are fulfilled as a byproduct of whatever action later
+executes the plan (normally the target write), and the executor harvests
+them afterward into thread telemetry.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from pyspark.sql import Observation
+
+logger = logging.getLogger(__name__)
+
+# Post-write the observations are already fulfilled, so `.get` returns
+# immediately; the timeout only guards pathological callers that harvest
+# before any action executed the observed plan.
+_HARVEST_TIMEOUT_S = 30.0
+
+
+def _get_with_timeout(observation: Observation, timeout: float) -> dict[str, Any]:
+    """Read ``observation.get`` with a timeout.
+
+    ``get`` blocks until fulfilled and the JVM side exposes no
+    non-blocking probe on this Spark line, so the read runs on a daemon
+    thread — on timeout the thread stays parked but, being a daemon,
+    can never hang interpreter shutdown.
+    """
+    result: list[dict[str, Any]] = []
+
+    def _reader() -> None:
+        result.append(dict(observation.get))
+
+    reader = threading.Thread(target=_reader, daemon=True, name="weevr-obs-harvest")
+    reader.start()
+    reader.join(timeout)
+    if not result:
+        raise TimeoutError("observation not fulfilled")
+    return result[0]
+
+
+@dataclass
+class _Entry:
+    key: str
+    observation: Observation
+    extras: dict[str, Any] = field(default_factory=dict)
+    derive: Callable[[dict[str, Any]], dict[str, Any]] | None = None
+
+
+class ObservationRegistry:
+    """Collects step observations for post-action harvest.
+
+    Observation names are namespaced ``__weevr_obs_<scope>_<step>_<name>``
+    so that main-pipeline, CTE sub-pipeline, and batch-item observations
+    never collide within one thread's plan.
+
+    Args:
+        scope: Pipeline scope label — ``"main"`` for the primary pipeline,
+            the CTE name for ``with:`` sub-pipelines.
+    """
+
+    def __init__(self, scope: str = "main") -> None:
+        self._scope = scope
+        self._entries: list[_Entry] = []
+        self._names: set[str] = set()
+
+    def create(
+        self,
+        step: str,
+        name: str,
+        *,
+        extras: dict[str, Any] | None = None,
+        derive: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+    ) -> Observation:
+        """Create and register a uniquely named Observation.
+
+        Args:
+            step: Step kind (e.g. ``"resolve"``, ``"map"``).
+            name: Step-local stat name (e.g. the FK column name).
+            extras: Values known at attach time, merged into the harvested
+                row before ``derive`` runs.
+            derive: Optional finalizer mapping the raw harvested values to
+                the published stats dict.
+
+        Returns:
+            The Observation to pass to ``DataFrame.observe``.
+        """
+        base = f"__weevr_obs_{self._scope}_{step}_{name}"
+        obs_name = base
+        key = f"{self._scope}.{step}.{name}"
+        suffix = 1
+        while obs_name in self._names:
+            obs_name = f"{base}_{suffix}"
+            key = f"{self._scope}.{step}.{name}_{suffix}"
+            suffix += 1
+        self._names.add(obs_name)
+
+        obs = Observation(obs_name)
+        self._entries.append(
+            _Entry(
+                key=key,
+                observation=obs,
+                extras=dict(extras or {}),
+                derive=derive,
+            )
+        )
+        return obs
+
+    def __bool__(self) -> bool:
+        return bool(self._entries)
+
+    def merge(self, other: ObservationRegistry) -> None:
+        """Absorb another registry's entries (e.g. a CTE sub-pipeline's)."""
+        self._entries.extend(other._entries)
+        self._names.update(other._names)
+
+    def harvest(self) -> dict[str, dict[str, Any]]:
+        """Read every registered observation into a stats mapping.
+
+        Best-effort: a failed or timed-out read logs a warning and yields
+        an absent entry — harvest never raises. On timeout the reader
+        thread stays parked on the blocking ``get``; acceptable because
+        the normal call point (after the terminal action) always finds
+        the observation already fulfilled.
+        """
+        stats: dict[str, dict[str, Any]] = {}
+        for entry in self._entries:
+            try:
+                values = _get_with_timeout(entry.observation, _HARVEST_TIMEOUT_S)
+            except Exception:
+                logger.warning(
+                    "Step statistics harvest failed for '%s'; stats absent.",
+                    entry.key,
+                )
+                continue
+            values.update(entry.extras)
+            if entry.derive is not None:
+                values = entry.derive(values)
+            stats[entry.key] = values
+        return stats

--- a/packages/weevr/src/weevr/operations/pipeline/_observations.py
+++ b/packages/weevr/src/weevr/operations/pipeline/_observations.py
@@ -32,6 +32,14 @@ def _get_with_timeout(observation: Observation, timeout: float) -> dict[str, Any
     non-blocking probe on this Spark line, so the read runs on a daemon
     thread — on timeout the thread stays parked but, being a daemon,
     can never hang interpreter shutdown.
+
+    Residual risk, accepted deliberately: each timed-out read leaks one
+    parked daemon thread for the life of the process, and harvest time
+    is bounded only per-entry. This is acceptable ONLY because every
+    harvest call site guarantees a prior action over every observed node
+    (executor: the rows_after_transforms count; CTEs: the per-CTE count;
+    preview: harvest is skipped unless the sampling action succeeded) —
+    a new call path must preserve that invariant or bound the harvest.
     """
     result: list[dict[str, Any]] = []
 

--- a/packages/weevr/src/weevr/operations/pipeline/resolve.py
+++ b/packages/weevr/src/weevr/operations/pipeline/resolve.py
@@ -17,6 +17,8 @@ from pyspark.sql.window import Window
 
 from weevr.errors.exceptions import ExecutionError
 from weevr.model.pipeline import ResolveParams
+from weevr.operations.pipeline._lookup_meta import LookupMeta
+from weevr.operations.pipeline._observations import ObservationRegistry
 from weevr.operations.pipeline._result import StepResult
 
 logger = logging.getLogger(__name__)
@@ -44,6 +46,8 @@ def apply_resolve(
     lookup_df: DataFrame,
     *,
     _drop_source_columns: bool | None = None,
+    observations: ObservationRegistry | None = None,
+    lookup_meta: LookupMeta | None = None,
 ) -> StepResult:
     """Resolve foreign keys by joining fact rows to a lookup dimension.
 
@@ -53,10 +57,18 @@ def apply_resolve(
         lookup_df: Lookup (dimension) DataFrame.
         _drop_source_columns: Override for drop behavior (used by batch
             mode to defer drops until after all FKs complete).
+        observations: When provided, resolution statistics are attached
+            as an Observation (computed by the terminal action, no extra
+            Spark jobs) instead of an eager aggregation, and the eager
+            stats disappear from ``StepResult.metadata``.
+        lookup_meta: Materialization-time facts about the lookup. When
+            the lookup's unique-key check already proved the join keys
+            duplicate-free (and the reuse is valid for this resolve),
+            the duplicate gate skips even its lookup-side pre-check.
 
     Returns:
         StepResult with the resolved FK column added and metadata
-        containing per-FK resolution statistics.
+        containing per-FK resolution statistics (eager mode only).
     """
     if params.match is None:
         raise ExecutionError("match is required for resolve")
@@ -119,7 +131,7 @@ def apply_resolve(
     # Step 3: Build join condition
     # ---------------------------------------------------------------
     join_cols_src = [norm_source_map.get(sc, sc) for sc in source_cols]
-    join_cols_lkp = [norm_lookup_map.get(lc, lc) for lc in lookup_bk_cols]
+    join_cols_lkp: list[str] = [norm_lookup_map.get(lc) or lc for lc in lookup_bk_cols]
     join_cond: Column = F.lit(True)
     for src_c, lkp_c in zip(join_cols_src, join_cols_lkp, strict=True):
         join_cond = join_cond & (F.col(f"__fact__.{src_c}") == F.col(f"__lkp__.{lkp_c}"))
@@ -135,38 +147,67 @@ def apply_resolve(
         join_cond = join_cond & (F.col(to_col).isNull() | (F.col(date_col) < F.col(to_col)))
 
     # ---------------------------------------------------------------
-    # Step 4: Left join with row ID for duplicate detection
+    # Step 4: Duplicate gate. For plain business-key resolves, decide
+    # lookup-side whether duplicates are possible at all: a dim-sized
+    # pre-check (or the reused materialization-time unique-key outcome)
+    # proves the common case clean and skips the row-id column, the
+    # window, and the fact-side duplicate count entirely. Any duplicate
+    # keys fall back to the exact fact-side path so on_duplicate
+    # semantics — error only when a fact row actually matches a
+    # duplicated key, before the write — are byte-identical. Resolves
+    # with an ``effective`` block keep the fact-side path
+    # unconditionally (a BK legitimately carries multiple versions).
     # ---------------------------------------------------------------
     pk_col = f"__lkp__.{params.pk}"
-    dup_marker = "__resolve_dup_rn__"
-    row_id = "__resolve_row_id__"
-    df_with_id = df.withColumn(row_id, F.monotonically_increasing_id())
-    fact_aliased = df_with_id.alias("__fact__")
     lkp_aliased = lookup_df.alias("__lkp__")
-    joined = fact_aliased.join(lkp_aliased, join_cond, "left")
 
-    window = Window.partitionBy(F.col(f"__fact__.{row_id}")).orderBy(F.col(pk_col).asc_nulls_last())
-    joined = joined.withColumn(dup_marker, F.row_number().over(window))
+    plain_bk = params.effective is None
+    if plain_bk:
+        if _uniqueness_reusable(lookup_meta, lookup_bk_cols, params.normalize):
+            need_dup_window = False
+        else:
+            need_dup_window = _has_duplicate_join_keys(lookup_df, join_cols_lkp)
+    else:
+        need_dup_window = True
 
-    # Count duplicates before filtering
-    dup_count = joined.filter(F.col(dup_marker) > 1).count()
+    if need_dup_window:
+        dup_marker = "__resolve_dup_rn__"
+        row_id = "__resolve_row_id__"
+        fact_base = df.withColumn(row_id, F.monotonically_increasing_id())
+        fact_aliased = fact_base.alias("__fact__")
+        joined = fact_aliased.join(lkp_aliased, join_cond, "left")
 
-    if dup_count > 0:
-        if params.on_duplicate == "error":
-            raise ExecutionError(
-                f"Duplicate matches found during resolve of '{params.name}': "
-                f"{dup_count} extra match(es). Use on_duplicate='warn' or "
-                f"'first' to handle duplicates."
-            )
-        if params.on_duplicate == "warn":
-            logger.warning(
-                "Resolve '%s': %d duplicate match(es) found; taking first match per row.",
-                params.name,
-                dup_count,
-            )
+        window = Window.partitionBy(F.col(f"__fact__.{row_id}")).orderBy(
+            F.col(pk_col).asc_nulls_last()
+        )
+        joined = joined.withColumn(dup_marker, F.row_number().over(window))
 
-    # Keep only first match per fact row
-    joined = joined.filter(F.col(dup_marker) == 1)
+        # Count duplicates before filtering
+        dup_count = joined.filter(F.col(dup_marker) > 1).count()
+
+        if dup_count > 0:
+            if params.on_duplicate == "error":
+                raise ExecutionError(
+                    f"Duplicate matches found during resolve of '{params.name}': "
+                    f"{dup_count} extra match(es). Use on_duplicate='warn' or "
+                    f"'first' to handle duplicates."
+                )
+            if params.on_duplicate == "warn":
+                logger.warning(
+                    "Resolve '%s': %d duplicate match(es) found; taking first match per row.",
+                    params.name,
+                    dup_count,
+                )
+
+        # Keep only first match per fact row
+        joined = joined.filter(F.col(dup_marker) == 1)
+    else:
+        # Duplicates provably impossible: a plain left join yields at most
+        # one match per fact row — no row id, no window, no dup count.
+        fact_base = df
+        fact_aliased = fact_base.alias("__fact__")
+        joined = fact_aliased.join(lkp_aliased, join_cond, "left")
+        dup_count = 0
 
     # ---------------------------------------------------------------
     # Step 6: Resolve FK value — match, unknown, invalid
@@ -195,7 +236,7 @@ def apply_resolve(
             include_renames = {c: c for c in params.include}
 
         prefix = params.include_prefix or ""
-        existing_cols = set(df_with_id.columns)
+        existing_cols = set(fact_base.columns)
         for src_name, tgt_name in include_renames.items():
             final_name = f"{prefix}{tgt_name}"
             if final_name in existing_cols:
@@ -216,7 +257,7 @@ def apply_resolve(
     # Step 8: Select final columns
     # ---------------------------------------------------------------
     # Keep all fact columns (minus internal ones) + resolved + includes
-    fact_cols = [c for c in df_with_id.columns if not c.startswith("__resolve_")]
+    fact_cols = [c for c in fact_base.columns if not c.startswith("__resolve_")]
     # Remove the invalid flag column
     fact_cols = [c for c in fact_cols if c != invalid_flag]
 
@@ -232,9 +273,10 @@ def apply_resolve(
 
     result_df = joined.select(*select_exprs)
 
-    # Drop internal row_id
-    if row_id in result_df.columns:
-        result_df = result_df.drop(row_id)
+    # Drop internal row_id (window path only; the name never survives
+    # the clean path)
+    if "__resolve_row_id__" in result_df.columns:
+        result_df = result_df.drop("__resolve_row_id__")
 
     # ---------------------------------------------------------------
     # Step 9: Drop source columns if requested
@@ -243,39 +285,88 @@ def apply_resolve(
         result_df = result_df.drop(*source_cols)
 
     # ---------------------------------------------------------------
-    # Step 10: Compute resolution stats (single aggregation pass)
+    # Step 10: Resolution stats — observed lazily when a registry is
+    # provided (fulfilled by the terminal action, zero extra jobs);
+    # computed eagerly otherwise so the function stays independently
+    # usable outside the engine.
     # ---------------------------------------------------------------
     fk_col = F.col(params.name)
-    agg_row = result_df.agg(
-        F.count("*").alias("total"),
+    stat_exprs = (
+        F.count(F.lit(1)).alias("total"),
         F.sum(F.when(fk_col == F.lit(params.on_invalid), 1).otherwise(0)).alias("invalid"),
         F.sum(F.when(fk_col == F.lit(params.on_unknown), 1).otherwise(0)).alias("unknown"),
-    ).collect()[0]
+    )
 
-    total = int(agg_row["total"] or 0)
-    invalid_count = int(agg_row["invalid"] or 0)
-    unknown_count = int(agg_row["unknown"] or 0)
-    matched_count = total - invalid_count - unknown_count
+    if observations is not None:
+        obs = observations.create(
+            step="resolve",
+            name=params.name,
+            extras={"duplicates": dup_count},
+            derive=_finalize_resolve_stats,
+        )
+        result_df = result_df.observe(obs, *stat_exprs)
+        return StepResult(result_df, metadata={})
 
-    stats: dict[str, Any] = {
-        "total": total,
-        "matched": matched_count,
-        "unknown": unknown_count,
-        "invalid": invalid_count,
-        "duplicates": dup_count,
-        "match_rate": round(matched_count / total * 100, 2) if total > 0 else 0.0,
-    }
-
+    agg_row = result_df.agg(*stat_exprs).collect()[0]
+    stats = _finalize_resolve_stats({**agg_row.asDict(), "duplicates": dup_count})
     return StepResult(
         result_df,
         metadata={"resolve_stats": {params.name: stats}},
     )
 
 
+def _uniqueness_reusable(
+    meta: LookupMeta | None,
+    join_key_columns: list[str],
+    normalize: str | None,
+) -> bool:
+    """Whether a materialization-time unique-key outcome proves this join clean.
+
+    Valid only when the declared unique-key columns equal this resolve's
+    match-target columns AND no normalization applies — normalization can
+    merge two distinct keys (``trim_lower`` collapses ``"A"``/``"a"``)
+    after the check ran, so a passed check proves nothing post-normalize.
+    Row-removing filters (``where``, current-flag) cannot create
+    duplicates and never invalidate the reuse.
+    """
+    if meta is None or not meta.unique_key_checked or meta.unique_key_passed is not True:
+        return False
+    if normalize is not None and normalize != "none":
+        return False
+    return meta.key_columns is not None and list(meta.key_columns) == join_key_columns
+
+
+def _has_duplicate_join_keys(lookup_df: DataFrame, join_columns: list[str]) -> bool:
+    """Dim-sized pre-check: does any join-key group hold more than one row?"""
+    counted = lookup_df.groupBy(*[F.col(c) for c in join_columns]).agg(
+        F.count(F.lit(1)).alias("__resolve_precheck_cnt__")
+    )
+    return counted.filter(F.col("__resolve_precheck_cnt__") > 1).limit(1).count() > 0
+
+
+def _finalize_resolve_stats(values: dict[str, Any]) -> dict[str, Any]:
+    """Derive the published resolve stats from raw aggregate values."""
+    total = int(values.get("total") or 0)
+    invalid_count = int(values.get("invalid") or 0)
+    unknown_count = int(values.get("unknown") or 0)
+    matched_count = total - invalid_count - unknown_count
+    return {
+        "total": total,
+        "matched": matched_count,
+        "unknown": unknown_count,
+        "invalid": invalid_count,
+        "duplicates": int(values.get("duplicates") or 0),
+        "match_rate": round(matched_count / total * 100, 2) if total > 0 else 0.0,
+    }
+
+
 def apply_resolve_batch(
     df: DataFrame,
     params: ResolveParams,
     lookups: dict[str, DataFrame],
+    *,
+    observations: ObservationRegistry | None = None,
+    lookup_meta: dict[str, LookupMeta] | None = None,
 ) -> StepResult:
     """Resolve multiple FKs in batch mode.
 
@@ -287,6 +378,10 @@ def apply_resolve_batch(
         df: Fact DataFrame.
         params: Resolve parameters with batch items.
         lookups: Dict mapping lookup names to DataFrames.
+        observations: Passed through to each item's resolve; see
+            :func:`apply_resolve`.
+        lookup_meta: Materialization facts keyed by lookup name; each
+            item receives its own lookup's entry.
 
     Returns:
         StepResult with all FK columns added and aggregated metadata.
@@ -330,7 +425,14 @@ def apply_resolve_batch(
             where=item.where,
         )
 
-        step_result = apply_resolve(result_df, item_params, lookup_df, _drop_source_columns=False)
+        step_result = apply_resolve(
+            result_df,
+            item_params,
+            lookup_df,
+            _drop_source_columns=False,
+            observations=observations,
+            lookup_meta=(lookup_meta or {}).get(lookup_name),
+        )
         result_df = step_result.df
 
         # Collect per-item stats

--- a/packages/weevr/src/weevr/operations/pipeline/resolve.py
+++ b/packages/weevr/src/weevr/operations/pipeline/resolve.py
@@ -159,6 +159,8 @@ def apply_resolve(
     # unconditionally (a BK legitimately carries multiple versions).
     # ---------------------------------------------------------------
     pk_col = f"__lkp__.{params.pk}"
+    if _should_broadcast(lookup_meta, df.sparkSession):
+        lookup_df = F.broadcast(lookup_df)
     lkp_aliased = lookup_df.alias("__lkp__")
 
     plain_bk = params.effective is None
@@ -313,6 +315,45 @@ def apply_resolve(
         result_df,
         metadata={"resolve_stats": {params.name: stats}},
     )
+
+
+def _parse_size_bytes(value: str) -> int | None:
+    """Parse Spark's byte-valued threshold strings (``10485760b``, ``10m``)."""
+    v = value.strip().lower()
+    multipliers = {"k": 1024, "m": 1024**2, "g": 1024**3}
+    try:
+        if v.endswith("b"):
+            v = v[:-1]
+        if v and v[-1] in multipliers:
+            return int(v[:-1]) * multipliers[v[-1]]
+        return int(v)
+    except ValueError:
+        return None
+
+
+def _should_broadcast(meta: LookupMeta | None, spark: Any) -> bool:
+    """Broadcast policy: declared strategy, or size confidently known small.
+
+    The size clause compares the source table's Delta snapshot bytes — a
+    conservative upper bound for the narrowed lookup — against
+    ``spark.sql.autoBroadcastJoinThreshold``. No evidence, disabled
+    threshold, or unparsable configuration means no hint: AQE decides.
+    Never forces an unknown-size lookup onto the driver.
+    """
+    if meta is None:
+        return False
+    if meta.broadcast_declared:
+        return True
+    if meta.size_in_bytes is None:
+        return False
+    try:
+        raw = spark.conf.get("spark.sql.autoBroadcastJoinThreshold", "10485760b")
+    except Exception:
+        return False
+    threshold = _parse_size_bytes(raw or "")
+    if threshold is None or threshold <= 0:
+        return False
+    return meta.size_in_bytes <= threshold
 
 
 def _uniqueness_reusable(

--- a/packages/weevr/src/weevr/operations/pipeline/resolve.py
+++ b/packages/weevr/src/weevr/operations/pipeline/resolve.py
@@ -374,7 +374,11 @@ def _uniqueness_reusable(
         return False
     if normalize is not None and normalize != "none":
         return False
-    return meta.key_columns is not None and list(meta.key_columns) == join_key_columns
+    if meta.key_columns is None:
+        return False
+    # Order-insensitive: uniqueness over a column set is independent of
+    # declaration order, and the join condition is a conjunction.
+    return set(meta.key_columns) == set(join_key_columns)
 
 
 def _has_duplicate_join_keys(lookup_df: DataFrame, join_columns: list[str]) -> bool:

--- a/packages/weevr/src/weevr/operations/pipeline/value_mapping.py
+++ b/packages/weevr/src/weevr/operations/pipeline/value_mapping.py
@@ -8,10 +8,16 @@ import pyspark.sql.functions as F
 from pyspark.sql import Column, DataFrame
 
 from weevr.model.pipeline import MapParams
+from weevr.operations.pipeline._observations import ObservationRegistry
 from weevr.operations.pipeline._result import StepResult
 
 
-def apply_map(df: DataFrame, params: MapParams) -> StepResult:
+def apply_map(
+    df: DataFrame,
+    params: MapParams,
+    *,
+    observations: ObservationRegistry | None = None,
+) -> StepResult:
     """Map discrete values in a column using a lookup dict.
 
     Null handling cascade: on_null (if set) → default (if set) → NULL
@@ -21,6 +27,8 @@ def apply_map(df: DataFrame, params: MapParams) -> StepResult:
     Args:
         df: Input DataFrame.
         params: Map parameters.
+        observations: When provided, validate-mode unmapped counts attach
+            as an Observation instead of an eager count.
 
     Returns:
         StepResult with mapped column (and optional flag column for
@@ -79,7 +87,20 @@ def apply_map(df: DataFrame, params: MapParams) -> StepResult:
     result = df.withColumn(target_col, expr)
 
     if params.unmapped == "validate":
-        unmapped_count = result.filter(F.col(flag_col_name)).count()
-        metadata["unmapped_count"] = unmapped_count
+        if observations is not None:
+            # Observed lazily: the terminal action computes the count as a
+            # byproduct; nothing rides StepResult.metadata.
+            obs = observations.create(
+                step="map",
+                name=target_col,
+                derive=lambda v: {"unmapped_count": int(v.get("unmapped") or 0)},
+            )
+            result = result.observe(
+                obs,
+                F.sum(F.when(F.col(flag_col_name), 1).otherwise(0)).alias("unmapped"),
+            )
+        else:
+            unmapped_count = result.filter(F.col(flag_col_name)).count()
+            metadata["unmapped_count"] = unmapped_count
 
     return StepResult(result, metadata)

--- a/tests/weevr/conftest.py
+++ b/tests/weevr/conftest.py
@@ -90,3 +90,37 @@ def tmp_delta_path(tmp_path: Path):
         return str(table_path)
 
     return _make_path
+
+
+@pytest.fixture()
+def job_counter(spark: SparkSession):
+    """Count Spark jobs executed inside a ``with`` block.
+
+    Uses the status tracker's known-job-id set, so it counts real JVM
+    jobs — including those launched without a Python-side action call
+    (writes, merges, observation-fulfilling actions). Complements
+    ``spark_action_counter``, which counts only DataFrame API calls.
+
+    Usage::
+
+        with job_counter() as jc:
+            df.write.format("delta").save(path)
+        assert jc.jobs == expected
+    """
+
+    class _JobCount:
+        def __enter__(self):
+            tracker = spark.sparkContext.statusTracker()
+            self._before = set(tracker.getJobIdsForGroup(None))
+            return self
+
+        def __exit__(self, *exc: object) -> bool:
+            tracker = spark.sparkContext.statusTracker()
+            self._after = set(tracker.getJobIdsForGroup(None))
+            return False
+
+        @property
+        def jobs(self) -> int:
+            return len(self._after - self._before)
+
+    return _JobCount

--- a/tests/weevr/engine/test_executor.py
+++ b/tests/weevr/engine/test_executor.py
@@ -1798,3 +1798,48 @@ class TestWithBlockColumnControlIntegration:
         assert "subgroup_desc" in cols
         assert "description" not in cols
         assert "level" not in cols
+
+
+class TestCteObservationScoping:
+    """CTE observations merge into the thread registry under unique scopes."""
+
+    def test_same_named_map_steps_in_cte_and_main_never_collide(self, spark: SparkSession) -> None:
+        from weevr.engine.executor import _resolve_with_block
+        from weevr.operations.pipeline import ObservationRegistry, run_pipeline
+
+        orders = spark.createDataFrame(
+            [{"id": 1, "code": "A"}, {"id": 2, "code": "X"}, {"id": 3, "code": "A"}]
+        )
+        sources_map = {"orders": orders}
+        map_step = {"map": {"column": "code", "values": {"A": "alpha"}, "unmapped": "validate"}}
+
+        thread = Thread.model_validate(
+            {
+                "name": "t",
+                "config_version": "1",
+                "sources": {"orders": {"type": "delta", "alias": "/fake/path"}},
+                "steps": [map_step],
+                "target": {"path": "/fake/target"},
+                "with": {"prepped": {"from": "orders", "steps": [map_step]}},
+            }
+        )
+
+        registry = ObservationRegistry(scope="main")
+        enriched = _resolve_with_block(thread, sources_map, observations=registry)
+
+        df = run_pipeline(
+            enriched["prepped"],
+            thread.steps,
+            enriched,
+            observations=registry,
+        )
+        df.collect()
+
+        stats = registry.harvest()
+        # One key per scope: the CTE's map and the main pipeline's map both
+        # observe a column named 'code' without colliding
+        assert set(stats) == {"prepped.map.code", "main.map.code"}
+        assert stats["prepped.map.code"]["unmapped_count"] == 1  # 'X'
+        # The CTE already rewrote A→alpha, so every row ('alpha','X','alpha')
+        # is unmapped for the main step's A→alpha mapping
+        assert stats["main.map.code"]["unmapped_count"] == 3

--- a/tests/weevr/engine/test_job_budget.py
+++ b/tests/weevr/engine/test_job_budget.py
@@ -60,7 +60,9 @@ class TestResolveActionBudget:
         after_first = spark_action_counter["total"]
 
         df = apply_resolve(df, _params("fk_1"), lookup).df
-        df = apply_resolve(df, _params("fk_2"), lookup).df
+        # Final result deliberately unconsumed — the chain exists to count
+        # the eager actions its construction fires, never to execute
+        apply_resolve(df, _params("fk_2"), lookup)
         after_third = spark_action_counter["total"]
 
         assert after_first - start == EAGER_ACTIONS_PER_RESOLVE
@@ -88,7 +90,7 @@ class TestResolveActionBudgetObserved:
 
         start = spark_action_counter["total"]
         df = apply_resolve(df, _params("fk_0"), lookup, observations=registry).df
-        df = apply_resolve(df, _params("fk_1"), lookup, observations=registry).df
+        apply_resolve(df, _params("fk_1"), lookup, observations=registry)
         after = spark_action_counter["total"]
 
         assert (after - start) / 2 == self.EAGER_ACTIONS_PER_RESOLVE_OBSERVED
@@ -105,7 +107,7 @@ class TestResolveActionBudgetObserved:
 
         start = spark_action_counter["total"]
         df = apply_resolve(df, _params("fk_0"), lookup, observations=registry, lookup_meta=meta).df
-        df = apply_resolve(df, _params("fk_1"), lookup, observations=registry, lookup_meta=meta).df
+        apply_resolve(df, _params("fk_1"), lookup, observations=registry, lookup_meta=meta)
         assert spark_action_counter["total"] - start == 0
 
 

--- a/tests/weevr/engine/test_job_budget.py
+++ b/tests/weevr/engine/test_job_budget.py
@@ -1,0 +1,66 @@
+"""Job-budget regression locks for pipeline step handlers.
+
+Locks the marginal eager-action cost of resolve steps. The baseline
+constant documents today's cost; conversions that remove eager actions
+ratchet it down and this suite catches any silent reintroduction.
+
+Two instruments, two purposes:
+
+- ``spark_action_counter`` counts Python-side action calls (count,
+  collect, ...) — the stable per-step invariant, independent of how
+  many JVM jobs each action fans out into.
+- ``job_counter`` counts real JVM jobs — used for scan-level
+  assertions where work happens without a Python action call (writes,
+  observation fulfillment). JVM jobs per action GROW with lineage
+  depth here (the O(N^2) recompute this topic removes), so the chain
+  lock below is expressed in actions, not jobs.
+"""
+
+import pytest
+from pyspark.sql import SparkSession
+
+from weevr.model.pipeline import ResolveParams
+from weevr.operations.pipeline.resolve import apply_resolve
+
+# Today each resolve fires two eager fact-scale actions: the duplicate
+# count and the stats aggregation. Ratcheted to 0 as the observation
+# conversion lands.
+EAGER_ACTIONS_PER_RESOLVE = 2
+
+
+def _lookup(spark: SparkSession):
+    return spark.createDataFrame(
+        [
+            {"code": "A", "sk": 1},
+            {"code": "B", "sk": 2},
+        ]
+    )
+
+
+def _fact(spark: SparkSession, n: int = 100):
+    return spark.range(n).selectExpr("id", "CASE WHEN id % 2 = 0 THEN 'A' ELSE 'B' END AS code")
+
+
+def _params(name: str) -> ResolveParams:
+    return ResolveParams(name=name, lookup="dim", match={"code": "code"}, pk="sk")
+
+
+@pytest.mark.spark
+class TestResolveActionBudget:
+    """Marginal eager-action cost of a resolve chain."""
+
+    def test_marginal_actions_per_resolve(self, spark: SparkSession, spark_action_counter) -> None:
+        lookup = _lookup(spark)
+        df = _fact(spark)
+
+        start = spark_action_counter["total"]
+        df = apply_resolve(df, _params("fk_0"), lookup).df
+        after_first = spark_action_counter["total"]
+
+        df = apply_resolve(df, _params("fk_1"), lookup).df
+        df = apply_resolve(df, _params("fk_2"), lookup).df
+        after_third = spark_action_counter["total"]
+
+        assert after_first - start == EAGER_ACTIONS_PER_RESOLVE
+        marginal = (after_third - after_first) / 2
+        assert marginal == EAGER_ACTIONS_PER_RESOLVE

--- a/tests/weevr/engine/test_job_budget.py
+++ b/tests/weevr/engine/test_job_budget.py
@@ -16,6 +16,8 @@ Two instruments, two purposes:
   lock below is expressed in actions, not jobs.
 """
 
+from typing import Any
+
 import pytest
 from pyspark.sql import SparkSession
 
@@ -105,3 +107,41 @@ class TestResolveActionBudgetObserved:
         df = apply_resolve(df, _params("fk_0"), lookup, observations=registry, lookup_meta=meta).df
         df = apply_resolve(df, _params("fk_1"), lookup, observations=registry, lookup_meta=meta).df
         assert spark_action_counter["total"] - start == 0
+
+
+@pytest.mark.spark
+class TestSingleSourceScan:
+    """A multi-resolve chain executes the fact source scan exactly once."""
+
+    def test_chain_construction_runs_zero_jobs_and_scans_once(
+        self, spark: SparkSession, job_counter, tmp_path
+    ) -> None:
+        from weevr.operations.pipeline import LookupMeta, ObservationRegistry
+
+        fact_path = str(tmp_path / "budget_fact")
+        _fact(spark, 200).write.format("delta").save(fact_path)
+        lookup = _lookup(spark)
+        meta = LookupMeta(key_columns=("code",), unique_key_checked=True, unique_key_passed=True)
+        registry = ObservationRegistry(scope="main")
+
+        df = spark.read.format("delta").load(fact_path)
+        with job_counter() as jc:
+            for i in range(3):
+                df = apply_resolve(
+                    df, _params(f"fk_{i}"), lookup, observations=registry, lookup_meta=meta
+                ).df
+        # Listener-verified: constructing the chain executes NOTHING — no
+        # job may touch the source before the terminal action.
+        assert jc.jobs == 0
+
+        # The final plan contains exactly one file-backed relation — the
+        # fact source (the lookup is an in-memory frame). Combined with the
+        # zero-jobs construction assertion, the single terminal action is
+        # the only execution of that scan.
+        jdf: Any = df._jdf
+        plan = str(jdf.queryExecution().optimizedPlan())
+        assert plan.count("parquet") == 1
+
+        with job_counter() as jc_terminal:
+            df.collect()
+        assert jc_terminal.jobs > 0  # exactly one action executed the chain

--- a/tests/weevr/engine/test_job_budget.py
+++ b/tests/weevr/engine/test_job_budget.py
@@ -64,3 +64,44 @@ class TestResolveActionBudget:
         assert after_first - start == EAGER_ACTIONS_PER_RESOLVE
         marginal = (after_third - after_first) / 2
         assert marginal == EAGER_ACTIONS_PER_RESOLVE
+
+
+@pytest.mark.spark
+class TestResolveActionBudgetObserved:
+    """With a registry, the stats aggregation disappears from the chain."""
+
+    # The stats aggregation is observed; the remaining action is the
+    # dim-scale lookup pre-check (bounded, permitted). With a reusable
+    # unique-key outcome even that disappears — see the zero-action test.
+    EAGER_ACTIONS_PER_RESOLVE_OBSERVED = 1
+
+    def test_marginal_actions_with_registry(
+        self, spark: SparkSession, spark_action_counter
+    ) -> None:
+        from weevr.operations.pipeline import ObservationRegistry
+
+        lookup = _lookup(spark)
+        registry = ObservationRegistry(scope="main")
+        df = _fact(spark)
+
+        start = spark_action_counter["total"]
+        df = apply_resolve(df, _params("fk_0"), lookup, observations=registry).df
+        df = apply_resolve(df, _params("fk_1"), lookup, observations=registry).df
+        after = spark_action_counter["total"]
+
+        assert (after - start) / 2 == self.EAGER_ACTIONS_PER_RESOLVE_OBSERVED
+
+    def test_zero_actions_with_uniqueness_reuse(
+        self, spark: SparkSession, spark_action_counter
+    ) -> None:
+        from weevr.operations.pipeline import LookupMeta, ObservationRegistry
+
+        lookup = _lookup(spark)
+        meta = LookupMeta(key_columns=("code",), unique_key_checked=True, unique_key_passed=True)
+        registry = ObservationRegistry(scope="main")
+        df = _fact(spark)
+
+        start = spark_action_counter["total"]
+        df = apply_resolve(df, _params("fk_0"), lookup, observations=registry, lookup_meta=meta).df
+        df = apply_resolve(df, _params("fk_1"), lookup, observations=registry, lookup_meta=meta).df
+        assert spark_action_counter["total"] - start == 0

--- a/tests/weevr/engine/test_lookup_meta_integration.py
+++ b/tests/weevr/engine/test_lookup_meta_integration.py
@@ -1,0 +1,139 @@
+"""End-to-end lookup-meta plumbing: scoped unique-key reuse reaches resolve.
+
+Locks the four-site materialization-capture plumbing: a lookup whose
+unique-key check passed at materialization must skip the resolve-time
+duplicate pre-check when consumed through the real engine paths. A
+missed capture site degrades silently to the fresh pre-check (safe but
+wasteful) — invisible to outcome assertions, so these tests spy on the
+pre-check itself.
+"""
+
+from typing import Any
+
+import pytest
+from pyspark.sql import SparkSession
+
+from weevr.engine import execute_thread
+from weevr.engine.planner import build_plan
+from weevr.engine.runner import execute_weave
+from weevr.model.lookup import Lookup
+from weevr.model.thread import Thread
+from weevr.model.weave import ThreadEntry
+
+pytestmark = pytest.mark.spark
+
+
+@pytest.fixture()
+def precheck_spy(monkeypatch: pytest.MonkeyPatch) -> list[Any]:
+    """Record every invocation of the resolve duplicate pre-check."""
+    from weevr.operations.pipeline import resolve as resolve_mod
+
+    calls: list[Any] = []
+    original = resolve_mod._has_duplicate_join_keys
+
+    def _spy(lookup_df, join_columns):  # type: ignore[no-untyped-def]
+        calls.append(list(join_columns))
+        return original(lookup_df, join_columns)
+
+    monkeypatch.setattr(resolve_mod, "_has_duplicate_join_keys", _spy)
+    return calls
+
+
+def _write_dim(spark: SparkSession, path: str) -> None:
+    spark.createDataFrame([{"sk": 1, "code": "A"}, {"sk": 2, "code": "B"}]).write.format(
+        "delta"
+    ).save(path)
+
+
+def _write_src(spark: SparkSession, path: str) -> None:
+    spark.createDataFrame(
+        [{"id": 1, "code": "A"}, {"id": 2, "code": "B"}, {"id": 3, "code": "A"}]
+    ).write.format("delta").save(path)
+
+
+def _lookup_cfg(dim_path: str, *, unique_key: bool) -> dict[str, Any]:
+    return {
+        "source": {"type": "delta", "alias": dim_path},
+        "materialize": True,
+        "key": ["code"],
+        "unique_key": unique_key,
+    }
+
+
+def _thread_cfg(src_path: str, tgt_path: str, *, lookups: dict[str, Any] | None = None) -> Thread:
+    cfg: dict[str, Any] = {
+        "name": "fact_t",
+        "config_version": "1",
+        "sources": {
+            "main": {"type": "delta", "alias": src_path},
+            "dim_codes": {"lookup": "dim_codes"},
+        },
+        "steps": [
+            {
+                "resolve": {
+                    "name": "code_sk",
+                    "lookup": "dim_codes",
+                    "match": {"code": "code"},
+                    "pk": "sk",
+                }
+            }
+        ],
+        "target": {"path": tgt_path},
+        "write": {"mode": "overwrite"},
+    }
+    if lookups is not None:
+        cfg["lookups"] = lookups
+    return Thread.model_validate(cfg)
+
+
+class TestThreadScopedReuse:
+    def test_thread_lookup_unique_key_skips_precheck(
+        self, spark: SparkSession, tmp_delta_path, precheck_spy: list[Any]
+    ) -> None:
+        dim = tmp_delta_path("meta_dim_t1")
+        src = tmp_delta_path("meta_src_t1")
+        tgt = tmp_delta_path("meta_tgt_t1")
+        _write_dim(spark, dim)
+        _write_src(spark, src)
+
+        thread = _thread_cfg(src, tgt, lookups={"dim_codes": _lookup_cfg(dim, unique_key=True)})
+        result = execute_thread(spark, thread)
+
+        assert result.status == "success", result.error
+        assert precheck_spy == []  # materialization outcome reused end-to-end
+
+    def test_thread_lookup_without_check_runs_precheck(
+        self, spark: SparkSession, tmp_delta_path, precheck_spy: list[Any]
+    ) -> None:
+        dim = tmp_delta_path("meta_dim_t2")
+        src = tmp_delta_path("meta_src_t2")
+        tgt = tmp_delta_path("meta_tgt_t2")
+        _write_dim(spark, dim)
+        _write_src(spark, src)
+
+        thread = _thread_cfg(src, tgt, lookups={"dim_codes": _lookup_cfg(dim, unique_key=False)})
+        result = execute_thread(spark, thread)
+
+        assert result.status == "success", result.error
+        assert precheck_spy == [["code"]]  # no reusable outcome → fresh pre-check
+
+
+class TestWeaveScopedReuse:
+    def test_weave_lookup_unique_key_skips_precheck(
+        self, spark: SparkSession, tmp_delta_path, precheck_spy: list[Any]
+    ) -> None:
+        dim = tmp_delta_path("meta_dim_w1")
+        src = tmp_delta_path("meta_src_w1")
+        tgt = tmp_delta_path("meta_tgt_w1")
+        _write_dim(spark, dim)
+        _write_src(spark, src)
+
+        thread = _thread_cfg(src, tgt)  # lookup declared at weave scope
+        threads = {"fact_t": thread}
+        plan = build_plan("meta_weave", threads, [ThreadEntry(name="fact_t")])
+        lookups = {"dim_codes": Lookup.model_validate(_lookup_cfg(dim, unique_key=True))}
+
+        result = execute_weave(spark, plan, threads, lookups=lookups)
+
+        assert result.status == "success"
+        assert precheck_spy == []

--- a/tests/weevr/operations/pipeline/test_resolve.py
+++ b/tests/weevr/operations/pipeline/test_resolve.py
@@ -1152,3 +1152,58 @@ class TestDuplicateGatePathSelection:
         apply_resolve(fact, self._params(), _dim_df(spark), observations=registry, lookup_meta=meta)
         # Declared unique key covers different columns than this join
         assert spark_action_counter["total"] - start == 1
+
+
+# ---------------------------------------------------------------------------
+# Broadcast hint policy
+# ---------------------------------------------------------------------------
+
+
+class TestBroadcastPolicy:
+    """Hint present for declared/known-small; absent for unknown size."""
+
+    @staticmethod
+    def _params() -> ResolveParams:
+        return ResolveParams(name="fk", lookup="dim", match={"bk": "natural_id"}, pk="id")
+
+    @staticmethod
+    def _analyzed_plan(df: Any) -> str:
+        return str(df._jdf.queryExecution().analyzed())
+
+    def _resolve_with_meta(self, spark: SparkSession, meta):  # type: ignore[no-untyped-def]
+        fact = spark.createDataFrame([("A",)], _fact_schema("bk"))
+        return apply_resolve(fact, self._params(), _dim_df(spark), lookup_meta=meta)
+
+    def test_declared_broadcast_hints(self, spark: SparkSession) -> None:
+        from weevr.operations.pipeline import LookupMeta
+
+        result = self._resolve_with_meta(spark, LookupMeta(broadcast_declared=True))
+        assert "broadcast" in self._analyzed_plan(result.df).lower()
+
+    def test_known_small_hints(self, spark: SparkSession) -> None:
+        from weevr.operations.pipeline import LookupMeta
+
+        result = self._resolve_with_meta(spark, LookupMeta(size_in_bytes=1024))
+        assert "broadcast" in self._analyzed_plan(result.df).lower()
+
+    def test_unknown_size_defers_to_aqe(self, spark: SparkSession) -> None:
+        from weevr.operations.pipeline import LookupMeta
+
+        result = self._resolve_with_meta(spark, LookupMeta())
+        assert "broadcast" not in self._analyzed_plan(result.df).lower()
+
+    def test_large_size_defers_to_aqe(self, spark: SparkSession) -> None:
+        from weevr.operations.pipeline import LookupMeta
+
+        result = self._resolve_with_meta(spark, LookupMeta(size_in_bytes=1 << 40))
+        assert "broadcast" not in self._analyzed_plan(result.df).lower()
+
+    def test_results_identical_with_hint(self, spark: SparkSession) -> None:
+        from weevr.operations.pipeline import LookupMeta
+
+        fact = spark.createDataFrame([("A",), ("C",), (None,)], _fact_schema("bk"))
+        plain = apply_resolve(fact, self._params(), _dim_df(spark))
+        hinted = apply_resolve(
+            fact, self._params(), _dim_df(spark), lookup_meta=LookupMeta(size_in_bytes=1)
+        )
+        assert sorted(map(str, plain.df.collect())) == sorted(map(str, hinted.df.collect()))

--- a/tests/weevr/operations/pipeline/test_resolve.py
+++ b/tests/weevr/operations/pipeline/test_resolve.py
@@ -1207,3 +1207,60 @@ class TestBroadcastPolicy:
             fact, self._params(), _dim_df(spark), lookup_meta=LookupMeta(size_in_bytes=1)
         )
         assert sorted(map(str, plain.df.collect())) == sorted(map(str, hinted.df.collect()))
+
+
+class TestObservedMapAndFallbackStats:
+    """Map validate-mode and missing-lookup fallback stats go lazy."""
+
+    def test_map_unmapped_count_parity(self, spark: SparkSession, spark_action_counter) -> None:
+        from weevr.model.pipeline import MapParams
+        from weevr.operations.pipeline import ObservationRegistry
+        from weevr.operations.pipeline.value_mapping import apply_map
+
+        df = spark.createDataFrame([("A",), ("B",), ("Z",), (None,)], _fact_schema("code"))
+        params = MapParams(column="code", values={"A": "1", "B": "2"}, unmapped="validate")
+
+        eager = apply_map(df, params)
+        assert eager.metadata["unmapped_count"] == 1  # Z; nulls excluded
+
+        registry = ObservationRegistry(scope="main")
+        start = spark_action_counter["total"]
+        observed = apply_map(df, params, observations=registry)
+        assert spark_action_counter["total"] - start == 0  # no eager action
+        assert "unmapped_count" not in observed.metadata
+
+        observed.df.collect()
+        stats = registry.harvest()
+        assert stats["main.map.code"]["unmapped_count"] == 1
+
+    def test_missing_lookup_fallback_count_observed(
+        self, spark: SparkSession, spark_action_counter
+    ) -> None:
+        from weevr.model.pipeline import ResolveStep
+        from weevr.operations.pipeline import ObservationRegistry, run_pipeline
+
+        df = spark.createDataFrame([("A",), ("B",)], _fact_schema("bk"))
+        step = ResolveStep(
+            resolve=ResolveParams(
+                name="fk",
+                lookup="missing_dim",
+                match={"bk": "natural_id"},
+                pk="id",
+                on_failure="warn",
+            )
+        )
+        registry = ObservationRegistry(scope="main")
+        start = spark_action_counter["total"]
+        out = run_pipeline(df, [step], {}, observations=registry)
+        assert spark_action_counter["total"] - start == 0  # fallback no longer counts
+
+        out.collect()
+        stats = registry.harvest()
+        assert stats["main.resolve.fk"] == {
+            "total": 2,
+            "matched": 0,
+            "unknown": 2,
+            "invalid": 0,
+            "duplicates": 0,
+            "match_rate": 0.0,
+        }

--- a/tests/weevr/operations/pipeline/test_resolve.py
+++ b/tests/weevr/operations/pipeline/test_resolve.py
@@ -1,5 +1,7 @@
 """Tests for resolve step handler — FK resolution via lookup join."""
 
+from typing import Any
+
 import pytest
 from pyspark.sql import SparkSession
 from pyspark.sql.types import (
@@ -866,3 +868,287 @@ class TestResolveEdgeCases:
         )
         with pytest.raises(ExecutionError, match="[Cc]ollid"):
             apply_resolve(fact, params, dim)
+
+
+# ---------------------------------------------------------------------------
+# Observed (lazy) statistics
+# ---------------------------------------------------------------------------
+
+
+class TestObservedResolveStats:
+    """Observation-mode stats match the eager values exactly."""
+
+    @staticmethod
+    def _mixed_fact(spark: SparkSession):
+        # A matches, X is unknown, null/blank are invalid
+        return spark.createDataFrame(
+            [("A",), ("A",), ("X",), (None,), ("",)],
+            _fact_schema("nid"),
+        )
+
+    @staticmethod
+    def _params() -> ResolveParams:
+        return ResolveParams(name="fk", lookup="dim", match={"nid": "natural_id"}, pk="id")
+
+    def test_parity_with_eager_stats(self, spark: SparkSession) -> None:
+        from weevr.operations.pipeline import ObservationRegistry
+
+        fact = self._mixed_fact(spark)
+        dim = _dim_df(spark)
+
+        eager = apply_resolve(fact, self._params(), dim)
+        eager_stats = eager.metadata["resolve_stats"]["fk"]
+
+        registry = ObservationRegistry(scope="main")
+        observed = apply_resolve(fact, self._params(), dim, observations=registry)
+        assert observed.metadata == {}  # stats no longer ride StepResult
+
+        observed.df.collect()  # the terminal action fulfills the observation
+        stats = registry.harvest()
+        assert stats["main.resolve.fk"] == eager_stats
+
+    def test_parity_when_plan_executes_twice(self, spark: SparkSession) -> None:
+        # A pre-write action on the same plan must not corrupt the values —
+        # the observed node is fixed, so both executions yield the same row.
+        from weevr.operations.pipeline import ObservationRegistry
+
+        fact = self._mixed_fact(spark)
+        dim = _dim_df(spark)
+
+        registry = ObservationRegistry(scope="main")
+        observed = apply_resolve(fact, self._params(), dim, observations=registry)
+        observed.df.count()  # first execution (e.g. rows_after_transforms)
+        observed.df.collect()  # second execution (e.g. the write)
+
+        stats = registry.harvest()
+        assert stats["main.resolve.fk"]["total"] == 5
+        assert stats["main.resolve.fk"]["matched"] == 2
+        assert stats["main.resolve.fk"]["unknown"] == 1
+        assert stats["main.resolve.fk"]["invalid"] == 2
+
+    def test_harvest_without_action_degrades(self, spark: SparkSession) -> None:
+        # No action ever executes the plan: harvest logs and yields absent
+        # stats, never raises. Uses a tiny frame so the timeout path is not
+        # exercised — the observation is simply unfulfilled.
+        from weevr.operations.pipeline import ObservationRegistry, _observations
+
+        registry = ObservationRegistry(scope="main")
+        fact = self._mixed_fact(spark)
+        dim = _dim_df(spark)
+        apply_resolve(fact, self._params(), dim, observations=registry)
+
+        original = _observations._HARVEST_TIMEOUT_S
+        _observations._HARVEST_TIMEOUT_S = 0.5
+        try:
+            stats = registry.harvest()
+        finally:
+            _observations._HARVEST_TIMEOUT_S = original
+        assert stats == {}
+
+    def test_unique_names_for_duplicate_steps(self, spark: SparkSession) -> None:
+        from weevr.operations.pipeline import ObservationRegistry
+
+        registry = ObservationRegistry(scope="main")
+        fact = self._mixed_fact(spark)
+        dim = _dim_df(spark)
+
+        first = apply_resolve(fact, self._params(), dim, observations=registry)
+        second = apply_resolve(first.df.drop("fk"), self._params(), dim, observations=registry)
+        second.df.collect()
+
+        stats = registry.harvest()
+        # Same step/name registered twice: both harvested under distinct keys
+        assert set(stats) == {"main.resolve.fk", "main.resolve.fk_1"}
+
+
+# ---------------------------------------------------------------------------
+# Duplicate-gate semantics matrix (equivalence lock)
+# ---------------------------------------------------------------------------
+
+
+class TestDuplicateGateSemantics:
+    """Locks on_duplicate outcomes across clean/dup-key/effective cases.
+
+    Written green against the eager fact-side gate; the lookup-side
+    pre-check rework must keep every outcome identical.
+    """
+
+    @staticmethod
+    def _dup_dim(spark: SparkSession):
+        # 'A' unique, 'B' duplicated lookup-side
+        return spark.createDataFrame(
+            [(1, "A"), (2, "B"), (3, "B")],
+            StructType(
+                [
+                    StructField("id", IntegerType(), False),
+                    StructField("natural_id", StringType(), False),
+                ]
+            ),
+        )
+
+    @staticmethod
+    def _params(on_duplicate: str) -> ResolveParams:
+        return ResolveParams(
+            name="fk",
+            lookup="dim",
+            match={"bk": "natural_id"},
+            pk="id",
+            on_duplicate=on_duplicate,  # type: ignore[arg-type]
+        )
+
+    @pytest.mark.parametrize("mode", ["error", "warn", "first"])
+    def test_clean_lookup_never_triggers(self, spark: SparkSession, mode: str) -> None:
+        fact = spark.createDataFrame([("A",), ("C",)], _fact_schema("bk"))
+        result = apply_resolve(fact, self._params(mode), _dim_df(spark))
+        by_bk = {r["bk"]: r["fk"] for r in result.df.collect()}
+        assert by_bk == {"A": 1, "C": 3}
+
+    def test_error_fires_only_on_actual_fact_match(self, spark: SparkSession) -> None:
+        # The lookup carries duplicated 'B' keys, but no fact row references
+        # 'B' — error must NOT fire; 'A' resolves normally.
+        fact = spark.createDataFrame([("A",)], _fact_schema("bk"))
+        result = apply_resolve(fact, self._params("error"), self._dup_dim(spark))
+        rows = result.df.collect()
+        assert len(rows) == 1
+        assert rows[0]["fk"] == 1
+
+    def test_error_fires_on_matched_duplicate(self, spark: SparkSession) -> None:
+        fact = spark.createDataFrame([("B",)], _fact_schema("bk"))
+        with pytest.raises(Exception, match="[Dd]uplicate"):
+            apply_resolve(fact, self._params("error"), self._dup_dim(spark))
+
+    def test_warn_takes_first_and_keeps_row_count(self, spark: SparkSession) -> None:
+        fact = spark.createDataFrame([("A",), ("B",)], _fact_schema("bk"))
+        result = apply_resolve(fact, self._params("warn"), self._dup_dim(spark))
+        rows = result.df.collect()
+        assert len(rows) == 2
+        by_bk = {r["bk"]: r["fk"] for r in rows}
+        assert by_bk["A"] == 1
+        assert by_bk["B"] == 2  # asc_nulls_last: lowest pk wins
+
+    def test_first_silent_on_matched_duplicate(self, spark: SparkSession) -> None:
+        fact = spark.createDataFrame([("B",), ("B",)], _fact_schema("bk"))
+        result = apply_resolve(fact, self._params("first"), self._dup_dim(spark))
+        rows = result.df.collect()
+        assert len(rows) == 2
+        assert all(r["fk"] == 2 for r in rows)
+
+    def test_effective_date_multi_version_unchanged(self, spark: SparkSession) -> None:
+        # A BK legitimately carries two date-ranged versions; a fact date
+        # inside one range resolves to that version without dup handling.
+        from weevr.model.pipeline import EffectiveConfig
+
+        dim = spark.createDataFrame(
+            [
+                (1, "A", "2026-01-01", "2026-02-01"),
+                (2, "A", "2026-02-01", None),
+            ],
+            StructType(
+                [
+                    StructField("id", IntegerType(), False),
+                    StructField("natural_id", StringType(), False),
+                    StructField("vf", StringType(), False),
+                    StructField("vt", StringType(), True),
+                ]
+            ),
+        )
+        fact = spark.createDataFrame(
+            [("A", "2026-01-15"), ("A", "2026-03-01")],
+            _fact_schema("bk", "event_date"),
+        )
+        params = ResolveParams(
+            name="fk",
+            lookup="dim",
+            match={"bk": "natural_id"},
+            pk="id",
+            on_duplicate="error",
+            effective=EffectiveConfig(date_column="event_date", **{"from": "vf", "to": "vt"}),
+        )
+        result = apply_resolve(fact, params, dim)
+        by_date = {r["event_date"]: r["fk"] for r in result.df.collect()}
+        assert by_date == {"2026-01-15": 1, "2026-03-01": 2}
+
+
+# ---------------------------------------------------------------------------
+# Duplicate-gate path selection and unique-key reuse
+# ---------------------------------------------------------------------------
+
+
+class TestDuplicateGatePathSelection:
+    """Clean lookups skip the window; reuse skips even the pre-check."""
+
+    @staticmethod
+    def _params(**kwargs) -> ResolveParams:  # type: ignore[no-untyped-def]
+        base = {"name": "fk", "lookup": "dim", "match": {"bk": "natural_id"}, "pk": "id"}
+        return ResolveParams(**{**base, **kwargs})
+
+    @staticmethod
+    def _analyzed_plan(df: Any) -> str:
+        return str(df._jdf.queryExecution().analyzed())
+
+    def test_clean_lookup_plan_has_no_window(self, spark: SparkSession) -> None:
+        fact = spark.createDataFrame([("A",)], _fact_schema("bk"))
+        result = apply_resolve(fact, self._params(), _dim_df(spark))
+        assert "row_number" not in self._analyzed_plan(result.df)
+
+    def test_dup_lookup_plan_keeps_window(self, spark: SparkSession) -> None:
+        dup_dim = spark.createDataFrame(
+            [(1, "A"), (2, "A")],
+            StructType(
+                [
+                    StructField("id", IntegerType(), False),
+                    StructField("natural_id", StringType(), False),
+                ]
+            ),
+        )
+        fact = spark.createDataFrame([("A",)], _fact_schema("bk"))
+        result = apply_resolve(fact, self._params(on_duplicate="first"), dup_dim)
+        assert "row_number" in self._analyzed_plan(result.df)
+
+    def test_valid_reuse_skips_precheck(self, spark: SparkSession, spark_action_counter) -> None:
+        from weevr.operations.pipeline import LookupMeta, ObservationRegistry
+
+        meta = LookupMeta(
+            key_columns=("natural_id",), unique_key_checked=True, unique_key_passed=True
+        )
+        fact = spark.createDataFrame([("A",)], _fact_schema("bk"))
+        registry = ObservationRegistry(scope="main")
+
+        start = spark_action_counter["total"]
+        apply_resolve(fact, self._params(), _dim_df(spark), observations=registry, lookup_meta=meta)
+        # Reuse + observed stats: the resolve step itself fires ZERO actions
+        assert spark_action_counter["total"] - start == 0
+
+    def test_normalize_invalidates_reuse(self, spark: SparkSession, spark_action_counter) -> None:
+        from weevr.operations.pipeline import LookupMeta, ObservationRegistry
+
+        meta = LookupMeta(
+            key_columns=("natural_id",), unique_key_checked=True, unique_key_passed=True
+        )
+        fact = spark.createDataFrame([("a",)], _fact_schema("bk"))
+        registry = ObservationRegistry(scope="main")
+
+        start = spark_action_counter["total"]
+        apply_resolve(
+            fact,
+            self._params(normalize="trim_lower"),
+            _dim_df(spark),
+            observations=registry,
+            lookup_meta=meta,
+        )
+        # trim_lower can merge distinct keys post-check — the pre-check must run
+        assert spark_action_counter["total"] - start == 1
+
+    def test_key_mismatch_invalidates_reuse(
+        self, spark: SparkSession, spark_action_counter
+    ) -> None:
+        from weevr.operations.pipeline import LookupMeta, ObservationRegistry
+
+        meta = LookupMeta(key_columns=("id",), unique_key_checked=True, unique_key_passed=True)
+        fact = spark.createDataFrame([("A",)], _fact_schema("bk"))
+        registry = ObservationRegistry(scope="main")
+
+        start = spark_action_counter["total"]
+        apply_resolve(fact, self._params(), _dim_df(spark), observations=registry, lookup_meta=meta)
+        # Declared unique key covers different columns than this join
+        assert spark_action_counter["total"] - start == 1

--- a/tests/weevr/operations/pipeline/test_resolve.py
+++ b/tests/weevr/operations/pipeline/test_resolve.py
@@ -1264,3 +1264,79 @@ class TestObservedMapAndFallbackStats:
             "duplicates": 0,
             "match_rate": 0.0,
         }
+
+
+class TestDuplicateGateEffectiveDateModes:
+    """warn/first on the effective-date axis (path unconditionally legacy)."""
+
+    @staticmethod
+    def _overlapping_dim(spark: SparkSession):
+        # Overlapping validity ranges for 'A': a fact date inside the overlap
+        # matches both versions — genuine duplicates on the range join
+        return spark.createDataFrame(
+            [
+                (1, "A", "2026-01-01", "2026-03-01"),
+                (2, "A", "2026-02-01", None),
+            ],
+            StructType(
+                [
+                    StructField("id", IntegerType(), False),
+                    StructField("natural_id", StringType(), False),
+                    StructField("vf", StringType(), False),
+                    StructField("vt", StringType(), True),
+                ]
+            ),
+        )
+
+    def _params(self, mode: str) -> ResolveParams:
+        from weevr.model.pipeline import EffectiveConfig
+
+        return ResolveParams(
+            name="fk",
+            lookup="dim",
+            match={"bk": "natural_id"},
+            pk="id",
+            on_duplicate=mode,  # type: ignore[arg-type]
+            effective=EffectiveConfig(date_column="event_date", **{"from": "vf", "to": "vt"}),
+        )
+
+    def test_warn_takes_first_in_overlap(self, spark: SparkSession) -> None:
+        fact = spark.createDataFrame([("A", "2026-02-15")], _fact_schema("bk", "event_date"))
+        result = apply_resolve(fact, self._params("warn"), self._overlapping_dim(spark))
+        rows = result.df.collect()
+        assert len(rows) == 1
+        assert rows[0]["fk"] == 1  # asc_nulls_last: lowest pk wins
+
+    def test_first_silent_in_overlap(self, spark: SparkSession) -> None:
+        fact = spark.createDataFrame([("A", "2026-02-15")], _fact_schema("bk", "event_date"))
+        result = apply_resolve(fact, self._params("first"), self._overlapping_dim(spark))
+        rows = result.df.collect()
+        assert len(rows) == 1
+        assert rows[0]["fk"] == 1
+
+
+class TestReuseKeyOrderInsensitivity:
+    def test_reordered_composite_key_still_reuses(
+        self, spark: SparkSession, spark_action_counter
+    ) -> None:
+        from weevr.operations.pipeline import LookupMeta, ObservationRegistry
+
+        dim = spark.createDataFrame(
+            [(1, "A", "X"), (2, "B", "Y")],
+            StructType(
+                [
+                    StructField("id", IntegerType(), False),
+                    StructField("k1", StringType(), False),
+                    StructField("k2", StringType(), False),
+                ]
+            ),
+        )
+        fact = spark.createDataFrame([("A", "X")], _fact_schema("c1", "c2"))
+        params = ResolveParams(name="fk", lookup="dim", match={"c1": "k1", "c2": "k2"}, pk="id")
+        # Declared key order reversed relative to the match values
+        meta = LookupMeta(key_columns=("k2", "k1"), unique_key_checked=True, unique_key_passed=True)
+        registry = ObservationRegistry(scope="main")
+
+        start = spark_action_counter["total"]
+        apply_resolve(fact, params, dim, observations=registry, lookup_meta=meta)
+        assert spark_action_counter["total"] - start == 0  # reuse held despite order

--- a/tests/weevr/test_context.py
+++ b/tests/weevr/test_context.py
@@ -1163,3 +1163,114 @@ class TestExecutionScopeWarnings:
         )
         warnings = self._run_validate(project, "threads/stub.thread", caplog)
         assert any("execution block" in w and "log_level" in w for w in warnings)
+
+
+@pytest.mark.spark
+class TestPreviewStepStats:
+    """Preview harvests sample-scoped step statistics into metadata."""
+
+    def test_preview_map_stats_sample_scoped(self, spark: SparkSession, tmp_path: Path) -> None:
+        # Uses a validate-mode map step: preview does not materialize
+        # lookups (pre-existing limitation), so resolve steps cannot run
+        # there — map stats exercise the same harvest path.
+        src = str(tmp_path / "src_pstats")
+        tgt = str(tmp_path / "tgt_pstats")
+        spark.createDataFrame(
+            [{"id": i, "code": "A" if i % 2 == 0 else "X"} for i in range(40)]
+        ).write.format("delta").save(src)
+
+        thread_dir = tmp_path / "threads"
+        thread_dir.mkdir(parents=True, exist_ok=True)
+        yaml_path = thread_dir / "pstats.thread"
+        yaml_path.write_text(
+            f"""\
+config_version: "1.0"
+sources:
+  main:
+    type: delta
+    alias: "{src}"
+steps:
+  - map:
+      column: code
+      values:
+        A: alpha
+      unmapped: validate
+target:
+  path: "{tgt}"
+write:
+  mode: overwrite
+"""
+        )
+        pytest.importorskip("pandas")  # the sampling action needs pandas
+        ctx = Context(spark=spark, project=_project_dir(tmp_path))
+        result = ctx.run(yaml_path, mode="preview", sample_rows=10)
+
+        assert result.status == "success", result.warnings
+        meta = result._preview_metadata or {}
+        stats = meta.get("pstats", {}).get("step_stats", {})
+        assert "main.map.code" in stats
+        # Sample-scoped: the count reflects the 10-row sample, not the
+        # 40-row source (which holds 20 unmapped rows)
+        assert 0 < stats["main.map.code"]["unmapped_count"] <= 10
+
+    def test_preview_without_stat_steps_has_no_key(
+        self, spark: SparkSession, tmp_path: Path
+    ) -> None:
+        src = str(tmp_path / "src_pnostats")
+        tgt = str(tmp_path / "tgt_pnostats")
+        spark.createDataFrame([{"id": 1}]).write.format("delta").save(src)
+
+        yaml_path = _create_thread_yaml(tmp_path, "pnostats", src, tgt)
+        ctx = Context(spark=spark, project=_project_dir(tmp_path))
+        result = ctx.run(yaml_path, mode="preview")
+
+        assert result.status == "success"
+        meta = result._preview_metadata or {}
+        assert "step_stats" not in meta.get("pnostats", {})
+
+    def test_preview_harvest_degrades_when_sampling_fails(
+        self, spark: SparkSession, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # No sampling action means unfulfilled observations: the harvest is
+        # skipped, the preview stays intact, and the thread is never demoted
+        # to errors.
+        from pyspark.sql import DataFrame
+
+        def _boom(self):  # type: ignore[no-untyped-def]
+            raise RuntimeError("sampling unavailable")
+
+        monkeypatch.setattr(DataFrame, "toPandas", _boom)
+
+        src = str(tmp_path / "src_pdeg")
+        tgt = str(tmp_path / "tgt_pdeg")
+        spark.createDataFrame([{"id": 1, "code": "X"}]).write.format("delta").save(src)
+        thread_dir = tmp_path / "threads"
+        thread_dir.mkdir(parents=True, exist_ok=True)
+        yaml_path = thread_dir / "pdeg.thread"
+        yaml_path.write_text(
+            f"""\
+config_version: "1.0"
+sources:
+  main:
+    type: delta
+    alias: "{src}"
+steps:
+  - map:
+      column: code
+      values:
+        A: alpha
+      unmapped: validate
+target:
+  path: "{tgt}"
+write:
+  mode: overwrite
+"""
+        )
+        ctx = Context(spark=spark, project=_project_dir(tmp_path))
+        result = ctx.run(yaml_path, mode="preview")
+
+        assert result.status == "success", result.warnings
+        meta = (result._preview_metadata or {}).get("pdeg", {})
+        assert "samples" not in meta
+        assert "step_stats" not in meta
+        assert result.preview_data is not None and "pdeg" in result.preview_data


### PR DESCRIPTION
## Summary

- Resolve steps fired two full-pipeline Spark actions each (a duplicate count and a
  statistics aggregation), so an N-resolve chain paid O(N²) redundant recompute — the
  dominant cost of resolve-heavy fact loads. Validate-mode map steps and the
  missing-lookup fallback added more. The statistics those actions computed were
  discarded.
- Closes #196

## Why

- Live-deployment profiling traced a slow fact load to 11 chained resolves re-executing
  the full lineage per step, twice. The stats never reached users; only the duplicate
  count had a functional consumer.

## What changed

- Per-step statistics attach as `pyspark.sql.Observation` objects and are computed as a
  byproduct of the write — zero extra Spark jobs. The executor harvests them post-write
  into a new engine-internal `ThreadTelemetry.step_stats` field (best-effort: a failed
  harvest warns and degrades, never fails the thread). CTE sub-pipelines and preview
  harvest under their own scopes; preview values are sample-scoped.
- Duplicate handling is now decided lookup-side: a dimension-sized pre-check (or the
  lookup's own materialization-time `unique_key` outcome, when the key columns match
  and no normalization applies) proves the common case duplicate-free and skips the
  row-id column, the window, and the fact-side duplicate count entirely. Lookups with
  duplicate keys fall back to the exact existing path — `on_duplicate` semantics,
  error text, and error-before-write timing are locked identical by an
  error/warn/first × clean/dup-key/effective-date test matrix.
- Broadcast policy: resolve joins hint `broadcast` when the lookup declared
  `strategy: broadcast` or its Delta snapshot size is provably under
  `spark.sql.autoBroadcastJoinThreshold` (a driver-side log read, no jobs); unknown
  sizes defer to AQE — an unknown-size lookup is never forced onto the driver.
- New job/action budget test harness locks the marginal cost per resolve (2 eager
  actions before, 0 with a reusable uniqueness outcome) and the single-source-scan
  guarantee, so eager actions cannot be silently reintroduced.
- End-to-end tests prove materialization facts flow from loom/weave/thread lookup
  scopes into resolve steps (spying the pre-check through real engine runs).

## How to test

- [x] uv sync --dev
- [x] uv run ruff check .
- [x] uv run ruff format .
- [x] uv run pyright .
- [x] uv run pytest (2531 passed) and the full Spark-marked suite (exit 0)

## Release / Versioning

- [x] PR title follows Conventional Commit format (feat:, fix:, chore:, docs:, ci:, etc.)
- [ ] Breaking change indicated (feat!: / fix!: or BREAKING CHANGE in body) — not breaking

## Notes

- `step_stats` is documented as engine-internal and unstable — its shape is
  deliberately not part of the public telemetry contract.
- Statistics values are byte-identical to the previous eager computation (parity
  tests, including plans that execute more than once).
- Preview cannot currently run resolve steps at all (it never materializes lookups) —
  a pre-existing limitation noted for future work, unchanged here.