### PR TITLE
feat(engine): execute each thread's DAG once behind a materialization boundary

### DIFF
--- a/docs/guides/execution-settings.md
+++ b/docs/guides/execution-settings.md
@@ -21,6 +21,7 @@ execution:
 | `log_level` | `minimal` \| `standard` \| `verbose` \| `debug` | `standard` | Logging verbosity for execution output |
 | `trace` | `bool` | `true` | Whether execution spans are collected for telemetry |
 | `max_parallel_threads` | `int >= 1` | unset | Upper bound on concurrently executing threads within a weave's parallel group; unset means unbounded |
+| `capture_samples` | `bool` | `false` | Capture 10-row output/quarantine samples at write time for display. Preview always samples regardless. |
 
 ## How loom and weave blocks combine
 
@@ -106,3 +107,18 @@ WARN: loom 'nightly' declares defaults.execution (log_level) — thread-scoped
 execution settings are not applied. Move them to the top-level execution
 block on the loom or weave.
 ```
+
+## Output samples
+
+Sample capture re-executes the working DataFrame's lineage, so it is
+off by default. Enable it per loom or weave:
+
+```yaml
+execution:
+  capture_samples: true
+```
+
+When disabled, result rendering shows a hint in place of the sample
+table. Preview mode always captures samples — previewing is what it is
+for. Like every `execution:` field, thread-scoped declarations are
+accepted but not applied in v1.x and produce a run-start warning.

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -257,7 +257,14 @@ depends on what was executed:
 `ThreadTelemetry` is the most detailed telemetry object. It includes:
 
 - **span** -- The thread's execution span
-- **rows_read**, **rows_written**, **rows_quarantined** -- Row counts
+- **rows_read**, **rows_written**, **rows_quarantined** -- Row counts.
+  On single-pass write paths these are computed as byproducts of the
+  write itself (query observations and Delta commit metrics) rather
+  than by separate Spark jobs. When a commit-metrics read fails or a
+  concurrent writer commits between the write and the read, the count
+  degrades to zero with a logged warning — a wrong number is never
+  reported. Merge-based paths (dimensions, CDC, merge write mode)
+  retain direct counts.
 - **validation_results** -- Per-rule pass/fail counts and severity
 - **assertion_results** -- Post-write assertion outcomes
 - **load_mode** -- The load mode used (full, incremental, CDC)

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -258,13 +258,15 @@ depends on what was executed:
 
 - **span** -- The thread's execution span
 - **rows_read**, **rows_written**, **rows_quarantined** -- Row counts.
-  On single-pass write paths these are computed as byproducts of the
-  write itself (query observations and Delta commit metrics) rather
-  than by separate Spark jobs. When a commit-metrics read fails or a
-  concurrent writer commits between the write and the read, the count
-  degrades to zero with a logged warning — a wrong number is never
-  reported. Merge-based paths (dimensions, CDC, merge write mode)
-  retain direct counts.
+  On single-pass write paths, `rows_read` and `rows_written` are
+  computed as byproducts of the write itself (query observations and
+  Delta commit metrics) rather than by separate Spark jobs; a
+  quarantine count runs only when validation actually quarantined
+  rows, against the cached quarantine frame. When a commit-metrics
+  read fails or a concurrent writer commits between the write and the
+  read, the count degrades to zero with a logged warning — a wrong
+  number is never reported. Merge-based paths (dimensions, CDC, merge
+  write mode) retain direct counts.
 - **validation_results** -- Per-rule pass/fail counts and severity
 - **assertion_results** -- Post-write assertion outcomes
 - **load_mode** -- The load mode used (full, incremental, CDC)
@@ -292,6 +294,26 @@ depends on what was executed:
   and may change without notice. In preview mode the values are
   sample-scoped (they reflect the sampled rows, not the full
   source), and are present only when sample capture succeeded.
+
+### Dimension merge metrics
+
+Dimension writes report merge outcomes derived from the Delta commit's
+split update keys — never the conflated `numTargetRowsUpdated`
+aggregate, which folds soft-delete stamps into the same number as
+version closes:
+
+- `rows_versioned` — current rows closed (a new version was inserted)
+- `rows_inserted` — genuinely new entities (new-version inserts are
+  excluded arithmetically)
+- `rows_deleted` — hard deletes plus soft-delete stamps from
+  `on_no_match_source`
+
+`rows_unchanged` is intentionally absent: no Delta metric expresses it
+(`numTargetRowsCopied` is a file-rewrite artifact, not a logical
+count), and deriving it arithmetically risks a wrong number under
+quarantine and seeding edge cases. When metrics cannot be read — or a
+concurrent writer's commit makes attribution unsafe — the fields stay
+zero and a warning is logged.
 
 ### Weave telemetry fields
 

--- a/docs/reference/configuration-keys.md
+++ b/docs/reference/configuration-keys.md
@@ -388,6 +388,7 @@ fields win). Thread-scoped declarations are not applied. See the
 | `log_level` | `"minimal" \| "standard" \| "verbose" \| "debug"` | `"standard"` | Logging verbosity. An explicit `Context(log_level=...)` argument takes precedence. |
 | `trace` | `bool` | `True` | Collect execution spans. `false` at loom scope disables telemetry for the run; at weave scope, omits that weave's nodes. |
 | `max_parallel_threads` | `int >= 1` | `None` | Cap on concurrently executing threads per weave group. Unset means unbounded. |
+| `capture_samples` | `bool` | `false` | Capture 10-row output samples at write time. Preview always samples. |
 
 ---
 

--- a/docs/schema/loom.json
+++ b/docs/schema/loom.json
@@ -238,7 +238,7 @@
       "type": "object"
     },
     "ExecutionConfig": {
-      "description": "Runtime execution settings declared on the top-level ``execution:`` block.\n\nCanonical declaration sites are the top-level ``execution:`` field on\nLoom and Weave. The effective settings for a weave execution merge\nfield-level (see :func:`resolve_effective_execution`) rather than\nreplacing whole-block. Thread-scoped execution settings are declared\nbut not applied in v1.x.\n\nAttributes:\n    log_level: Logging verbosity for execution output.\n    trace: Whether to collect execution spans for telemetry.\n    max_parallel_threads: Upper bound on concurrently executing\n        threads within a weave's parallel group. Unset means\n        unbounded (pool sized to the group).",
+      "description": "Runtime execution settings declared on the top-level ``execution:`` block.\n\nCanonical declaration sites are the top-level ``execution:`` field on\nLoom and Weave. The effective settings for a weave execution merge\nfield-level (see :func:`resolve_effective_execution`) rather than\nreplacing whole-block. Thread-scoped execution settings are declared\nbut not applied in v1.x.\n\nAttributes:\n    log_level: Logging verbosity for execution output.\n    trace: Whether to collect execution spans for telemetry.\n    max_parallel_threads: Upper bound on concurrently executing\n        threads within a weave's parallel group. Unset means\n        unbounded (pool sized to the group).\n    capture_samples: Whether output samples are captured at write\n        time. Off by default; preview always samples.",
       "properties": {
         "log_level": {
           "$ref": "#/$defs/LogLevel",
@@ -264,6 +264,12 @@
           "default": null,
           "description": "Maximum threads executing concurrently within a weave's parallel group. Unset means unbounded.",
           "title": "Max Parallel Threads"
+        },
+        "capture_samples": {
+          "default": false,
+          "description": "Whether to capture 10-row output samples at write time for display. Preview mode always captures samples regardless of this setting.",
+          "title": "Capture Samples",
+          "type": "boolean"
         }
       },
       "title": "ExecutionConfig",

--- a/docs/schema/thread.json
+++ b/docs/schema/thread.json
@@ -1348,7 +1348,7 @@
       "type": "object"
     },
     "ExecutionConfig": {
-      "description": "Runtime execution settings declared on the top-level ``execution:`` block.\n\nCanonical declaration sites are the top-level ``execution:`` field on\nLoom and Weave. The effective settings for a weave execution merge\nfield-level (see :func:`resolve_effective_execution`) rather than\nreplacing whole-block. Thread-scoped execution settings are declared\nbut not applied in v1.x.\n\nAttributes:\n    log_level: Logging verbosity for execution output.\n    trace: Whether to collect execution spans for telemetry.\n    max_parallel_threads: Upper bound on concurrently executing\n        threads within a weave's parallel group. Unset means\n        unbounded (pool sized to the group).",
+      "description": "Runtime execution settings declared on the top-level ``execution:`` block.\n\nCanonical declaration sites are the top-level ``execution:`` field on\nLoom and Weave. The effective settings for a weave execution merge\nfield-level (see :func:`resolve_effective_execution`) rather than\nreplacing whole-block. Thread-scoped execution settings are declared\nbut not applied in v1.x.\n\nAttributes:\n    log_level: Logging verbosity for execution output.\n    trace: Whether to collect execution spans for telemetry.\n    max_parallel_threads: Upper bound on concurrently executing\n        threads within a weave's parallel group. Unset means\n        unbounded (pool sized to the group).\n    capture_samples: Whether output samples are captured at write\n        time. Off by default; preview always samples.",
       "properties": {
         "log_level": {
           "$ref": "#/$defs/LogLevel",
@@ -1374,6 +1374,12 @@
           "default": null,
           "description": "Maximum threads executing concurrently within a weave's parallel group. Unset means unbounded.",
           "title": "Max Parallel Threads"
+        },
+        "capture_samples": {
+          "default": false,
+          "description": "Whether to capture 10-row output samples at write time for display. Preview mode always captures samples regardless of this setting.",
+          "title": "Capture Samples",
+          "type": "boolean"
         }
       },
       "title": "ExecutionConfig",

--- a/docs/schema/weave.json
+++ b/docs/schema/weave.json
@@ -238,7 +238,7 @@
       "type": "object"
     },
     "ExecutionConfig": {
-      "description": "Runtime execution settings declared on the top-level ``execution:`` block.\n\nCanonical declaration sites are the top-level ``execution:`` field on\nLoom and Weave. The effective settings for a weave execution merge\nfield-level (see :func:`resolve_effective_execution`) rather than\nreplacing whole-block. Thread-scoped execution settings are declared\nbut not applied in v1.x.\n\nAttributes:\n    log_level: Logging verbosity for execution output.\n    trace: Whether to collect execution spans for telemetry.\n    max_parallel_threads: Upper bound on concurrently executing\n        threads within a weave's parallel group. Unset means\n        unbounded (pool sized to the group).",
+      "description": "Runtime execution settings declared on the top-level ``execution:`` block.\n\nCanonical declaration sites are the top-level ``execution:`` field on\nLoom and Weave. The effective settings for a weave execution merge\nfield-level (see :func:`resolve_effective_execution`) rather than\nreplacing whole-block. Thread-scoped execution settings are declared\nbut not applied in v1.x.\n\nAttributes:\n    log_level: Logging verbosity for execution output.\n    trace: Whether to collect execution spans for telemetry.\n    max_parallel_threads: Upper bound on concurrently executing\n        threads within a weave's parallel group. Unset means\n        unbounded (pool sized to the group).\n    capture_samples: Whether output samples are captured at write\n        time. Off by default; preview always samples.",
       "properties": {
         "log_level": {
           "$ref": "#/$defs/LogLevel",
@@ -264,6 +264,12 @@
           "default": null,
           "description": "Maximum threads executing concurrently within a weave's parallel group. Unset means unbounded.",
           "title": "Max Parallel Threads"
+        },
+        "capture_samples": {
+          "default": false,
+          "description": "Whether to capture 10-row output samples at write time for display. Preview mode always captures samples regardless of this setting.",
+          "title": "Capture Samples",
+          "type": "boolean"
         }
       },
       "title": "ExecutionConfig",

--- a/docs/schema/weevr.json
+++ b/docs/schema/weevr.json
@@ -1349,7 +1349,7 @@
         "type": "object"
       },
       "ExecutionConfig": {
-        "description": "Runtime execution settings declared on the top-level ``execution:`` block.\n\nCanonical declaration sites are the top-level ``execution:`` field on\nLoom and Weave. The effective settings for a weave execution merge\nfield-level (see :func:`resolve_effective_execution`) rather than\nreplacing whole-block. Thread-scoped execution settings are declared\nbut not applied in v1.x.\n\nAttributes:\n    log_level: Logging verbosity for execution output.\n    trace: Whether to collect execution spans for telemetry.\n    max_parallel_threads: Upper bound on concurrently executing\n        threads within a weave's parallel group. Unset means\n        unbounded (pool sized to the group).",
+        "description": "Runtime execution settings declared on the top-level ``execution:`` block.\n\nCanonical declaration sites are the top-level ``execution:`` field on\nLoom and Weave. The effective settings for a weave execution merge\nfield-level (see :func:`resolve_effective_execution`) rather than\nreplacing whole-block. Thread-scoped execution settings are declared\nbut not applied in v1.x.\n\nAttributes:\n    log_level: Logging verbosity for execution output.\n    trace: Whether to collect execution spans for telemetry.\n    max_parallel_threads: Upper bound on concurrently executing\n        threads within a weave's parallel group. Unset means\n        unbounded (pool sized to the group).\n    capture_samples: Whether output samples are captured at write\n        time. Off by default; preview always samples.",
         "properties": {
           "log_level": {
             "$ref": "#/$defs/LogLevel",
@@ -1375,6 +1375,12 @@
             "default": null,
             "description": "Maximum threads executing concurrently within a weave's parallel group. Unset means unbounded.",
             "title": "Max Parallel Threads"
+          },
+          "capture_samples": {
+            "default": false,
+            "description": "Whether to capture 10-row output samples at write time for display. Preview mode always captures samples regardless of this setting.",
+            "title": "Capture Samples",
+            "type": "boolean"
           }
         },
         "title": "ExecutionConfig",
@@ -5323,7 +5329,7 @@
         "type": "object"
       },
       "ExecutionConfig": {
-        "description": "Runtime execution settings declared on the top-level ``execution:`` block.\n\nCanonical declaration sites are the top-level ``execution:`` field on\nLoom and Weave. The effective settings for a weave execution merge\nfield-level (see :func:`resolve_effective_execution`) rather than\nreplacing whole-block. Thread-scoped execution settings are declared\nbut not applied in v1.x.\n\nAttributes:\n    log_level: Logging verbosity for execution output.\n    trace: Whether to collect execution spans for telemetry.\n    max_parallel_threads: Upper bound on concurrently executing\n        threads within a weave's parallel group. Unset means\n        unbounded (pool sized to the group).",
+        "description": "Runtime execution settings declared on the top-level ``execution:`` block.\n\nCanonical declaration sites are the top-level ``execution:`` field on\nLoom and Weave. The effective settings for a weave execution merge\nfield-level (see :func:`resolve_effective_execution`) rather than\nreplacing whole-block. Thread-scoped execution settings are declared\nbut not applied in v1.x.\n\nAttributes:\n    log_level: Logging verbosity for execution output.\n    trace: Whether to collect execution spans for telemetry.\n    max_parallel_threads: Upper bound on concurrently executing\n        threads within a weave's parallel group. Unset means\n        unbounded (pool sized to the group).\n    capture_samples: Whether output samples are captured at write\n        time. Off by default; preview always samples.",
         "properties": {
           "log_level": {
             "$ref": "#/$defs/LogLevel",
@@ -5349,6 +5355,12 @@
             "default": null,
             "description": "Maximum threads executing concurrently within a weave's parallel group. Unset means unbounded.",
             "title": "Max Parallel Threads"
+          },
+          "capture_samples": {
+            "default": false,
+            "description": "Whether to capture 10-row output samples at write time for display. Preview mode always captures samples regardless of this setting.",
+            "title": "Capture Samples",
+            "type": "boolean"
           }
         },
         "title": "ExecutionConfig",
@@ -6837,7 +6849,7 @@
         "type": "object"
       },
       "ExecutionConfig": {
-        "description": "Runtime execution settings declared on the top-level ``execution:`` block.\n\nCanonical declaration sites are the top-level ``execution:`` field on\nLoom and Weave. The effective settings for a weave execution merge\nfield-level (see :func:`resolve_effective_execution`) rather than\nreplacing whole-block. Thread-scoped execution settings are declared\nbut not applied in v1.x.\n\nAttributes:\n    log_level: Logging verbosity for execution output.\n    trace: Whether to collect execution spans for telemetry.\n    max_parallel_threads: Upper bound on concurrently executing\n        threads within a weave's parallel group. Unset means\n        unbounded (pool sized to the group).",
+        "description": "Runtime execution settings declared on the top-level ``execution:`` block.\n\nCanonical declaration sites are the top-level ``execution:`` field on\nLoom and Weave. The effective settings for a weave execution merge\nfield-level (see :func:`resolve_effective_execution`) rather than\nreplacing whole-block. Thread-scoped execution settings are declared\nbut not applied in v1.x.\n\nAttributes:\n    log_level: Logging verbosity for execution output.\n    trace: Whether to collect execution spans for telemetry.\n    max_parallel_threads: Upper bound on concurrently executing\n        threads within a weave's parallel group. Unset means\n        unbounded (pool sized to the group).\n    capture_samples: Whether output samples are captured at write\n        time. Off by default; preview always samples.",
         "properties": {
           "log_level": {
             "$ref": "#/$defs/LogLevel",
@@ -6863,6 +6875,12 @@
             "default": null,
             "description": "Maximum threads executing concurrently within a weave's parallel group. Unset means unbounded.",
             "title": "Max Parallel Threads"
+          },
+          "capture_samples": {
+            "default": false,
+            "description": "Whether to capture 10-row output samples at write time for display. Preview mode always captures samples regardless of this setting.",
+            "title": "Capture Samples",
+            "type": "boolean"
           }
         },
         "title": "ExecutionConfig",

--- a/packages/weevr-core/src/weevr/model/execution.py
+++ b/packages/weevr-core/src/weevr/model/execution.py
@@ -35,6 +35,8 @@ class ExecutionConfig(FrozenBase):
         max_parallel_threads: Upper bound on concurrently executing
             threads within a weave's parallel group. Unset means
             unbounded (pool sized to the group).
+        capture_samples: Whether output samples are captured at write
+            time. Off by default; preview always samples.
     """
 
     log_level: LogLevel = Field(
@@ -51,6 +53,14 @@ class ExecutionConfig(FrozenBase):
         description=(
             "Maximum threads executing concurrently within a weave's "
             "parallel group. Unset means unbounded."
+        ),
+    )
+    capture_samples: bool = Field(
+        default=False,
+        description=(
+            "Whether to capture 10-row output samples at write time for "
+            "display. Preview mode always captures samples regardless of "
+            "this setting."
         ),
     )
 

--- a/packages/weevr/src/weevr/engine/display.py
+++ b/packages/weevr/src/weevr/engine/display.py
@@ -2955,7 +2955,14 @@ def _render_execute_thread_detail(
     parts.append(_render_schema_table(getattr(tr, "output_schema", None)))
 
     # Data sample (output)
-    parts.append(_render_sample_table(getattr(tr, "samples", None), "output"))
+    samples_out = getattr(tr, "samples", None)
+    if samples_out and "output" in samples_out:
+        parts.append(_render_sample_table(samples_out, "output"))
+    else:
+        parts.append(
+            f'<p style="{_S_NONE}">Samples not captured — enable '
+            "<code>execution.capture_samples</code> to include output rows.</p>"
+        )
 
     # Quarantine sample
     parts.append(

--- a/packages/weevr/src/weevr/engine/executor.py
+++ b/packages/weevr/src/weevr/engine/executor.py
@@ -9,7 +9,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from pyspark.sql import SparkSession
+from pyspark.sql import Observation, SparkSession
+from pyspark.sql import functions as F
 
 from weevr.delta import read_delta
 from weevr.engine.column_sets import materialize_column_sets
@@ -46,6 +47,7 @@ from weevr.operations.fact import check_fact_sentinels, validate_fact_schema
 from weevr.operations.hashing import compute_dimension_keys, compute_keys
 from weevr.operations.naming import normalize_columns
 from weevr.operations.pipeline import LookupMeta, ObservationRegistry, run_pipeline
+from weevr.operations.pipeline._observations import read_observation
 from weevr.operations.quarantine import write_quarantine
 from weevr.operations.readers import (
     read_cdc_source,
@@ -396,8 +398,6 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
                     thread.load.cdc.preset == "delta_cdf"
                     and "_commit_version" in primary_df.columns
                 ):
-                    from pyspark.sql import functions as F
-
                     max_row = primary_df.agg(F.max("_commit_version").alias("mv")).collect()
                     if max_row and max_row[0]["mv"] is not None:
                         new_hwm = str(max_row[0]["mv"])
@@ -436,6 +436,19 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
             # write); CTE sub-pipelines contribute under their own scopes.
             obs_registry = ObservationRegistry(scope="main")
 
+            # Merge-terminal paths (dimension, CDC, merge write mode) fix
+            # observations with ZERO rows — the merge's internal execution
+            # fires observed nodes without flowing source rows through them
+            # (locked in test_merge_observation_semantics). Those paths keep
+            # eager counts, which double as the action that fixes the step
+            # observations with true full-scale values. Single-pass write
+            # paths (overwrite/append) go fully lazy.
+            merge_terminal = (
+                thread.target.dimension is not None
+                or load_mode == "cdc"
+                or (thread.write is not None and thread.write.mode == "merge")
+            )
+
             # Resolve with: block CTEs before the primary DataFrame is set
             if thread.with_:
                 sources_map = _resolve_with_block(
@@ -449,7 +462,12 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
 
             # Step 5 — primary DataFrame is the first declared source
             df = next(iter(sources_map.values()))
-            rows_read = df.count()
+            rows_read_obs: Observation | None = None
+            if merge_terminal:
+                rows_read = df.count()
+            else:
+                rows_read_obs = Observation()
+                df = df.observe(rows_read_obs, F.count(F.lit(1)).alias("n"))
 
             # Step 6 — run pipeline steps
             df = run_pipeline(
@@ -463,13 +481,17 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
                 lookup_meta=lookup_meta,
             )
 
-            # Capture intermediate row count for waterfall visualization.
-            # This count is also the FIRST action over the pipeline plan:
-            # Spark observations are fixed by the first completed execution,
-            # so the step statistics harvested later carry the values from
-            # this full-scale execution — removing or reordering this count
-            # changes which action fixes them.
-            rows_after_transforms = df.count()
+            # Intermediate row count for waterfall visualization. On
+            # merge-terminal paths this eager count is ALSO the first action
+            # over the plan — the one that fixes every observation with true
+            # full-scale values before the merge can zero-fire them. On
+            # single-pass paths it becomes an observation fixed by the write.
+            rows_after_transforms_obs: Observation | None = None
+            if merge_terminal:
+                rows_after_transforms = df.count()
+            else:
+                rows_after_transforms_obs = Observation()
+                df = df.observe(rows_after_transforms_obs, F.count(F.lit(1)).alias("n"))
 
             # Step 7 — run validation rules
             if thread.validations:
@@ -776,8 +798,14 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
                     samples["quarantine"] = quarantine_sample
 
             # Harvest step observations — fulfilled by the write (or the
-            # last action that executed the plan). Best-effort by design.
+            # first action that executed the plan). Best-effort by design.
             step_stats = obs_registry.harvest() or None
+            if rows_read_obs is not None:
+                rr = read_observation(rows_read_obs)
+                rows_read = int(rr["n"]) if rr and rr.get("n") is not None else 0
+            if rows_after_transforms_obs is not None:
+                rat = read_observation(rows_after_transforms_obs)
+                rows_after_transforms = int(rat["n"]) if rat and rat.get("n") is not None else 0
 
             telemetry = _build_telemetry(
                 span_builder,
@@ -949,11 +977,12 @@ def _resolve_with_block(
         )
         if observations is not None and cte_registry is not None:
             observations.merge(cte_registry)
-        row_count = cte_df.count()
         enriched[cte_name] = cte_df
 
         if cte_builder is not None:
-            cte_builder.set_attribute("row_count", row_count)
+            # Collector-gated: the count exists only for the CTE span
+            # attribute — collector-less runs pay no CTE action at all
+            cte_builder.set_attribute("row_count", cte_df.count())
             cte_builder.set_attribute("from", cte.from_)
             cte_builder.set_attribute("step_count", len(cte.steps))
             span = cte_builder.finish()

--- a/packages/weevr/src/weevr/engine/executor.py
+++ b/packages/weevr/src/weevr/engine/executor.py
@@ -9,6 +9,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from pyspark import StorageLevel
 from pyspark.sql import Observation, SparkSession
 from pyspark.sql import functions as F
 
@@ -196,6 +197,8 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
     thread_variable_ctx = _build_thread_variable_context(thread)
     thread_cached_lookups: dict[str, Any] = {}
     cdc_window_df: Any = None
+    working_df_persisted: Any = None
+    quarantine_df_persisted: Any = None
 
     # Compute effective resources by merging weave-level with thread-level
     effective_cached_lookups = cached_lookups
@@ -397,8 +400,6 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
                 # op-code counts, and the merge itself all execute this
                 # lineage — window-scale, cached once, released in the
                 # thread's finally block
-                from pyspark import StorageLevel
-
                 primary_df = primary_df.persist(StorageLevel.MEMORY_AND_DISK)
                 cdc_window_df = primary_df
 
@@ -512,13 +513,19 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
                         f"Fatal validation failure in thread '{thread.name}'",
                     )
 
-                # Write quarantine rows if present
+                # Write quarantine rows if present. The union computes once:
+                # persist, count from cache, write only when rows exist (an
+                # all-clean run leaves the prior quarantine table untouched),
+                # sample from cache. Released in finally.
                 if outcome.quarantine_df is not None:
-                    rows_quarantined = write_quarantine(spark, outcome.quarantine_df, target_path)
+                    quarantine_df_persisted = outcome.quarantine_df.persist(
+                        StorageLevel.MEMORY_AND_DISK
+                    )
+                    rows_quarantined = write_quarantine(spark, quarantine_df_persisted, target_path)
                     if capture_samples:
                         with contextlib.suppress(Exception):
                             quarantine_sample = (
-                                outcome.quarantine_df.limit(10).toPandas().to_dict("records")
+                                quarantine_df_persisted.limit(10).toPandas().to_dict("records")
                             )
 
                 # Continue with clean_df
@@ -586,6 +593,14 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
                     spark=spark,
                     target_path=target_path,
                 )
+                # Exports reuse one compute of the working DataFrame: the
+                # persist anchors here — after warp/drift, before the
+                # branch-specific write — the point common to all branches
+                # (the CDC branch deliberately skips target mapping, so
+                # mapping is not a valid anchor). Released in finally.
+                if thread.exports:
+                    df = df.persist(StorageLevel.MEMORY_AND_DISK)
+                    working_df_persisted = df
 
                 # Seed phase (before merge)
                 if seed_config is not None or dim_config.seed_system_members:
@@ -642,6 +657,14 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
                     spark=spark,
                     target_path=target_path,
                 )
+                # Exports reuse one compute of the working DataFrame: the
+                # persist anchors here — after warp/drift, before the
+                # branch-specific write — the point common to all branches
+                # (the CDC branch deliberately skips target mapping, so
+                # mapping is not a valid anchor). Released in finally.
+                if thread.exports:
+                    df = df.persist(StorageLevel.MEMORY_AND_DISK)
+                    working_df_persisted = df
 
                 output_schema = [(name, str(dtype)) for name, dtype in df.dtypes]
                 if capture_samples:
@@ -676,6 +699,14 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
                     spark=spark,
                     target_path=target_path,
                 )
+                # Exports reuse one compute of the working DataFrame: the
+                # persist anchors here — after warp/drift, before the
+                # branch-specific write — the point common to all branches
+                # (the CDC branch deliberately skips target mapping, so
+                # mapping is not a valid anchor). Released in finally.
+                if thread.exports:
+                    df = df.persist(StorageLevel.MEMORY_AND_DISK)
+                    working_df_persisted = df
 
                 # General seed phase (non-dimension)
                 if seed_config is not None:
@@ -944,6 +975,12 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
         if cdc_window_df is not None:
             with contextlib.suppress(Exception):
                 cdc_window_df.unpersist()
+        if working_df_persisted is not None:
+            with contextlib.suppress(Exception):
+                working_df_persisted.unpersist()
+        if quarantine_df_persisted is not None:
+            with contextlib.suppress(Exception):
+                quarantine_df_persisted.unpersist()
 
 
 def _resolve_with_block(

--- a/packages/weevr/src/weevr/engine/executor.py
+++ b/packages/weevr/src/weevr/engine/executor.py
@@ -54,6 +54,7 @@ from weevr.operations.readers import (
     read_sources,
 )
 from weevr.operations.seeding import build_system_member_rows, execute_seeds
+from weevr.operations.target_handle import TargetHandle
 from weevr.operations.validation import validate_dataframe
 from weevr.operations.warp import (
     append_warp_only_columns,
@@ -279,6 +280,12 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
                     thread_name=thread.name,
                 )
 
+            # One existence/identity resolution per thread. Refreshed after
+            # every engine-internal commit (warp pre-init, seeds) so
+            # downstream consumers observe post-commit state exactly as
+            # their previous independent probes did.
+            target_handle = TargetHandle(spark, target_path)
+
             # --- Warp resolution ---
             resolved_warp = None
             warp_findings: list[dict[str, str]] = []
@@ -309,6 +316,7 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
                 engine_col_names = list((thread.target.audit_columns or {}).keys())
                 effective_warp = build_effective_warp(resolved_warp.columns, [], engine_col_names)
                 pre_initialize_table(spark, target_path, effective_warp)
+                target_handle.refresh()
 
             # --- Watermark/CDC state loading ---
             if load_mode in ("incremental_watermark", "cdc") and thread.load is not None:
@@ -532,7 +540,7 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
 
             if dim_config is not None and dim_builder is not None:
                 # Dimension merge routing
-                df = apply_target_mapping(df, thread.target, spark)
+                df = apply_target_mapping(df, thread.target, spark, handle=target_handle)
                 if audit_columns and audit_ctx is not None:
                     df = inject_audit_columns(df, audit_columns, audit_ctx)
                     audit_columns_applied = list(audit_columns)
@@ -561,13 +569,18 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
                             on=seed_config.on if seed_config else "first_write",
                             rows=all_seed_rows,
                         )
-                        execute_seeds(spark, combined_seed, target_path, target_schema)
+                        execute_seeds(
+                            spark, combined_seed, target_path, target_schema, handle=target_handle
+                        )
+                        target_handle.refresh()
 
                 output_schema = [(name, str(dtype)) for name, dtype in df.dtypes]
                 if capture_samples:
                     with contextlib.suppress(Exception):
                         output_sample = df.limit(10).toPandas().to_dict("records")
-                execute_dimension_merge(spark, df, dim_builder, target_path, run_timestamp)
+                execute_dimension_merge(
+                    spark, df, dim_builder, target_path, run_timestamp, handle=target_handle
+                )
                 rows_written = df.count()
 
             elif load_mode == "cdc" and thread.load is not None and thread.load.cdc is not None:
@@ -595,13 +608,19 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
                         output_sample = df.limit(10).toPandas().to_dict("records")
                 cdc_write = _validate_cdc_write_config(thread)
                 cdc_counts = execute_cdc_merge(
-                    spark, df, target_path, cdc_write, thread.load.cdc, load_config=thread.load
+                    spark,
+                    df,
+                    target_path,
+                    cdc_write,
+                    thread.load.cdc,
+                    load_config=thread.load,
+                    handle=target_handle,
                 )
                 rows_written = sum(cdc_counts.values())
 
             else:
                 # Standard write path
-                df = apply_target_mapping(df, thread.target, spark)
+                df = apply_target_mapping(df, thread.target, spark, handle=target_handle)
                 if audit_columns and audit_ctx is not None:
                     df = inject_audit_columns(df, audit_columns, audit_ctx)
                     audit_columns_applied = list(audit_columns)
@@ -619,13 +638,16 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
 
                 # General seed phase (non-dimension)
                 if seed_config is not None:
-                    execute_seeds(spark, seed_config, target_path, df.schema)
+                    execute_seeds(spark, seed_config, target_path, df.schema, handle=target_handle)
+                    target_handle.refresh()
 
                 output_schema = [(name, str(dtype)) for name, dtype in df.dtypes]
                 if capture_samples:
                     with contextlib.suppress(Exception):
                         output_sample = df.limit(10).toPandas().to_dict("records")
-                rows_written = write_target(spark, df, thread.target, thread.write, target_path)
+                rows_written = write_target(
+                    spark, df, thread.target, thread.write, target_path, handle=target_handle
+                )
 
             # Step 13b — post-write fact sentinel advisory. Runs against
             # the written table, where columnar stats make per-column

--- a/packages/weevr/src/weevr/engine/executor.py
+++ b/packages/weevr/src/weevr/engine/executor.py
@@ -51,6 +51,7 @@ from weevr.operations.pipeline import LookupMeta, ObservationRegistry, run_pipel
 from weevr.operations.pipeline._observations import read_observation
 from weevr.operations.quarantine import write_quarantine
 from weevr.operations.readers import (
+    compute_generic_cdc_hwm,
     read_cdc_source,
     read_source,
     read_source_incremental,
@@ -395,6 +396,7 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
                     load_config=thread.load,
                     prior_state=prior_state,
                     connections=connections,
+                    compute_hwm=False,
                 )
                 # Persist the change window: the version capture, the
                 # op-code counts, and the merge itself all execute this
@@ -402,6 +404,14 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
                 # thread's finally block
                 primary_df = primary_df.persist(StorageLevel.MEMORY_AND_DISK)
                 cdc_window_df = primary_df
+                # Generic-preset HWM computes AGAINST the persisted window,
+                # sharing one lineage with the op counts and the merge — the
+                # captured value and the applied rows cannot diverge. (The
+                # old in-read capture ran on a separate execution: a commit
+                # between it and the merge silently decoupled persisted
+                # state from applied state.)
+                if thread.load.cdc.preset != "delta_cdf":
+                    cdc_new_hwm = compute_generic_cdc_hwm(primary_df, thread.load)
 
                 # Capture new CDF version if Delta CDF
                 if (
@@ -628,16 +638,20 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
                 merge_result = execute_dimension_merge(
                     spark, df, dim_builder, target_path, run_timestamp, handle=target_handle
                 )
-                # Input-rows semantic without a third full-scale action:
-                # transforms after the eager rows_after_transforms count are
-                # column-only, so write-input rows = that count minus the
-                # quarantined rows (both already known). First writes report
-                # the commit's own numOutputRows instead.
-                rows_written = (
-                    merge_result.rows_inserted
-                    if was_first_write
-                    else rows_after_transforms - rows_quarantined
-                )
+                # Input-rows semantic. Quarantine-free merges need no new
+                # action: transforms after the eager rows_after_transforms
+                # count are column-only, so write-input rows equal it. With
+                # quarantined rows the subtraction would lie — quarantine
+                # frames are exploded one row per FAILED RULE, so a source
+                # row failing two rules subtracts twice — and the input df
+                # must be counted directly (exact beats cheap here). First
+                # writes report the commit's own numOutputRows.
+                if was_first_write:
+                    rows_written = merge_result.rows_inserted
+                elif rows_quarantined:
+                    rows_written = df.count()
+                else:
+                    rows_written = rows_after_transforms
 
             elif load_mode == "cdc" and thread.load is not None and thread.load.cdc is not None:
                 # CDC merge routing (no dimension) — skip target column

--- a/packages/weevr/src/weevr/engine/executor.py
+++ b/packages/weevr/src/weevr/engine/executor.py
@@ -600,10 +600,20 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
                 if capture_samples:
                     with contextlib.suppress(Exception):
                         output_sample = df.limit(10).toPandas().to_dict("records")
-                execute_dimension_merge(
+                was_first_write = not target_handle.exists()
+                merge_result = execute_dimension_merge(
                     spark, df, dim_builder, target_path, run_timestamp, handle=target_handle
                 )
-                rows_written = df.count()
+                # Input-rows semantic without a third full-scale action:
+                # transforms after the eager rows_after_transforms count are
+                # column-only, so write-input rows = that count minus the
+                # quarantined rows (both already known). First writes report
+                # the commit's own numOutputRows instead.
+                rows_written = (
+                    merge_result.rows_inserted
+                    if was_first_write
+                    else rows_after_transforms - rows_quarantined
+                )
 
             elif load_mode == "cdc" and thread.load is not None and thread.load.cdc is not None:
                 # CDC merge routing (no dimension) — skip target column

--- a/packages/weevr/src/weevr/engine/executor.py
+++ b/packages/weevr/src/weevr/engine/executor.py
@@ -84,6 +84,7 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
     column_set_defs: dict[str, ColumnSet] | None = None,
     connections: dict[str, OneLakeConnection] | None = None,
     lookup_meta: dict[str, LookupMeta] | None = None,
+    capture_samples: bool = False,
 ) -> ThreadResult:
     """Execute a single thread from sources through transforms to a Delta target.
 
@@ -139,6 +140,9 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
             configured.
         lookup_meta: Materialization-time lookup facts inherited from the
             weave/loom scope; thread-level facts merge on top.
+        capture_samples: Whether to capture 10-row output/quarantine
+            samples for display (effective ``execution.capture_samples``).
+            Off by default — sampling re-executes the pipeline lineage.
 
     Returns:
         :class:`ThreadResult` with status, row count, write mode, target path,
@@ -472,10 +476,11 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
                 # Write quarantine rows if present
                 if outcome.quarantine_df is not None:
                     rows_quarantined = write_quarantine(spark, outcome.quarantine_df, target_path)
-                    with contextlib.suppress(Exception):
-                        quarantine_sample = (
-                            outcome.quarantine_df.limit(10).toPandas().to_dict("records")
-                        )
+                    if capture_samples:
+                        with contextlib.suppress(Exception):
+                            quarantine_sample = (
+                                outcome.quarantine_df.limit(10).toPandas().to_dict("records")
+                            )
 
                 # Continue with clean_df
                 df = outcome.clean_df
@@ -559,8 +564,9 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
                         execute_seeds(spark, combined_seed, target_path, target_schema)
 
                 output_schema = [(name, str(dtype)) for name, dtype in df.dtypes]
-                with contextlib.suppress(Exception):
-                    output_sample = df.limit(10).toPandas().to_dict("records")
+                if capture_samples:
+                    with contextlib.suppress(Exception):
+                        output_sample = df.limit(10).toPandas().to_dict("records")
                 execute_dimension_merge(spark, df, dim_builder, target_path, run_timestamp)
                 rows_written = df.count()
 
@@ -584,8 +590,9 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
                 )
 
                 output_schema = [(name, str(dtype)) for name, dtype in df.dtypes]
-                with contextlib.suppress(Exception):
-                    output_sample = df.limit(10).toPandas().to_dict("records")
+                if capture_samples:
+                    with contextlib.suppress(Exception):
+                        output_sample = df.limit(10).toPandas().to_dict("records")
                 cdc_write = _validate_cdc_write_config(thread)
                 cdc_counts = execute_cdc_merge(
                     spark, df, target_path, cdc_write, thread.load.cdc, load_config=thread.load
@@ -615,8 +622,9 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
                     execute_seeds(spark, seed_config, target_path, df.schema)
 
                 output_schema = [(name, str(dtype)) for name, dtype in df.dtypes]
-                with contextlib.suppress(Exception):
-                    output_sample = df.limit(10).toPandas().to_dict("records")
+                if capture_samples:
+                    with contextlib.suppress(Exception):
+                        output_sample = df.limit(10).toPandas().to_dict("records")
                 rows_written = write_target(spark, df, thread.target, thread.write, target_path)
 
             # Step 13b — post-write fact sentinel advisory. Runs against

--- a/packages/weevr/src/weevr/engine/executor.py
+++ b/packages/weevr/src/weevr/engine/executor.py
@@ -195,6 +195,7 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
     # --- Thread-level resource lifecycle ---
     thread_variable_ctx = _build_thread_variable_context(thread)
     thread_cached_lookups: dict[str, Any] = {}
+    cdc_window_df: Any = None
 
     # Compute effective resources by merging weave-level with thread-level
     effective_cached_lookups = cached_lookups
@@ -392,6 +393,14 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
                     prior_state=prior_state,
                     connections=connections,
                 )
+                # Persist the change window: the version capture, the
+                # op-code counts, and the merge itself all execute this
+                # lineage — window-scale, cached once, released in the
+                # thread's finally block
+                from pyspark import StorageLevel
+
+                primary_df = primary_df.persist(StorageLevel.MEMORY_AND_DISK)
+                cdc_window_df = primary_df
 
                 # Capture new CDF version if Delta CDF
                 if (
@@ -932,6 +941,9 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
         # Cleanup thread-level lookups only; weave-level cleanup is the caller's job
         if thread_cached_lookups:
             cleanup_lookups(thread_cached_lookups)
+        if cdc_window_df is not None:
+            with contextlib.suppress(Exception):
+                cdc_window_df.unpersist()
 
 
 def _resolve_with_block(

--- a/packages/weevr/src/weevr/engine/runner.py
+++ b/packages/weevr/src/weevr/engine/runner.py
@@ -337,6 +337,9 @@ def execute_weave(
                                     all_lookup_results, base=pre_lookup_meta
                                 )
                                 or None,
+                                capture_samples=(
+                                    execution.capture_samples if execution is not None else False
+                                ),
                                 weave_lookups=lookups,
                                 resolved_params=params,
                                 loom_name=loom_name,
@@ -357,6 +360,9 @@ def execute_weave(
                                     all_lookup_results, base=pre_lookup_meta
                                 )
                                 or None,
+                                capture_samples=(
+                                    execution.capture_samples if execution is not None else False
+                                ),
                                 weave_lookups=lookups,
                                 resolved_params=params,
                                 loom_name=loom_name,

--- a/packages/weevr/src/weevr/operations/dimension.py
+++ b/packages/weevr/src/weevr/operations/dimension.py
@@ -7,11 +7,13 @@ target configuration.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 from dataclasses import dataclass
 from functools import reduce
 from typing import Any
 
+from pyspark import StorageLevel
 from pyspark.sql import Column, DataFrame, SparkSession
 from pyspark.sql import functions as F
 
@@ -286,6 +288,11 @@ def _execute_versioned_merge(
     scd = config.columns
     bk_cols = config.business_key
 
+    # The MERGE's unioned source embeds this lineage twice (directly and
+    # via the new-version derivation); persist so it computes once.
+    # Released in the finally below.
+    source_df = source_df.persist(StorageLevel.MEMORY_AND_DISK)
+
     # Identify version-group hash columns
     version_hash_cols: list[str] = []
     if config.change_detection:
@@ -386,7 +393,11 @@ def _execute_versioned_merge(
     )
 
     pre_version = handle.current_version() if handle is not None else None
-    merger.execute()
+    try:
+        merger.execute()
+    finally:
+        with contextlib.suppress(Exception):
+            source_df.unpersist()
     if handle is not None:
         handle.mark_exists()
     return _populate_merge_result(result, handle, pre_version, versioned=True)

--- a/packages/weevr/src/weevr/operations/dimension.py
+++ b/packages/weevr/src/weevr/operations/dimension.py
@@ -255,9 +255,13 @@ def execute_dimension_merge(
         return result
 
     if config.track_history and builder.has_version_groups():
-        return _execute_versioned_merge(spark, source_df, builder, target_path, run_timestamp)
+        return _execute_versioned_merge(
+            spark, source_df, builder, target_path, run_timestamp, handle=handle
+        )
 
-    return _execute_standard_merge(spark, source_df, builder, target_path, run_timestamp)
+    return _execute_standard_merge(
+        spark, source_df, builder, target_path, run_timestamp, handle=handle
+    )
 
 
 def _execute_versioned_merge(
@@ -266,6 +270,7 @@ def _execute_versioned_merge(
     builder: DimensionMergeBuilder,
     target_path: str,
     run_timestamp: str,
+    handle: TargetHandle | None = None,
 ) -> DimensionMergeResult:
     """SCD Type 2 staged merge: pre-join to identify changes, then MERGE.
 
@@ -380,8 +385,11 @@ def _execute_versioned_merge(
         scope_condition=f"target.{quote_identifier(scd.is_current)} = true",
     )
 
+    pre_version = handle.current_version() if handle is not None else None
     merger.execute()
-    return result
+    if handle is not None:
+        handle.mark_exists()
+    return _populate_merge_result(result, handle, pre_version, versioned=True)
 
 
 def _execute_standard_merge(
@@ -390,6 +398,7 @@ def _execute_standard_merge(
     builder: DimensionMergeBuilder,
     target_path: str,
     run_timestamp: str,
+    handle: TargetHandle | None = None,
 ) -> DimensionMergeResult:
     """Standard merge for non-versioned dimensions (Type 1)."""
     config = builder.config
@@ -443,8 +452,48 @@ def _execute_standard_merge(
 
     merger = merger.whenNotMatchedInsertAll()
     merger = _apply_not_matched_by_source(merger, builder)
+    pre_version = handle.current_version() if handle is not None else None
     merger.execute()
+    if handle is not None:
+        handle.mark_exists()
+    return _populate_merge_result(result, handle, pre_version, versioned=False)
 
+
+def _populate_merge_result(
+    result: DimensionMergeResult,
+    handle: TargetHandle | None,
+    pre_version: int | None,
+    *,
+    versioned: bool,
+) -> DimensionMergeResult:
+    """Fill merge metrics from the commit's split update keys.
+
+    Uses the split keys only — the ``numTargetRowsUpdated`` aggregate
+    conflates the close/overwrite clause with the soft-delete clause
+    (``whenNotMatchedBySourceUpdate``) and must never feed the split.
+    On the versioned path, one close corresponds to exactly one
+    new-version insert (single current row per entity), so new-entity
+    inserts are total inserts minus closes. ``rows_unchanged`` stays
+    absent by decision — no Delta metric expresses it. Metrics absent or
+    guard-rejected: warn and leave zeros, never a corrupted number.
+    """
+    if handle is None:
+        return result
+    metrics = handle.commit_metrics_after(pre_version)
+    if metrics is None or "numTargetRowsMatchedUpdated" not in metrics:
+        logger.warning("Dimension merge metrics unavailable; counts reported as zero")
+        return result
+    matched_updated = int(metrics.get("numTargetRowsMatchedUpdated", 0))
+    inserted = int(metrics.get("numTargetRowsInserted", 0))
+    deleted = int(metrics.get("numTargetRowsDeleted", 0))
+    nmbs_updated = int(metrics.get("numTargetRowsNotMatchedBySourceUpdated", 0))
+    if versioned:
+        result.rows_versioned = matched_updated
+        result.rows_inserted = inserted - matched_updated
+    else:
+        result.rows_overwritten = matched_updated
+        result.rows_inserted = inserted
+    result.rows_deleted = deleted + nmbs_updated
     return result
 
 

--- a/packages/weevr/src/weevr/operations/dimension.py
+++ b/packages/weevr/src/weevr/operations/dimension.py
@@ -15,7 +15,7 @@ from typing import Any
 from pyspark.sql import Column, DataFrame, SparkSession
 from pyspark.sql import functions as F
 
-from weevr.delta import delta_table_exists, resolve_delta_table
+from weevr.delta import resolve_delta_table
 from weevr.model.dimension import DimensionConfig
 from weevr.model.write import WriteConfig
 from weevr.operations.target_handle import TargetHandle
@@ -240,13 +240,18 @@ def execute_dimension_merge(
     config = builder.config
     result = DimensionMergeResult()
 
-    target_present = (
-        handle.exists() if handle is not None else delta_table_exists(spark, target_path)
-    )
-    if not target_present:
-        # First write — insert all rows directly
-        result.rows_inserted = source_df.count()
+    if handle is None:
+        handle = TargetHandle(spark, target_path)
+    if not handle.exists():
+        # First write — insert all rows directly; the count comes from the
+        # write's own commit metrics (guarded), not a pre-count
         source_df.write.format("delta").save(target_path)
+        metrics = handle.commit_metrics_after(None)
+        if metrics is not None and "numOutputRows" in metrics:
+            result.rows_inserted = int(metrics["numOutputRows"])
+        else:
+            logger.warning("First-write row count unavailable for '%s'; reporting 0", target_path)
+        handle.mark_exists()
         return result
 
     if config.track_history and builder.has_version_groups():

--- a/packages/weevr/src/weevr/operations/dimension.py
+++ b/packages/weevr/src/weevr/operations/dimension.py
@@ -492,7 +492,10 @@ def _populate_merge_result(
         return result
     metrics = handle.commit_metrics_after(pre_version)
     if metrics is None or "numTargetRowsMatchedUpdated" not in metrics:
-        logger.warning("Dimension merge metrics unavailable; counts reported as zero")
+        logger.warning(
+            "Dimension merge metrics unavailable for '%s'; counts reported as zero",
+            handle.path,
+        )
         return result
     matched_updated = int(metrics.get("numTargetRowsMatchedUpdated", 0))
     inserted = int(metrics.get("numTargetRowsInserted", 0))

--- a/packages/weevr/src/weevr/operations/dimension.py
+++ b/packages/weevr/src/weevr/operations/dimension.py
@@ -18,6 +18,7 @@ from pyspark.sql import functions as F
 from weevr.delta import delta_table_exists, resolve_delta_table
 from weevr.model.dimension import DimensionConfig
 from weevr.model.write import WriteConfig
+from weevr.operations.target_handle import TargetHandle
 from weevr.operations.writers import quote_identifier
 
 logger = logging.getLogger(__name__)
@@ -205,6 +206,7 @@ def execute_dimension_merge(
     builder: DimensionMergeBuilder,
     target_path: str,
     run_timestamp: str,
+    handle: TargetHandle | None = None,
 ) -> DimensionMergeResult:
     """Execute the staged dimension merge against a Delta target.
 
@@ -229,13 +231,19 @@ def execute_dimension_merge(
         target_path: Path to the Delta target table.
         run_timestamp: ISO timestamp for SCD valid_from values.
 
+        handle: Pre-resolved target handle; when absent the function
+            self-resolves existence (operations stay independently usable).
+
     Returns:
         DimensionMergeResult with row-level metrics.
     """
     config = builder.config
     result = DimensionMergeResult()
 
-    if not delta_table_exists(spark, target_path):
+    target_present = (
+        handle.exists() if handle is not None else delta_table_exists(spark, target_path)
+    )
+    if not target_present:
         # First write — insert all rows directly
         result.rows_inserted = source_df.count()
         source_df.write.format("delta").save(target_path)

--- a/packages/weevr/src/weevr/operations/pipeline/_observations.py
+++ b/packages/weevr/src/weevr/operations/pipeline/_observations.py
@@ -54,6 +54,18 @@ def _get_with_timeout(observation: Observation, timeout: float) -> dict[str, Any
     return result[0]
 
 
+def read_observation(observation: Observation) -> dict[str, Any] | None:
+    """Best-effort read of one observation's values.
+
+    Same posture as registry harvest: timeout-guarded, never raises —
+    an unfulfilled observation yields None.
+    """
+    try:
+        return _get_with_timeout(observation, _HARVEST_TIMEOUT_S)
+    except Exception:
+        return None
+
+
 @dataclass
 class _Entry:
     key: str

--- a/packages/weevr/src/weevr/operations/readers.py
+++ b/packages/weevr/src/weevr/operations/readers.py
@@ -337,6 +337,25 @@ def read_source_incremental(
     return df, new_hwm
 
 
+def compute_generic_cdc_hwm(df: DataFrame, load_config: LoadConfig) -> str | None:
+    """High-water mark of a generic CDC change window: max of the typed column.
+
+    Window-scale. Run this against the PERSISTED window when one exists so
+    the captured value matches the rows every later action processes.
+    """
+    if load_config.watermark_column is None:
+        return None
+    typed = typed_watermark_col(
+        load_config.watermark_column,
+        load_config.watermark_type,
+        load_config.watermark_format,
+    )
+    hwm_row = df.agg(F.max(typed).alias("hwm")).collect()
+    if hwm_row and hwm_row[0]["hwm"] is not None:
+        return str(hwm_row[0]["hwm"])
+    return None
+
+
 def read_cdc_source(
     spark: SparkSession,
     source: Source,
@@ -346,6 +365,7 @@ def read_cdc_source(
     load_config: LoadConfig | None = None,
     prior_state: WatermarkState | None = None,
     connections: dict[str, OneLakeConnection] | None = None,
+    compute_hwm: bool = True,
 ) -> tuple[DataFrame, str | None]:
     """Read a CDC source, optionally narrowed by a watermark filter.
 
@@ -380,6 +400,9 @@ def read_cdc_source(
             a ``watermark_column``.
         connections: Named connection declarations forwarded to the
             read.
+        compute_hwm: When False the generic-preset HWM aggregation is
+            skipped; the caller recomputes via :func:`compute_generic_cdc_hwm`
+            against its persisted window.
 
     Returns:
         Tuple of ``(DataFrame, new_hwm_value)``. ``new_hwm_value`` is
@@ -417,17 +440,13 @@ def read_cdc_source(
         df = df.filter(filter_expr)
 
     # Capture HWM from the filtered DataFrame *before* operation routing
-    # so D rows still advance the window (DEC-003).
+    # so D rows still advance the window (DEC-003). Callers that persist
+    # the window pass compute_hwm=False and recompute from the pinned
+    # frame instead — this read is lazy, so a value captured here could
+    # otherwise diverge from the rows a later action actually processes.
     new_hwm: str | None = None
-    if load_config is not None and load_config.watermark_column is not None:
-        typed = typed_watermark_col(
-            load_config.watermark_column,
-            load_config.watermark_type,
-            load_config.watermark_format,
-        )
-        hwm_row = df.agg(F.max(typed).alias("hwm")).collect()
-        if hwm_row and hwm_row[0]["hwm"] is not None:
-            new_hwm = str(hwm_row[0]["hwm"])
+    if compute_hwm and load_config is not None and load_config.watermark_column is not None:
+        new_hwm = compute_generic_cdc_hwm(df, load_config)
 
         if load_config.watermark_format is not None:
             logger.debug(

--- a/packages/weevr/src/weevr/operations/seeding.py
+++ b/packages/weevr/src/weevr/operations/seeding.py
@@ -14,6 +14,7 @@ from weevr.errors.exceptions import ExecutionError
 from weevr.model.dimension import DimensionConfig, SystemMemberConfig
 from weevr.model.seed import SeedConfig
 from weevr.operations.pipeline.type_defaults import resolve_type_defaults
+from weevr.operations.target_handle import TargetHandle
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +49,12 @@ def _table_row_count(spark: SparkSession, path: str) -> int:
     return spark.read.format("delta").load(path).count()
 
 
-def check_seed_trigger(spark: SparkSession, table_path: str, seed_config: SeedConfig) -> bool:
+def check_seed_trigger(
+    spark: SparkSession,
+    table_path: str,
+    seed_config: SeedConfig,
+    handle: TargetHandle | None = None,
+) -> bool:
     """Evaluate whether the seed trigger condition is satisfied.
 
     For ``first_write``, the trigger fires when no Delta table exists at
@@ -60,10 +66,13 @@ def check_seed_trigger(spark: SparkSession, table_path: str, seed_config: SeedCo
         table_path: Filesystem path to the target Delta table.
         seed_config: Seed configuration carrying the ``on`` condition.
 
+        handle: Pre-resolved target handle; when absent the function
+            self-resolves existence (operations stay independently usable).
+
     Returns:
         ``True`` when seeds should be inserted, ``False`` otherwise.
     """
-    exists = delta_table_exists(spark, table_path)
+    exists = handle.exists() if handle is not None else delta_table_exists(spark, table_path)
 
     if seed_config.on == "first_write":
         return not exists
@@ -128,6 +137,7 @@ def execute_seeds(
     seed_config: SeedConfig,
     table_path: str,
     target_schema: StructType,
+    handle: TargetHandle | None = None,
 ) -> SeedResult:
     """Check the seed trigger and insert rows when the condition is satisfied.
 
@@ -140,10 +150,13 @@ def execute_seeds(
         table_path: Filesystem path to the target Delta table.
         target_schema: Schema that seed rows should conform to.
 
+        handle: Pre-resolved target handle; when absent the function
+            self-resolves existence (operations stay independently usable).
+
     Returns:
         :class:`SeedResult` describing the outcome.
     """
-    triggered = check_seed_trigger(spark, table_path, seed_config)
+    triggered = check_seed_trigger(spark, table_path, seed_config, handle=handle)
 
     if not triggered:
         return SeedResult(
@@ -156,7 +169,7 @@ def execute_seeds(
     seed_df = build_seed_dataframe(spark, seed_config.rows, target_schema)
     rows_inserted = len(seed_config.rows)
 
-    table_exists = delta_table_exists(spark, table_path)
+    table_exists = handle.exists() if handle is not None else delta_table_exists(spark, table_path)
     if table_exists:
         seed_df.write.format("delta").mode("append").save(table_path)
     else:

--- a/packages/weevr/src/weevr/operations/target_handle.py
+++ b/packages/weevr/src/weevr/operations/target_handle.py
@@ -34,6 +34,7 @@ class TargetHandle:
         self._spark = spark
         self.path = path
         self._exists: bool | None = None
+        self._version_read_failed = False
 
     def exists(self) -> bool:
         """Whether a Delta table exists at the target (cached until refresh)."""
@@ -64,11 +65,19 @@ class TargetHandle:
         before a counted write so the engine's own earlier commits to the
         same target (warp pre-init, seeds) are already included.
         """
+        self._version_read_failed = False
+        if not self.exists():
+            return None
         try:
             table = _delta.resolve_delta_table(self._spark, self.path)
             row = table.history(1).select("version").collect()
             return int(row[0][0]) if row else None
         except Exception:
+            # An EXISTING table whose history could not be read is not a
+            # fresh table — remember the difference so the metrics guard
+            # reports the right cause instead of a phantom foreign commit
+            self._version_read_failed = True
+            logger.warning("Could not read current version for '%s'", self.path)
             return None
 
     def commit_metrics_after(self, pre_version: int | None) -> dict[str, str] | None:
@@ -80,6 +89,13 @@ class TargetHandle:
         version jump, and the metrics are then reported absent rather
         than misattributed. Degrade, never misattribute.
         """
+        if self._version_read_failed:
+            logger.warning(
+                "Commit metrics for '%s' skipped: pre-write version was "
+                "unreadable, so the commit cannot be attributed",
+                self.path,
+            )
+            return None
         expected = 0 if pre_version is None else pre_version + 1
         try:
             table = _delta.resolve_delta_table(self._spark, self.path)

--- a/packages/weevr/src/weevr/operations/target_handle.py
+++ b/packages/weevr/src/weevr/operations/target_handle.py
@@ -1,0 +1,58 @@
+"""Target handle — one existence/identity resolution per thread.
+
+The executor resolves a thread's target once and threads the handle to
+every consumer (target mapping, seeding, writers, merge routing). The
+handle caches the *resolution mechanics*, not a frozen snapshot:
+existence is a refreshable query, explicitly invalidated after any
+engine-internal commit the thread itself makes (warp pre-init, seeds),
+so downstream consumers observe post-commit state exactly as their
+previous independent probes did — with one probe mechanism instead of
+three to five per thread.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from pyspark.sql import SparkSession
+
+from weevr import delta as _delta
+
+logger = logging.getLogger(__name__)
+
+
+class TargetHandle:
+    """Cached target existence resolution for one thread execution.
+
+    Args:
+        spark: Active SparkSession.
+        path: Resolved target path or table alias.
+    """
+
+    def __init__(self, spark: SparkSession, path: str) -> None:
+        """Bind the handle to a resolved target path or alias."""
+        self._spark = spark
+        self.path = path
+        self._exists: bool | None = None
+
+    def exists(self) -> bool:
+        """Whether a Delta table exists at the target (cached until refresh)."""
+        if self._exists is None:
+            self._exists = _delta.delta_table_exists(self._spark, self.path)
+        return self._exists
+
+    def refresh(self) -> None:
+        """Invalidate the cached existence after an engine-internal commit.
+
+        Must be called after warp pre-init and after seeds — the commits a
+        thread makes to its own target before the primary write.
+        """
+        self._exists = None
+
+    def mark_exists(self) -> None:
+        """Record that the target now exists without re-probing.
+
+        Used after a commit the engine itself just made successfully —
+        existence is monotonic within a run.
+        """
+        self._exists = True

--- a/packages/weevr/src/weevr/operations/target_handle.py
+++ b/packages/weevr/src/weevr/operations/target_handle.py
@@ -56,3 +56,44 @@ class TargetHandle:
         existence is monotonic within a run.
         """
         self._exists = True
+
+    def current_version(self) -> int | None:
+        """The target's latest Delta commit version, or None when absent.
+
+        A driver-side log read — no Spark jobs. Captured immediately
+        before a counted write so the engine's own earlier commits to the
+        same target (warp pre-init, seeds) are already included.
+        """
+        try:
+            table = _delta.resolve_delta_table(self._spark, self.path)
+            row = table.history(1).select("version").collect()
+            return int(row[0][0]) if row else None
+        except Exception:
+            return None
+
+    def commit_metrics_after(self, pre_version: int | None) -> dict[str, str] | None:
+        """Operation metrics of the commit that followed ``pre_version``.
+
+        Accepts the latest commit ONLY when its version is exactly
+        ``pre_version + 1`` (or 0 for a fresh table) — a foreign commit
+        landing between the engine's write and this read makes the
+        version jump, and the metrics are then reported absent rather
+        than misattributed. Degrade, never misattribute.
+        """
+        expected = 0 if pre_version is None else pre_version + 1
+        try:
+            table = _delta.resolve_delta_table(self._spark, self.path)
+            row = table.history(1).select("version", "operationMetrics").collect()[0]
+        except Exception:
+            logger.warning("Commit metrics unavailable for '%s'", self.path)
+            return None
+        if int(row[0]) != expected:
+            logger.warning(
+                "Commit metrics for '%s' skipped: expected version %d, found %d "
+                "(foreign commit interleaved)",
+                self.path,
+                expected,
+                int(row[0]),
+            )
+            return None
+        return dict(row[1])

--- a/packages/weevr/src/weevr/operations/writers.py
+++ b/packages/weevr/src/weevr/operations/writers.py
@@ -473,6 +473,8 @@ def execute_cdc_merge(
                 cdc_writer.saveAsTable(target_path)
             else:
                 cdc_writer.save(target_path)
+            if handle is not None:
+                handle.mark_exists()
             return counts
 
         delta_table = resolve_delta_table(spark, target_path)
@@ -537,6 +539,8 @@ def execute_cdc_merge(
             )
 
         merger.execute()
+        if handle is not None:
+            handle.mark_exists()
         return counts
 
     except ExecutionError:

--- a/packages/weevr/src/weevr/operations/writers.py
+++ b/packages/weevr/src/weevr/operations/writers.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from pyspark.sql import Column, DataFrame, SparkSession
 from pyspark.sql import functions as F
 from pyspark.sql.window import Window
@@ -13,6 +15,8 @@ from weevr.model.target import Target
 from weevr.model.write import WriteConfig
 from weevr.operations.readers import typed_watermark_col
 from weevr.operations.target_handle import TargetHandle
+
+logger = logging.getLogger(__name__)
 
 
 def quote_identifier(name: str) -> str:
@@ -132,12 +136,17 @@ def write_target(
     mode = write_config.mode if write_config else "overwrite"
     partition_cols = target.partition_by or []
     use_table_api = is_table_alias(target_path)
-    target_exists = (
-        handle.exists() if handle is not None else delta_table_exists(spark, target_path)
-    )
+    if handle is None:
+        handle = TargetHandle(spark, target_path)
+    target_exists = handle.exists()
 
     try:
-        row_count = df.count()
+        # Merge keeps an eager input count — merge metrics express outcome
+        # rows, not the input-rows semantic this function returns, and the
+        # merge action cannot fulfill observations (it zero-fires them).
+        # Single-pass modes count from the write's own commit metrics.
+        row_count = df.count() if mode == "merge" and target_exists else -1
+        pre_version = handle.current_version() if row_count == -1 and target_exists else None
 
         if mode == "overwrite" or not target_exists:
             # First write (any mode) and overwrite: write as overwrite to create/replace table.
@@ -176,6 +185,19 @@ def write_target(
                 raise ExecutionError("merge mode requires 'match_keys' to be set")
             _execute_merge(spark, df, write_config, target_path)
 
+        if row_count == -1:
+            # Single-pass write: the commit's own numOutputRows, guarded
+            # against foreign commits. Absent-with-warning on any miss.
+            metrics = handle.commit_metrics_after(pre_version)
+            if metrics is not None and "numOutputRows" in metrics:
+                row_count = int(metrics["numOutputRows"])
+            else:
+                logger.warning(
+                    "Rows-written count unavailable for '%s'; reporting 0",
+                    target_path,
+                )
+                row_count = 0
+        handle.mark_exists()
         return row_count
 
     except ExecutionError:

--- a/packages/weevr/src/weevr/operations/writers.py
+++ b/packages/weevr/src/weevr/operations/writers.py
@@ -12,6 +12,7 @@ from weevr.model.load import CdcConfig, LoadConfig
 from weevr.model.target import Target
 from weevr.model.write import WriteConfig
 from weevr.operations.readers import typed_watermark_col
+from weevr.operations.target_handle import TargetHandle
 
 
 def quote_identifier(name: str) -> str:
@@ -23,7 +24,12 @@ def quote_identifier(name: str) -> str:
     return f"`{name.replace('`', '``')}`"
 
 
-def apply_target_mapping(df: DataFrame, target: Target, spark: SparkSession) -> DataFrame:
+def apply_target_mapping(
+    df: DataFrame,
+    target: Target,
+    spark: SparkSession,
+    handle: TargetHandle | None = None,
+) -> DataFrame:
     """Apply target column mapping to shape the DataFrame for writing.
 
     Column-level transformations (expr, type, default, drop) are applied first.
@@ -38,6 +44,9 @@ def apply_target_mapping(df: DataFrame, target: Target, spark: SparkSession) -> 
         df: Input DataFrame.
         target: Target configuration including mapping mode and column specs.
         spark: Active SparkSession (used to probe existing target schema).
+
+        handle: Pre-resolved target handle; when absent the function
+            self-resolves existence (operations stay independently usable).
 
     Returns:
         DataFrame shaped for writing to the target.
@@ -64,7 +73,12 @@ def apply_target_mapping(df: DataFrame, target: Target, spark: SparkSession) -> 
     # Narrow column set according to mapping mode.
     if target.mapping_mode == "auto":
         target_path = target.alias or target.path
-        if target_path and delta_table_exists(spark, target_path):
+        target_present = (
+            handle.exists()
+            if handle is not None and target_path == handle.path
+            else bool(target_path) and delta_table_exists(spark, target_path)
+        )
+        if target_path and target_present:
             if is_table_alias(target_path):
                 existing_cols = spark.read.format("delta").table(target_path).columns
             else:
@@ -91,6 +105,7 @@ def write_target(
     target: Target,
     write_config: WriteConfig | None,
     target_path: str,
+    handle: TargetHandle | None = None,
 ) -> int:
     """Write a DataFrame to a Delta table.
 
@@ -105,6 +120,9 @@ def write_target(
         write_config: Write mode and merge parameters. Defaults to overwrite when None.
         target_path: Table alias or physical path for the Delta table.
 
+        handle: Pre-resolved target handle; when absent the function
+            self-resolves existence (operations stay independently usable).
+
     Returns:
         Number of rows in ``df`` (rows written for overwrite/append; input rows for merge).
 
@@ -114,7 +132,9 @@ def write_target(
     mode = write_config.mode if write_config else "overwrite"
     partition_cols = target.partition_by or []
     use_table_api = is_table_alias(target_path)
-    target_exists = delta_table_exists(spark, target_path)
+    target_exists = (
+        handle.exists() if handle is not None else delta_table_exists(spark, target_path)
+    )
 
     try:
         row_count = df.count()
@@ -299,6 +319,7 @@ def execute_cdc_merge(
     cdc_config: CdcConfig,
     *,
     load_config: LoadConfig | None = None,
+    handle: TargetHandle | None = None,
 ) -> dict[str, int]:
     """Execute a CDC merge operation, routing rows by operation type.
 
@@ -319,6 +340,9 @@ def execute_cdc_merge(
         cdc_config: CDC configuration (preset or explicit mapping).
         load_config: Thread-level load configuration; supplies the
             watermark ordering for generic CDC reduction.
+
+        handle: Pre-resolved target handle; when absent the function
+            self-resolves existence (operations stay independently usable).
 
     Returns:
         Dict with counts: ``{"inserts": N, "updates": N, "deletes": N}``.
@@ -394,7 +418,9 @@ def execute_cdc_merge(
         )
 
     counts: dict[str, int] = {"inserts": 0, "updates": 0, "deletes": 0}
-    target_exists = delta_table_exists(spark, target_path)
+    target_exists = (
+        handle.exists() if handle is not None else delta_table_exists(spark, target_path)
+    )
 
     try:
         # Count operations in a single pass over the (reduced) window

--- a/tests/weevr/engine/test_cdc_integration.py
+++ b/tests/weevr/engine/test_cdc_integration.py
@@ -1196,3 +1196,62 @@ class TestCdcWindowBoundedness:
             window_df.unpersist()
         finally:
             spark.sql("RESET spark.databricks.delta.properties.defaults.enableChangeDataFeed")
+
+
+@pytest.mark.spark
+class TestGenericCdcWindowConsistency:
+    """Generic-preset HWM derives from the same frame the merge processes.
+
+    Note: Delta recaches persisted plans on same-session commits, so a
+    persist alone cannot freeze the window against them — but same-run
+    source mutation is already rejected territory (concurrent same-target
+    writes), and foreign-session commits do not invalidate this session's
+    cache. What the executor's post-persist capture guarantees — and what
+    the old in-read capture broke — is that the persisted watermark and
+    the applied rows derive from ONE lineage and cannot diverge.
+    """
+
+    def test_generic_hwm_consistent_with_processed_rows(
+        self, spark: SparkSession, tmp_delta_path
+    ) -> None:
+        from pyspark import StorageLevel
+
+        from weevr.model.load import LoadConfig
+        from weevr.operations.readers import compute_generic_cdc_hwm, read_cdc_source
+
+        src = tmp_delta_path("gcdc_src")
+        spark.createDataFrame(
+            [
+                {"id": 1, "op": "I", "seq": 10},
+                {"id": 2, "op": "I", "seq": 20},
+            ]
+        ).write.format("delta").save(src)
+
+        load = LoadConfig(
+            mode="cdc",
+            watermark_column="seq",
+            watermark_type="long",
+            cdc=CdcConfig(operation_column="op", insert_value="I"),
+        )
+        window_df, hwm_in_read = read_cdc_source(
+            spark,
+            Source(type="delta", alias=src),
+            load.cdc,
+            load_config=load,
+            compute_hwm=False,
+        )
+        assert hwm_in_read is None  # deferred to the caller, post-persist
+
+        window_df = window_df.persist(StorageLevel.MEMORY_AND_DISK)
+        window_df.count()
+
+        # Whatever the frame holds when processed, the HWM matches it —
+        # including after a (same-session) commit widens the recached plan
+        spark.createDataFrame([{"id": 3, "op": "I", "seq": 99}]).write.format("delta").mode(
+            "append"
+        ).save(src)
+
+        processed_rows = window_df.collect()
+        hwm = compute_generic_cdc_hwm(window_df, load)
+        assert hwm == str(max(r["seq"] for r in processed_rows))
+        window_df.unpersist()

--- a/tests/weevr/engine/test_cdc_integration.py
+++ b/tests/weevr/engine/test_cdc_integration.py
@@ -1155,3 +1155,44 @@ class TestCdcWatermarkComposition:
         target_ids = {r["id"] for r in spark.read.format("delta").load(tgt).collect()}
         assert 4 in target_ids
         assert 2 not in target_ids
+
+
+@pytest.mark.spark
+class TestCdcWindowBoundedness:
+    """The persisted change window pins data-derived semantics."""
+
+    def test_persisted_window_ignores_mid_run_commits(
+        self, spark: SparkSession, tmp_delta_path
+    ) -> None:
+        # The watermark version must derive from rows actually read. The
+        # CDF read is lazy, so a commit landing mid-run would otherwise
+        # widen the window on re-execution — the executor persists and
+        # materializes the window before any later action, pinning it.
+        from pyspark import StorageLevel
+        from pyspark.sql import functions as F
+
+        src = tmp_delta_path("cdcw_src")
+        spark.sql("SET spark.databricks.delta.properties.defaults.enableChangeDataFeed=true")
+        try:
+            spark.createDataFrame([{"id": 1, "v": "a"}]).write.format("delta").save(src)
+            spark.createDataFrame([{"id": 2, "v": "b"}]).write.format("delta").mode("append").save(
+                src
+            )  # v1
+
+            source = Source(type="delta", alias=src)
+            window_df, _ = read_cdc_source(
+                spark, source, CdcConfig(preset="delta_cdf"), last_version=0
+            )
+            window_df = window_df.persist(StorageLevel.MEMORY_AND_DISK)
+            window_df.count()  # materialize — the executor's eager count does this
+
+            # Mid-run commit AFTER the window materialized
+            spark.createDataFrame([{"id": 3, "v": "c"}]).write.format("delta").mode("append").save(
+                src
+            )  # v2
+
+            window_max = window_df.agg(F.max("_commit_version")).collect()[0][0]
+            assert int(window_max) == 1  # pinned window, not log-latest (2)
+            window_df.unpersist()
+        finally:
+            spark.sql("RESET spark.databricks.delta.properties.defaults.enableChangeDataFeed")

--- a/tests/weevr/engine/test_executor.py
+++ b/tests/weevr/engine/test_executor.py
@@ -1843,3 +1843,73 @@ class TestCteObservationScoping:
         # The CTE already rewrote A→alpha, so every row ('alpha','X','alpha')
         # is unmapped for the main step's A→alpha mapping
         assert stats["main.map.code"]["unmapped_count"] == 3
+
+
+@pytest.mark.spark
+class TestCaptureSamplesGate:
+    """Samples are opt-in: off fires no sampling, on attempts it."""
+
+    @staticmethod
+    def _thread(src: str, tgt: str) -> Thread:
+        return Thread.model_validate(
+            {
+                "name": "sample_t",
+                "config_version": "1",
+                "sources": {"main": {"type": "delta", "alias": src}},
+                "steps": [],
+                "target": {"path": tgt},
+                "write": {"mode": "overwrite"},
+            }
+        )
+
+    @pytest.fixture()
+    def topandas_spy(self, monkeypatch: pytest.MonkeyPatch) -> list[int]:
+        from pyspark.sql import DataFrame
+
+        calls: list[int] = []
+        original = DataFrame.toPandas
+
+        def _spy(self):  # type: ignore[no-untyped-def]
+            calls.append(1)
+            return original(self)
+
+        monkeypatch.setattr(DataFrame, "toPandas", _spy)
+        return calls
+
+    def test_off_by_default_no_sampling(
+        self, spark: SparkSession, tmp_delta_path, topandas_spy: list[int]
+    ) -> None:
+        src = tmp_delta_path("cs_src_off")
+        tgt = tmp_delta_path("cs_tgt_off")
+        spark.createDataFrame([{"id": 1}]).write.format("delta").save(src)
+
+        result = execute_thread(spark, self._thread(src, tgt))
+
+        assert result.status == "success"
+        assert topandas_spy == []  # zero sampling attempts
+        assert result.samples is None or "output" not in (result.samples or {})
+
+    def test_on_attempts_sampling(
+        self, spark: SparkSession, tmp_delta_path, topandas_spy: list[int]
+    ) -> None:
+        src = tmp_delta_path("cs_src_on")
+        tgt = tmp_delta_path("cs_tgt_on")
+        spark.createDataFrame([{"id": 1}]).write.format("delta").save(src)
+
+        result = execute_thread(spark, self._thread(src, tgt), capture_samples=True)
+
+        assert result.status == "success"
+        # The attempt is what the flag governs; content requires pandas
+        # (present on Fabric, optional in dev) and stays suppressed-on-error
+        assert len(topandas_spy) >= 1
+
+    def test_display_hint_when_samples_absent(self, spark: SparkSession, tmp_delta_path) -> None:
+        src = tmp_delta_path("cs_src_hint")
+        tgt = tmp_delta_path("cs_tgt_hint")
+        spark.createDataFrame([{"id": 1}]).write.format("delta").save(src)
+
+        from weevr.engine.display import _render_execute_thread_detail
+
+        result = execute_thread(spark, self._thread(src, tgt))
+        html_out = _render_execute_thread_detail(result, result.telemetry, None)
+        assert "capture_samples" in html_out  # the hint names the switch

--- a/tests/weevr/engine/test_executor.py
+++ b/tests/weevr/engine/test_executor.py
@@ -2056,3 +2056,92 @@ class TestLazyExecutorCounts:
         assert result.telemetry is not None
         assert result.telemetry.rows_read == 2
         assert result.telemetry.rows_after_transforms == 2
+
+
+@pytest.mark.spark
+class TestPersistBoundaries:
+    """Exports and quarantine reuse one compute; unpersist always runs."""
+
+    @pytest.fixture()
+    def unpersist_spy(self, monkeypatch: pytest.MonkeyPatch) -> list[int]:
+        """Count DataFrame.unpersist calls (Delta internals cache RDDs of
+        their own, so asserting on the global persistent-RDD registry is
+        noise — the release INVOCATION is the engine's contract)."""
+        from pyspark.sql import DataFrame
+
+        calls: list[int] = []
+        original = DataFrame.unpersist
+
+        def _spy(inner_self, blocking=False):  # type: ignore[no-untyped-def]
+            calls.append(1)
+            return original(inner_self, blocking)
+
+        monkeypatch.setattr(DataFrame, "unpersist", _spy)
+        return calls
+
+    def test_exports_share_one_compute_and_unpersist(
+        self, spark: SparkSession, tmp_delta_path, unpersist_spy: list[int]
+    ) -> None:
+        src = tmp_delta_path("pb_src")
+        tgt = tmp_delta_path("pb_tgt")
+        exp1 = tmp_delta_path("pb_exp1")
+        exp2 = tmp_delta_path("pb_exp2")
+        spark.createDataFrame([{"id": i} for i in range(4)]).write.format("delta").save(src)
+
+        thread = Thread.model_validate(
+            {
+                "name": "pb_t",
+                "config_version": "1",
+                "sources": {"main": {"type": "delta", "alias": src}},
+                "steps": [],
+                "target": {"path": tgt},
+                "write": {"mode": "overwrite"},
+                "exports": [
+                    {"name": "e1", "type": "delta", "path": exp1},
+                    {"name": "e2", "type": "delta", "path": exp2},
+                ],
+            }
+        )
+        result = execute_thread(spark, thread)
+        assert result.status == "success", result.error
+
+        # Both exports carry this run's output
+        assert spark.read.format("delta").load(exp1).count() == 4
+        assert spark.read.format("delta").load(exp2).count() == 4
+        assert len(unpersist_spy) >= 1  # working-df persist released in finally
+
+    def test_all_clean_run_leaves_quarantine_untouched(
+        self, spark: SparkSession, tmp_delta_path, unpersist_spy: list[int]
+    ) -> None:
+        src = tmp_delta_path("pb_q_src")
+        tgt = tmp_delta_path("pb_q_tgt")
+        spark.createDataFrame([{"id": 1, "v": 5}, {"id": 2, "v": -1}]).write.format("delta").save(
+            src
+        )
+
+        cfg = {
+            "name": "pb_q_t",
+            "config_version": "1",
+            "sources": {"main": {"type": "delta", "alias": src}},
+            "steps": [],
+            "target": {"path": tgt},
+            "write": {"mode": "overwrite"},
+            "validations": [{"rule": "v >= 0", "severity": "error", "name": "v_nonneg"}],
+        }
+        result = execute_thread(spark, Thread.model_validate(cfg))
+        assert result.status == "success", result.error
+        assert result.telemetry is not None and result.telemetry.rows_quarantined == 1
+        q = spark.read.format("delta").load(tgt + "_quarantine")
+        assert q.count() == 1
+
+        # All-clean second run against a clean source: prior quarantine
+        # rows remain untouched
+        src2 = tmp_delta_path("pb_q_src2")
+        spark.createDataFrame([{"id": 3, "v": 7}]).write.format("delta").save(src2)
+        cfg2 = dict(cfg)
+        cfg2["sources"] = {"main": {"type": "delta", "alias": src2}}
+        unpersist_spy.clear()
+        result2 = execute_thread(spark, Thread.model_validate(cfg2))
+        assert result2.status == "success"
+        assert spark.read.format("delta").load(tgt + "_quarantine").count() == 1
+        assert len(unpersist_spy) >= 1  # quarantine persist released in finally

--- a/tests/weevr/engine/test_executor.py
+++ b/tests/weevr/engine/test_executor.py
@@ -2145,3 +2145,98 @@ class TestPersistBoundaries:
         assert result2.status == "success"
         assert spark.read.format("delta").load(tgt + "_quarantine").count() == 1
         assert len(unpersist_spy) >= 1  # quarantine persist released in finally
+
+
+@pytest.mark.spark
+class TestFindingsRegression:
+    """Locks for the review-round fixes."""
+
+    def test_dimension_rows_written_with_multi_rule_quarantine(
+        self, spark: SparkSession, tmp_delta_path
+    ) -> None:
+        # One row fails TWO error rules → quarantine explodes to 2 rows;
+        # rows_written must still count write-input rows (2), not
+        # rows_after_transforms − exploded (3 − 2 = 1)
+        src = tmp_delta_path("fr_dim_src")
+        tgt = tmp_delta_path("fr_dim_tgt")
+        spark.createDataFrame(
+            [
+                {"customer_id": "C1", "v": 5, "w": 5},
+                {"customer_id": "C2", "v": 5, "w": 5},
+                {"customer_id": "C3", "v": -1, "w": -1},
+            ]
+        ).write.format("delta").save(src)
+
+        thread = Thread.model_validate(
+            {
+                "name": "fr_dim_t",
+                "config_version": "1",
+                "sources": {"main": {"type": "delta", "alias": src}},
+                "steps": [],
+                "target": {
+                    "path": tgt,
+                    "dimension": {
+                        "business_key": ["customer_id"],
+                        "surrogate_key": {"name": "_sk", "columns": ["customer_id"]},
+                    },
+                },
+                "validations": [
+                    {"rule": "v >= 0", "severity": "error", "name": "v_ok"},
+                    {"rule": "w >= 0", "severity": "error", "name": "w_ok"},
+                ],
+            }
+        )
+        # First run creates the table; second run exercises the merge path
+        result = execute_thread(spark, thread)
+        assert result.status == "success", result.error
+        result2 = execute_thread(spark, thread)
+        assert result2.status == "success", result2.error
+
+        telem = result2.telemetry
+        assert telem is not None
+        assert telem.rows_quarantined == 2  # exploded per rule (existing semantic)
+        assert result2.rows_written == 2  # C1, C2 — never 1
+
+    def test_failing_write_still_unpersists(
+        self, spark: SparkSession, tmp_delta_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The B-007 lesson: a failure mid-write must not leak the export
+        # persist — the finally block releases every boundary
+        from pyspark.sql import DataFrame
+
+        import weevr.engine.executor as executor_mod
+
+        unpersists: list[int] = []
+        original_unpersist = DataFrame.unpersist
+
+        def _unpersist_spy(inner_self, blocking=False):  # type: ignore[no-untyped-def]
+            unpersists.append(1)
+            return original_unpersist(inner_self, blocking)
+
+        def _boom(*args, **kwargs):  # type: ignore[no-untyped-def]
+            raise RuntimeError("write exploded")
+
+        monkeypatch.setattr(DataFrame, "unpersist", _unpersist_spy)
+        monkeypatch.setattr(executor_mod, "write_target", _boom)
+
+        src = tmp_delta_path("fr_fail_src")
+        tgt = tmp_delta_path("fr_fail_tgt")
+        exp = tmp_delta_path("fr_fail_exp")
+        spark.createDataFrame([{"id": 1}]).write.format("delta").save(src)
+
+        thread = Thread.model_validate(
+            {
+                "name": "fr_fail_t",
+                "config_version": "1",
+                "sources": {"main": {"type": "delta", "alias": src}},
+                "steps": [],
+                "target": {"path": tgt},
+                "write": {"mode": "overwrite"},
+                "exports": [{"name": "e1", "type": "delta", "path": exp}],
+            }
+        )
+        from weevr.errors.exceptions import ExecutionError
+
+        with pytest.raises(ExecutionError, match="write exploded"):
+            execute_thread(spark, thread)
+        assert len(unpersists) >= 1  # the export persist was released

--- a/tests/weevr/engine/test_executor.py
+++ b/tests/weevr/engine/test_executor.py
@@ -2204,7 +2204,7 @@ class TestFindingsRegression:
         # persist — the finally block releases every boundary
         from pyspark.sql import DataFrame
 
-        import weevr.engine.executor as executor_mod
+        from weevr.engine import executor as executor_mod
 
         unpersists: list[int] = []
         original_unpersist = DataFrame.unpersist

--- a/tests/weevr/engine/test_executor.py
+++ b/tests/weevr/engine/test_executor.py
@@ -1932,15 +1932,14 @@ class TestTargetHandle:
             return original(spark, path)
 
         # Patch the source module (the handle reads it) and each module
-        # holding a direct reference from `from weevr.delta import ...`
-        import weevr.operations.dimension as dim_mod
+        # still holding a direct reference from `from weevr.delta import ...`
+        # (dimension.py probes exclusively through the handle now)
         import weevr.operations.seeding as seed_mod
         import weevr.operations.writers as writers_mod
 
         monkeypatch.setattr(delta_mod, "delta_table_exists", _spy)
         monkeypatch.setattr(writers_mod, "delta_table_exists", _spy)
         monkeypatch.setattr(seed_mod, "delta_table_exists", _spy)
-        monkeypatch.setattr(dim_mod, "delta_table_exists", _spy)
         return calls
 
     def test_standard_path_probes_once(

--- a/tests/weevr/engine/test_executor.py
+++ b/tests/weevr/engine/test_executor.py
@@ -810,7 +810,7 @@ class TestExecuteThreadConnections:
 
         captured_paths: list[str] = []
 
-        def fake_write_target(spark_arg, df_arg, target_arg, write_arg, path_arg):
+        def fake_write_target(spark_arg, df_arg, target_arg, write_arg, path_arg, handle=None):
             captured_paths.append(path_arg)
             return df_arg.count()
 
@@ -850,7 +850,7 @@ class TestExecuteThreadConnections:
 
         captured_paths: list[str] = []
 
-        def fake_write_target(spark_arg, df_arg, target_arg, write_arg, path_arg):
+        def fake_write_target(spark_arg, df_arg, target_arg, write_arg, path_arg, handle=None):
             captured_paths.append(path_arg)
             return df_arg.count()
 
@@ -1997,3 +1997,63 @@ class TestTargetHandle:
         assert target.count() == 2  # seed row + data row (append saw table exists)
         target_probes = [p for p in probe_spy if p == tgt]
         assert len(target_probes) == 2  # pre-seed probe + post-refresh probe
+
+
+@pytest.mark.spark
+class TestLazyExecutorCounts:
+    """rows_read/rows_after_transforms via observations on single-pass paths."""
+
+    def test_overwrite_path_counts_parity_zero_actions(
+        self, spark: SparkSession, tmp_delta_path, spark_action_counter
+    ) -> None:
+        src = tmp_delta_path("lc_src")
+        tgt = tmp_delta_path("lc_tgt")
+        spark.createDataFrame([{"id": i} for i in range(7)]).write.format("delta").save(src)
+
+        thread = Thread.model_validate(
+            {
+                "name": "lazy_t",
+                "config_version": "1",
+                "sources": {"main": {"type": "delta", "alias": src}},
+                "steps": [{"filter": {"expr": "id < 5"}}],
+                "target": {"path": tgt},
+                "write": {"mode": "overwrite"},
+            }
+        )
+        start = spark_action_counter["total"]
+        result = execute_thread(spark, thread)
+        actions = spark_action_counter["total"] - start
+
+        assert result.status == "success"
+        assert result.telemetry is not None
+        assert result.telemetry.rows_read == 7
+        assert result.telemetry.rows_after_transforms == 5
+        assert result.rows_written == 5
+        # No count()/collect() actions beyond write_target's remaining
+        # eager rows count (removed by the commit-metrics task)
+        assert actions == 1
+
+    def test_merge_path_keeps_eager_counts(self, spark: SparkSession, tmp_delta_path) -> None:
+        # Merge-terminal threads keep true values — the eager count is the
+        # observation-fixing action, never the merge's zero-fire
+        src = tmp_delta_path("lc_m_src")
+        tgt = tmp_delta_path("lc_m_tgt")
+        spark.createDataFrame([{"id": 1, "v": "a"}, {"id": 2, "v": "b"}]).write.format(
+            "delta"
+        ).save(src)
+
+        thread = Thread.model_validate(
+            {
+                "name": "lazy_m_t",
+                "config_version": "1",
+                "sources": {"main": {"type": "delta", "alias": src}},
+                "steps": [],
+                "target": {"path": tgt},
+                "write": {"mode": "merge", "match_keys": ["id"]},
+            }
+        )
+        result = execute_thread(spark, thread)
+        assert result.status == "success"
+        assert result.telemetry is not None
+        assert result.telemetry.rows_read == 2
+        assert result.telemetry.rows_after_transforms == 2

--- a/tests/weevr/engine/test_executor.py
+++ b/tests/weevr/engine/test_executor.py
@@ -1913,3 +1913,87 @@ class TestCaptureSamplesGate:
         result = execute_thread(spark, self._thread(src, tgt))
         html_out = _render_execute_thread_detail(result, result.telemetry, None)
         assert "capture_samples" in html_out  # the hint names the switch
+
+
+@pytest.mark.spark
+class TestTargetHandle:
+    """One existence resolution per thread; refresh after own commits."""
+
+    @pytest.fixture()
+    def probe_spy(self, monkeypatch: pytest.MonkeyPatch) -> list[str]:
+        """Count real existence probes across every consuming module."""
+        from weevr import delta as delta_mod
+
+        calls: list[str] = []
+        original = delta_mod.delta_table_exists
+
+        def _spy(spark, path):  # type: ignore[no-untyped-def]
+            calls.append(path)
+            return original(spark, path)
+
+        # Patch the source module (the handle reads it) and each module
+        # holding a direct reference from `from weevr.delta import ...`
+        import weevr.operations.dimension as dim_mod
+        import weevr.operations.seeding as seed_mod
+        import weevr.operations.writers as writers_mod
+
+        monkeypatch.setattr(delta_mod, "delta_table_exists", _spy)
+        monkeypatch.setattr(writers_mod, "delta_table_exists", _spy)
+        monkeypatch.setattr(seed_mod, "delta_table_exists", _spy)
+        monkeypatch.setattr(dim_mod, "delta_table_exists", _spy)
+        return calls
+
+    def test_standard_path_probes_once(
+        self, spark: SparkSession, tmp_delta_path, probe_spy: list[str]
+    ) -> None:
+        src = tmp_delta_path("th_src")
+        tgt = tmp_delta_path("th_tgt")
+        spark.createDataFrame([{"id": 1}]).write.format("delta").save(src)
+
+        thread = Thread.model_validate(
+            {
+                "name": "handle_t",
+                "config_version": "1",
+                "sources": {"main": {"type": "delta", "alias": src}},
+                "steps": [],
+                "target": {"path": tgt},
+                "write": {"mode": "overwrite"},
+            }
+        )
+        result = execute_thread(spark, thread)
+
+        assert result.status == "success"
+        target_probes = [p for p in probe_spy if p == tgt]
+        assert len(target_probes) == 1  # one resolution, cached thereafter
+
+    def test_seed_commit_refreshes_existence(
+        self, spark: SparkSession, tmp_delta_path, probe_spy: list[str]
+    ) -> None:
+        # first_write seeds fire on a fresh table (probe: absent), then the
+        # seed commit refreshes the handle so the write path re-observes
+        # (probe: present) — exactly today's two independent-probe outcomes,
+        # through one mechanism
+        src = tmp_delta_path("th_seed_src")
+        tgt = tmp_delta_path("th_seed_tgt")
+        spark.createDataFrame([{"id": 1, "name": "x"}]).write.format("delta").save(src)
+
+        thread = Thread.model_validate(
+            {
+                "name": "handle_seed_t",
+                "config_version": "1",
+                "sources": {"main": {"type": "delta", "alias": src}},
+                "steps": [],
+                "target": {
+                    "path": tgt,
+                    "seed": {"on": "first_write", "rows": [{"id": -1, "name": "seed"}]},
+                },
+                "write": {"mode": "append"},
+            }
+        )
+        result = execute_thread(spark, thread)
+
+        assert result.status == "success", result.error
+        target = spark.read.format("delta").load(tgt)
+        assert target.count() == 2  # seed row + data row (append saw table exists)
+        target_probes = [p for p in probe_spy if p == tgt]
+        assert len(target_probes) == 2  # pre-seed probe + post-refresh probe

--- a/tests/weevr/engine/test_job_budget.py
+++ b/tests/weevr/engine/test_job_budget.py
@@ -147,3 +147,93 @@ class TestSingleSourceScan:
         with job_counter() as jc_terminal:
             df.collect()
         assert jc_terminal.jobs > 0  # exactly one action executed the chain
+
+
+@pytest.mark.spark
+class TestThreadActionBudget:
+    """The headline invariant: a gate-free thread pays the write, only.
+
+    "Fact-scale eager action" here means the Python-side patterns the
+    boundary work removed — DataFrame.count()/toPandas() on working
+    lineage. Driver-side commit-log reads (history(1).collect()) are the
+    design's accepted metadata cost and are not counted.
+    """
+
+    @pytest.fixture()
+    def eager_spies(self, monkeypatch: pytest.MonkeyPatch) -> dict[str, list[int]]:
+        from pyspark.sql import DataFrame
+
+        spies: dict[str, list[int]] = {"count": [], "toPandas": []}
+        orig_count = DataFrame.count
+        orig_topandas = DataFrame.toPandas
+
+        def _count(inner_self):  # type: ignore[no-untyped-def]
+            spies["count"].append(1)
+            return orig_count(inner_self)
+
+        def _topandas(inner_self):  # type: ignore[no-untyped-def]
+            spies["toPandas"].append(1)
+            return orig_topandas(inner_self)
+
+        monkeypatch.setattr(DataFrame, "count", _count)
+        monkeypatch.setattr(DataFrame, "toPandas", _topandas)
+        return spies
+
+    def test_gate_free_thread_zero_eager_actions(
+        self, spark: SparkSession, tmp_delta_path, eager_spies: dict[str, list[int]]
+    ) -> None:
+        from weevr.engine import execute_thread
+        from weevr.model.thread import Thread
+
+        src = tmp_delta_path("budget_gate_src")
+        tgt = tmp_delta_path("budget_gate_tgt")
+        spark.createDataFrame([{"id": i} for i in range(6)]).write.format("delta").save(src)
+
+        thread = Thread.model_validate(
+            {
+                "name": "budget_t",
+                "config_version": "1",
+                "sources": {"main": {"type": "delta", "alias": src}},
+                "steps": [{"filter": {"expr": "id < 4"}}],
+                "target": {"path": tgt},
+                "write": {"mode": "overwrite"},
+            }
+        )
+        result = execute_thread(spark, thread)
+
+        assert result.status == "success", result.error
+        # No validations, no warp, no exports, samples off → the write is
+        # the only fact-scale execution; telemetry still arrives
+        assert eager_spies["count"] == []
+        assert eager_spies["toPandas"] == []
+        assert result.telemetry is not None
+        assert result.telemetry.rows_read == 6
+        assert result.telemetry.rows_after_transforms == 4
+        assert result.rows_written == 4
+
+    def test_exports_add_no_eager_actions(
+        self, spark: SparkSession, tmp_delta_path, eager_spies: dict[str, list[int]]
+    ) -> None:
+        from weevr.engine import execute_thread
+        from weevr.model.thread import Thread
+
+        src = tmp_delta_path("budget_exp_src")
+        tgt = tmp_delta_path("budget_exp_tgt")
+        exp = tmp_delta_path("budget_exp_out")
+        spark.createDataFrame([{"id": i} for i in range(3)]).write.format("delta").save(src)
+
+        thread = Thread.model_validate(
+            {
+                "name": "budget_exp_t",
+                "config_version": "1",
+                "sources": {"main": {"type": "delta", "alias": src}},
+                "steps": [],
+                "target": {"path": tgt},
+                "write": {"mode": "overwrite"},
+                "exports": [{"name": "e1", "type": "delta", "path": exp}],
+            }
+        )
+        result = execute_thread(spark, thread)
+        assert result.status == "success", result.error
+        assert eager_spies["count"] == []  # export rides the persisted frame
+        assert spark.read.format("delta").load(exp).count() == 3

--- a/tests/weevr/engine/test_job_budget.py
+++ b/tests/weevr/engine/test_job_budget.py
@@ -237,3 +237,107 @@ class TestThreadActionBudget:
         assert result.status == "success", result.error
         assert eager_spies["count"] == []  # export rides the persisted frame
         assert spark.read.format("delta").load(exp).count() == 3
+
+
+@pytest.mark.spark
+class TestFeatureEnableMatrix:
+    """Each observability feature adds only its bounded, enumerated cost."""
+
+    @pytest.fixture()
+    def eager_spies(self, monkeypatch: pytest.MonkeyPatch) -> dict[str, list[int]]:
+        from pyspark.sql import DataFrame
+
+        spies: dict[str, list[int]] = {"count": [], "toPandas": []}
+        orig_count = DataFrame.count
+        orig_topandas = DataFrame.toPandas
+
+        def _count(inner_self):  # type: ignore[no-untyped-def]
+            spies["count"].append(1)
+            return orig_count(inner_self)
+
+        def _topandas(inner_self):  # type: ignore[no-untyped-def]
+            spies["toPandas"].append(1)
+            return orig_topandas(inner_self)
+
+        monkeypatch.setattr(DataFrame, "count", _count)
+        monkeypatch.setattr(DataFrame, "toPandas", _topandas)
+        return spies
+
+    @staticmethod
+    def _base_cfg(src: str, tgt: str) -> dict:
+        return {
+            "name": "matrix_t",
+            "config_version": "1",
+            "sources": {"main": {"type": "delta", "alias": src}},
+            "steps": [],
+            "target": {"path": tgt},
+            "write": {"mode": "overwrite"},
+        }
+
+    def test_samples_on_adds_only_sampling_attempts(
+        self, spark: SparkSession, tmp_delta_path, eager_spies: dict[str, list[int]]
+    ) -> None:
+        from weevr.engine import execute_thread
+        from weevr.model.thread import Thread
+
+        src = tmp_delta_path("mx_s_src")
+        tgt = tmp_delta_path("mx_s_tgt")
+        spark.createDataFrame([{"id": 1}]).write.format("delta").save(src)
+
+        execute_thread(spark, Thread.model_validate(self._base_cfg(src, tgt)), capture_samples=True)
+        assert eager_spies["count"] == []  # samples add sampling only
+        assert 1 <= len(eager_spies["toPandas"]) <= 2  # output (+quarantine) samples
+
+    def test_cte_collector_adds_one_count_per_cte(
+        self, spark: SparkSession, tmp_delta_path, eager_spies: dict[str, list[int]]
+    ) -> None:
+        from weevr.engine import execute_thread
+        from weevr.model.thread import Thread
+        from weevr.telemetry.collector import SpanCollector
+
+        src = tmp_delta_path("mx_c_src")
+        tgt = tmp_delta_path("mx_c_tgt")
+        spark.createDataFrame([{"id": 1, "amount": 50}]).write.format("delta").save(src)
+
+        cfg = self._base_cfg(src, tgt)
+        cfg["with"] = {"prepped": {"from": "main", "steps": [{"filter": {"expr": "amount > 0"}}]}}
+        cfg["steps"] = []
+        cfg["sources"] = {"main": {"type": "delta", "alias": src}}
+
+        execute_thread(spark, Thread.model_validate(cfg), collector=SpanCollector(trace_id="t"))
+        # Exactly the one collector-gated CTE count; without a collector the
+        # gate-free lock elsewhere proves zero
+        assert eager_spies["count"] == [1]
+
+    def test_cdc_thread_actions_bounded(
+        self, spark: SparkSession, tmp_delta_path, eager_spies: dict[str, list[int]]
+    ) -> None:
+        from weevr.engine import execute_thread
+        from weevr.model.thread import Thread
+
+        src = tmp_delta_path("mx_cdc_src")
+        tgt = tmp_delta_path("mx_cdc_tgt")
+        spark.createDataFrame(
+            [
+                {"id": 1, "v": "a", "op": "I", "seq": 1},
+                {"id": 2, "v": "b", "op": "I", "seq": 2},
+            ]
+        ).write.format("delta").save(src)
+
+        cfg = self._base_cfg(src, tgt)
+        cfg["name"] = "mx_cdc_t"
+        cfg["write"] = {"mode": "merge", "match_keys": ["id"]}
+        cfg["load"] = {
+            "mode": "cdc",
+            "watermark_column": "seq",
+            "watermark_type": "long",
+            "watermark_store": {"kind": "delta", "path": tgt + "_wm"},
+            "cdc": {"operation_column": "op", "insert_value": "I"},
+        }
+        result = execute_thread(spark, Thread.model_validate(cfg))
+        assert result.status == "success", result.error
+        # Enumerated, all window-scale against the persisted change window:
+        # rows_read + rows_after_transforms (merge-terminal eager pair) +
+        # the ordering-column null guard on explicit mappings. Nothing
+        # grows with feature count.
+        assert len(eager_spies["count"]) == 3

--- a/tests/weevr/engine/test_runner.py
+++ b/tests/weevr/engine/test_runner.py
@@ -8,6 +8,9 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import pytest
+from pyspark.sql import SparkSession
+
 from weevr.engine.cache_manager import CacheManager
 from weevr.engine.planner import build_plan
 from weevr.engine.result import ThreadResult, WeaveResult
@@ -2612,3 +2615,57 @@ class TestConnectionPropagation:
             call_kwargs = call[1]
             assert "connections" in call_kwargs
             assert call_kwargs["connections"]["gold"] is fake_conn
+
+
+@pytest.mark.spark
+class TestCaptureSamplesWiring:
+    """execution.capture_samples rides weave config → runner → executor."""
+
+    def test_weave_execution_flag_reaches_thread_sampling(
+        self,
+        spark: SparkSession,
+        tmp_path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from pyspark.sql import DataFrame
+
+        attempts: list[int] = []
+        original = DataFrame.toPandas
+
+        def _spy(inner_self):  # type: ignore[no-untyped-def]
+            attempts.append(1)
+            return original(inner_self)
+
+        monkeypatch.setattr(DataFrame, "toPandas", _spy)
+
+        src = str(tmp_path / "csw_src")
+        tgt = str(tmp_path / "csw_tgt")
+        spark.createDataFrame([{"id": 1}]).write.format("delta").save(src)
+
+        thread = Thread.model_validate(
+            {
+                "name": "csw_t",
+                "config_version": "1",
+                "sources": {"main": {"type": "delta", "alias": src}},
+                "steps": [],
+                "target": {"path": tgt},
+                "write": {"mode": "overwrite"},
+            }
+        )
+        threads = {"csw_t": thread}
+        plan = build_plan("csw_weave", threads, _entries("csw_t"))
+
+        # Flag off (default): no sampling attempts
+        result_off = execute_weave(spark, plan, threads)
+        assert result_off.status == "success"
+        assert attempts == []
+
+        # Flag on via the weave's execution block: sampling attempted
+        result_on = execute_weave(
+            spark,
+            plan,
+            threads,
+            execution=ExecutionConfig(capture_samples=True),
+        )
+        assert result_on.status == "success"
+        assert len(attempts) >= 1

--- a/tests/weevr/model/test_execution.py
+++ b/tests/weevr/model/test_execution.py
@@ -141,3 +141,21 @@ class TestResolveEffectiveExecution:
         assert eff.max_parallel_threads == 2
         assert eff.log_level == LogLevel.DEBUG
         assert eff.trace is True
+
+
+class TestCaptureSamples:
+    """capture_samples participates in the field-level effective merge."""
+
+    def test_default_is_off(self):
+        assert ExecutionConfig().capture_samples is False
+
+    def test_loom_setting_inherited_by_weave(self):
+        loom = ExecutionConfig(capture_samples=True)
+        eff = resolve_effective_execution(loom, ExecutionConfig())
+        assert eff.capture_samples is True
+
+    def test_weave_override_wins(self):
+        loom = ExecutionConfig(capture_samples=True)
+        weave = ExecutionConfig(capture_samples=False)
+        eff = resolve_effective_execution(loom, weave)
+        assert eff.capture_samples is False

--- a/tests/weevr/operations/test_dimension_merge.py
+++ b/tests/weevr/operations/test_dimension_merge.py
@@ -810,3 +810,110 @@ class TestNoMatchSourceSystemMemberSoftDelete:
         assert current["__unknown__"] is False  # system member's current row never stamped
         assert current["C2"] is True
         assert current["C1"] is False
+
+
+@pytest.mark.spark
+class TestMergeResultMetrics:
+    """DimensionMergeResult populated from split commit-metric keys."""
+
+    @staticmethod
+    def _merge(spark, path, dim, rows, ts, overrides=None):  # type: ignore[no-untyped-def]
+        from weevr.operations.target_handle import TargetHandle
+
+        source = _prepare_source(spark, rows, dim, ts)
+        builder = DimensionMergeBuilder(dim, write_overrides=overrides)
+        handle = TargetHandle(spark, path)
+        return execute_dimension_merge(spark, source, builder, path, ts, handle=handle)
+
+    def test_versioned_split_consistent_with_table_state(
+        self, spark: SparkSession, tmp_delta_path
+    ) -> None:
+        path = tmp_delta_path("mm_versioned")
+        dim = _make_dim(
+            track_history=True,
+            change_detection={  # type: ignore[arg-type]
+                "names": {"columns": ["name"], "on_change": "version"},
+            },
+        )
+        r1 = self._merge(
+            spark,
+            path,
+            dim,
+            [
+                {"customer_id": "C1", "name": "Alice"},
+                {"customer_id": "C2", "name": "Bob"},
+            ],
+            "2026-01-01",
+        )
+        assert r1.rows_inserted == 2  # first write via commit metrics
+
+        # C1 changes (close + new version), C3 arrives (new entity)
+        r2 = self._merge(
+            spark,
+            path,
+            dim,
+            [
+                {"customer_id": "C1", "name": "Alicia"},
+                {"customer_id": "C2", "name": "Bob"},
+                {"customer_id": "C3", "name": "Cara"},
+            ],
+            "2026-02-01",
+        )
+        assert r2.rows_versioned == 1  # C1 closed
+        assert r2.rows_inserted == 1  # C3 only — new-version insert excluded
+        assert r2.rows_deleted == 0
+        # Consistency with observed table state
+        target = spark.read.format("delta").load(path).collect()
+        assert len(target) == 4  # C1 v1+v2, C2, C3
+
+    def test_versioned_soft_delete_lands_in_rows_deleted(
+        self, spark: SparkSession, tmp_delta_path
+    ) -> None:
+        # track_history + on_no_match_source: soft_delete — the split keys
+        # keep the soft-delete clause out of rows_versioned
+        path = tmp_delta_path("mm_soft")
+        dim = _make_dim(
+            track_history=True,
+            change_detection={  # type: ignore[arg-type]
+                "names": {"columns": ["name"], "on_change": "version"},
+            },
+        )
+        overrides = _write_overrides(on_no_match_source="soft_delete", soft_delete_column="deleted")
+        rows = [
+            {"customer_id": "C1", "name": "Alice", "deleted": False},
+            {"customer_id": "C2", "name": "Bob", "deleted": False},
+        ]
+        self._merge(spark, path, dim, rows, "2026-01-01", overrides)
+
+        # C2 vanishes; C1 unchanged → soft-delete stamp is the only update
+        r2 = self._merge(spark, path, dim, rows[:1], "2026-02-01", overrides)
+        assert r2.rows_versioned == 0  # stamp must NOT count as a close
+        assert r2.rows_deleted == 1  # C2's current row stamped
+        assert r2.rows_inserted == 0
+
+    def test_standard_overwrite_split(self, spark: SparkSession, tmp_delta_path) -> None:
+        path = tmp_delta_path("mm_standard")
+        dim = _make_dim()
+        self._merge(
+            spark,
+            path,
+            dim,
+            [
+                {"customer_id": "C1", "name": "Alice"},
+                {"customer_id": "C2", "name": "Bob"},
+            ],
+            "2026-01-01",
+        )
+        r2 = self._merge(
+            spark,
+            path,
+            dim,
+            [
+                {"customer_id": "C1", "name": "Alicia"},
+                {"customer_id": "C3", "name": "Cara"},
+            ],
+            "2026-02-01",
+        )
+        assert r2.rows_overwritten == 1  # C1 updated in place
+        assert r2.rows_inserted == 1  # C3
+        assert r2.rows_deleted == 0

--- a/tests/weevr/operations/test_merge_observation_semantics.py
+++ b/tests/weevr/operations/test_merge_observation_semantics.py
@@ -1,0 +1,94 @@
+"""Empirical locks for merge-time observation and metric-key semantics.
+
+Two load-bearing assumptions of the single-execution telemetry design,
+verified against the pinned pyspark/delta-spark line rather than assumed:
+
+(a) an ``Observation`` attached to a MERGE's *source* plan — Delta's
+    classic MERGE INTO may execute the source more than once internally
+    (touched-files pass + write pass), and ``observe`` semantics are
+    defined for a single execution;
+(b) the Delta commit ``operationMetrics`` expose the *split* matched
+    update keys (``numTargetRowsMatchedUpdated`` /
+    ``numTargetRowsNotMatchedBySourceUpdated``) rather than only the
+    conflated ``numTargetRowsUpdated`` aggregate.
+
+If either lock breaks on a runtime upgrade, the recorded fallbacks apply:
+CDC counts move to one bounded action on the persisted change window, and
+the dimension split degrades to absent-with-warning for the
+track_history + soft_delete combination.
+"""
+
+import pytest
+from delta.tables import DeltaTable
+from pyspark.sql import Observation, SparkSession
+from pyspark.sql import functions as F
+
+pytestmark = pytest.mark.spark
+
+
+def _seed_target(spark: SparkSession, path: str) -> DeltaTable:
+    spark.createDataFrame(
+        [{"id": 1, "v": "a"}, {"id": 2, "v": "b"}, {"id": 3, "v": "c"}]
+    ).write.format("delta").save(path)
+    return DeltaTable.forPath(spark, path)
+
+
+class TestMergeSourceObservation:
+    def test_merge_fulfills_source_observation_with_zero_rows(
+        self, spark: SparkSession, tmp_delta_path
+    ) -> None:
+        path = tmp_delta_path("obs_merge_tgt")
+        target = _seed_target(spark, path)
+
+        # Source: one update (id=2), one insert (id=4), one absent (id=1,3)
+        obs = Observation("merge_src_probe")
+        source = spark.createDataFrame([{"id": 2, "v": "B"}, {"id": 4, "v": "d"}]).observe(
+            obs, F.count(F.lit(1)).alias("n"), F.sum("id").alias("id_sum")
+        )
+
+        (
+            target.alias("t")
+            .merge(source.alias("s"), "t.id = s.id")
+            .whenMatchedUpdateAll()
+            .whenNotMatchedInsertAll()
+            .whenNotMatchedBySourceUpdate(set={"v": F.lit("gone")})
+            .execute()
+        )
+
+        row = dict(obs.get)
+        # VERDICT (2026-07-19, pyspark 3.5 / delta pinned): the merge
+        # fulfills the observation WITHOUT flowing source rows through the
+        # observed node — it fires with zero rows. Merge-fulfilled
+        # observations are therefore UNUSABLE for source-side counts; the
+        # engine uses bounded window-scale actions instead (the recorded
+        # fallback). This lock pins the misbehavior: if a runtime upgrade
+        # makes this exactly-once (n=2, id_sum=6), the assertion fails and
+        # the observation mechanism can be reconsidered.
+        assert row == {"n": 0, "id_sum": None}
+
+    def test_split_update_metric_keys_present(self, spark: SparkSession, tmp_delta_path) -> None:
+        path = tmp_delta_path("obs_merge_metrics")
+        target = _seed_target(spark, path)
+
+        source = spark.createDataFrame([{"id": 2, "v": "B"}, {"id": 4, "v": "d"}])
+        (
+            target.alias("t")
+            .merge(source.alias("s"), "t.id = s.id")
+            .whenMatchedUpdateAll()
+            .whenNotMatchedInsertAll()
+            .whenNotMatchedBySourceUpdate(set={"v": F.lit("gone")})
+            .execute()
+        )
+
+        metrics = (
+            DeltaTable.forPath(spark, path).history(1).select("operationMetrics").collect()[0][0]
+        )
+        # The split keys the dimension-metrics arithmetic depends on
+        assert "numTargetRowsMatchedUpdated" in metrics
+        assert "numTargetRowsNotMatchedBySourceUpdated" in metrics
+        assert int(metrics["numTargetRowsMatchedUpdated"]) == 1  # id=2
+        assert int(metrics["numTargetRowsNotMatchedBySourceUpdated"]) == 2  # ids 1,3
+        assert int(metrics["numTargetRowsInserted"]) == 1  # id=4
+        # And the aggregate conflates them — the reason it must never be
+        # used for the split
+        assert int(metrics["numTargetRowsUpdated"]) == 3

--- a/tests/weevr/operations/test_writers.py
+++ b/tests/weevr/operations/test_writers.py
@@ -628,3 +628,88 @@ class TestWriteTargetMerge:
         assert rows[1]["is_deleted"] is None
         # id=2 orphan → soft_delete_value (True)
         assert rows[2]["is_deleted"] is True
+
+
+@pytest.mark.spark
+class TestCommitMetricsCounts:
+    """Write counts come from guarded commit metrics on single-pass paths."""
+
+    @pytest.fixture()
+    def count_spy(self, monkeypatch: pytest.MonkeyPatch) -> list[int]:
+        """Count DataFrame.count() calls — the eager pattern being removed.
+
+        The generic action counter also sees the driver-side
+        ``history(1).collect()`` metadata reads, which are the design's
+        accepted (log-scale) cost; this spy isolates fact-scale counts.
+        """
+        from pyspark.sql import DataFrame
+
+        calls: list[int] = []
+        original = DataFrame.count
+
+        def _spy(inner_self):  # type: ignore[no-untyped-def]
+            calls.append(1)
+            return original(inner_self)
+
+        monkeypatch.setattr(DataFrame, "count", _spy)
+        return calls
+
+    def test_overwrite_and_append_counts_parity(
+        self, spark: SparkSession, tmp_delta_path, count_spy: list[int]
+    ) -> None:
+        from weevr.model.target import Target
+        from weevr.model.write import WriteConfig
+
+        path = tmp_delta_path("cm_tgt")
+        target = Target(path=path)
+        df3 = spark.createDataFrame([{"id": i} for i in range(3)])
+        df2 = spark.createDataFrame([{"id": i} for i in range(2)])
+
+        n1 = write_target(spark, df3, target, WriteConfig(mode="overwrite"), path)
+        n2 = write_target(spark, df2, target, WriteConfig(mode="append"), path)
+        assert count_spy == []  # no eager data counts
+
+        assert n1 == 3
+        assert n2 == 2
+        assert spark.read.format("delta").load(path).count() == 5
+
+    def test_foreign_commit_degrades_to_zero_with_warning(
+        self, spark: SparkSession, tmp_delta_path, caplog
+    ) -> None:
+        from weevr.operations.target_handle import TargetHandle
+
+        path = tmp_delta_path("cm_guard")
+        spark.createDataFrame([{"id": 1}]).write.format("delta").save(path)  # v0
+        handle = TargetHandle(spark, path)
+        pre = handle.current_version()
+        assert pre == 0
+
+        # Two commits land after capture: the engine's own would be v1;
+        # a foreign writer pushes latest to v2
+        spark.createDataFrame([{"id": 2}]).write.format("delta").mode("append").save(path)
+        spark.createDataFrame([{"id": 3}]).write.format("delta").mode("append").save(path)
+
+        metrics = handle.commit_metrics_after(pre)
+        assert metrics is None  # degrade, never misattribute
+        assert any("foreign commit" in r.message for r in caplog.records)
+
+    def test_dimension_first_write_count_from_metrics(
+        self, spark: SparkSession, tmp_delta_path, count_spy: list[int]
+    ) -> None:
+        from weevr.model.dimension import DimensionConfig
+        from weevr.operations.dimension import DimensionMergeBuilder, execute_dimension_merge
+        from weevr.operations.hashing import compute_dimension_keys
+
+        path = tmp_delta_path("cm_dim_first")
+        dim = DimensionConfig(
+            business_key=["k"],
+            surrogate_key={"name": "_sk", "columns": ["k"]},  # type: ignore[arg-type]
+        )
+        src = spark.createDataFrame([{"k": "A", "v": 1}, {"k": "B", "v": 2}])
+        src = compute_dimension_keys(src, dim)
+        builder = DimensionMergeBuilder(dim)
+
+        result = execute_dimension_merge(spark, src, builder, path, "2026-01-01")
+        assert count_spy == []  # pre-count gone
+
+        assert result.rows_inserted == 2

--- a/tests/weevr/operations/test_writers.py
+++ b/tests/weevr/operations/test_writers.py
@@ -713,3 +713,35 @@ class TestCommitMetricsCounts:
         assert count_spy == []  # pre-count gone
 
         assert result.rows_inserted == 2
+
+
+@pytest.mark.spark
+class TestVersionReadFailureDistinction:
+    """A failed history read on an existing table is not a fresh table."""
+
+    def test_unreadable_version_skips_metrics_without_foreign_commit_claim(
+        self, spark: SparkSession, tmp_delta_path, monkeypatch: pytest.MonkeyPatch, caplog
+    ) -> None:
+        from weevr.operations import target_handle as th_mod
+        from weevr.operations.target_handle import TargetHandle
+
+        path = tmp_delta_path("vrf_tgt")
+        spark.createDataFrame([{"id": 1}]).write.format("delta").save(path)
+        handle = TargetHandle(spark, path)
+        assert handle.exists() is True
+
+        original = th_mod._delta.resolve_delta_table
+
+        def _boom(spark_arg, path_arg):  # type: ignore[no-untyped-def]
+            raise RuntimeError("history unavailable")
+
+        monkeypatch.setattr(th_mod._delta, "resolve_delta_table", _boom)
+        pre = handle.current_version()
+        assert pre is None  # degraded — but flagged as a read failure
+
+        monkeypatch.setattr(th_mod._delta, "resolve_delta_table", original)
+        metrics = handle.commit_metrics_after(pre)
+        assert metrics is None
+        messages = " ".join(r.message for r in caplog.records)
+        assert "unreadable" in messages
+        assert "foreign commit" not in messages  # never the phantom diagnosis


### PR DESCRIPTION
## Summary

- A thread's working DataFrame was never persisted, yet telemetry counts, output
  samples, secondary exports, and merge internals re-executed the full
  source→pipeline lineage 3–9+ times per thread, at any verbosity. A gate-free
  thread now executes its fact-scale DAG exactly once — the write.
- Closes #197

## Why

- Observability was priced in full lineage re-executions. On live deployments the
  redundant executions dominated wall-clock for wide fact threads.

## What changed

- **Counts without jobs.** On single-pass write paths (overwrite/append),
  `rows_read` and `rows_after_transforms` ride query observations fixed by the
  write; `rows_written` comes from the commit's own `numOutputRows`. Merge-based
  paths (dimensions, CDC, merge write mode) deliberately keep one eager count:
  an empirical spike — locked as a permanent regression test — showed Delta's
  MERGE fulfills observations attached to its source plan with zero rows, so the
  eager count doubles as the action that fixes every observation with true
  values before the merge can corrupt them.
- **Own-commit guard.** Write counts and dimension merge metrics are read from
  `history(1)` only when the commit version is exactly the pre-write capture
  plus one. A concurrent writer's interleaved commit — or an unreadable
  pre-version — degrades to zero with a precise warning; a wrong number is never
  reported.
- **Dimension merges report real metrics** (`rows_versioned`, `rows_inserted`,
  `rows_deleted`) from the commit's split update keys, never the conflated
  aggregate that folds soft-delete stamps into updates. `rows_unchanged` is
  intentionally absent (no Delta metric expresses it). The
  `track_history` + `soft_delete` combination is explicitly tested.
- **Samples are opt-in.** `execution.capture_samples` (default false, loom/weave
  scope) gates the `limit(10).toPandas()` sampling; display shows a hint when
  off; preview always samples. Schema regenerated.
- **Three narrow persist boundaries**, each released in `finally` on success and
  failure: the working frame when exports exist (primary write + all exports
  share one compute), the quarantine union (count from cache, write only when
  rows exist — an all-clean run leaves the prior quarantine table untouched),
  and the SCD2 merge source (the union embeds it twice).
- **CDC change window persisted:** op-code counts, the watermark capture, and
  the merge share one window-scale lineage — the persisted watermark and the
  applied rows can no longer diverge (the generic-preset watermark previously
  computed on a separate execution inside the reader).
- **Target existence resolves once per thread** through a handle, refreshed
  after the thread's own warp pre-init and seed commits; operations functions
  self-resolve when called standalone.
- Budget locks: a gate-free thread makes zero eager fact-scale calls
  (spy-verified), each observability feature adds only its enumerated bounded
  cost, and a single-scan guarantee is asserted for the export path.

## How to test

- [x] uv sync --dev
- [x] uv run ruff check .
- [x] uv run ruff format .
- [x] uv run pyright .
- [x] uv run pytest (2534 passed) and the full Spark-marked suite (exit 0)

## Release / Versioning

- [x] PR title follows Conventional Commit format (feat:, fix:, chore:, docs:, ci:, etc.)
- [ ] Breaking change indicated (feat!: / fix!: or BREAKING CHANGE in body) — not breaking

## Notes

- Release-notes callout: output samples are now opt-in — default runs skip the
  sampling jobs and display shows a hint naming the switch; set
  `execution.capture_samples: true` to restore the previous display. Preview is
  unaffected.
- Count values keep parity with previous behavior on every path; degrade cases
  (unreadable metrics, interleaved foreign commits) report zero with a warning
  rather than a misattributed number.