### PR TITLE
refactor(engine): materialize shared resources once per scope

### DIFF
--- a/docs/guides/engine-internals.md
+++ b/docs/guides/engine-internals.md
@@ -27,8 +27,12 @@ conditional execution, and structured result collection.
 - **Parallel execution group** — A set of threads with no mutual dependencies
   that can run concurrently on the same SparkSession.
 - **Cache target** — A thread whose output is read by two or more downstream
-  threads. The engine caches the DataFrame in memory to avoid re-reading from
-  Delta.
+  threads. The engine persists the post-write snapshot under the target's
+  canonical identity (alias, path, and connection-declared forms all map to
+  one key) and serves consumers from an explicit registry — a registry miss
+  simply falls back to a direct Delta read. The snapshot materializes
+  eagerly at registration, so parallel consumers in one group never race to
+  compute it.
 
 ## How it works
 
@@ -115,13 +119,30 @@ skipped.
    after pre-steps and before any thread runs. Internal lookups
    whose source is produced by a thread in group N are deferred
    and materialized at the group N+1 boundary — after their
-   producer completes.
-4. **Column set materialization** — If the weave (or loom) defines
-   `column_sets`, all sets are resolved to from→to mapping dicts.
-   Delta/YAML sources are read via `read_source()`; param sources
-   resolve from runtime parameters. Connection-backed column sets
-   resolve through the merged loom + weave connection dict.
-   Results are captured in `WeaveTelemetry.column_set_results`.
+   producer completes. Materialization reads the source exactly
+   once: the narrowed frame persists first and both the warming
+   count and the `unique_key` check run against the cache. A
+   `strategy: broadcast` lookup persists *and* carries the
+   broadcast hint — consuming joins build their exchange from the
+   resident cache instead of re-reading the source per join, so
+   its memory profile is "resident cache + per-join exchange"
+   rather than a fresh exchange per join. Non-materialized
+   (`materialize: false`) lookups keep their per-thread re-read,
+   but a declared `unique_key` validates once per weave — the
+   first consumer validates (concurrent group-mates block on that
+   outcome), and a failure outcome is observed consistently by
+   every later consumer.
+4. **Column set materialization** — Column sets resolve to
+   from→to mapping dicts **once per declaring scope**: loom-level
+   sets resolve at loom start and pass down as resolved mappings;
+   a weave materializes only its own declarations (including any
+   overrides of loom sets — precedence is unchanged); a thread
+   materializes only thread-level declarations and merges the
+   already-resolved parent mappings. Delta/YAML sources are read
+   via `read_source()`; param sources resolve from runtime
+   parameters; connection-backed sets resolve through the merged
+   loom + weave connection dict. Results are captured in
+   `WeaveTelemetry.column_set_results`.
 5. **Thread execution** — Parallel groups are processed
    sequentially. Within each group, threads are submitted to a
    `ThreadPoolExecutor` for concurrent execution. Threads

--- a/packages/weevr-core/src/weevr/config/onelake.py
+++ b/packages/weevr-core/src/weevr/config/onelake.py
@@ -1,0 +1,63 @@
+"""OneLake path construction — pure string building, Spark-free.
+
+Lives in the core wheel so both the runtime (readers, executor, target
+identity) and plan-time analysis (the planner's target/source indexes)
+resolve connection+table declarations to the same physical path. The
+engine wheel re-exports these from ``weevr.config.paths`` for
+compatibility.
+"""
+
+from __future__ import annotations
+
+from weevr.model.connection import OneLakeConnection
+
+_ONELAKE_HOST = "onelake.dfs.fabric.microsoft.com"
+
+
+def build_onelake_path(
+    connection: OneLakeConnection,
+    schema: str | None,
+    table: str,
+) -> str:
+    """Build an abfss:// path from connection properties.
+
+    Args:
+        connection: OneLake connection declaration with workspace and lakehouse
+            identifiers.
+        schema: Schema name to use. When provided, takes precedence over
+            ``connection.default_schema``.
+        table: Table name to append to the path.
+
+    Returns:
+        A fully-qualified ``abfss://`` URI for the given table.
+    """
+    effective_schema = schema or connection.default_schema
+    base = f"abfss://{connection.workspace}@{_ONELAKE_HOST}/{connection.lakehouse}/Tables"
+    if effective_schema:
+        return f"{base}/{effective_schema}/{table}"
+    return f"{base}/{table}"
+
+
+def resolve_connection_path(
+    connection_name: str,
+    table: str | None,
+    schema_override: str | None,
+    connections: dict[str, OneLakeConnection] | None,
+) -> str:
+    """Resolve a connection+table declaration to its abfss:// path.
+
+    The one shared implementation of connection resolution — the executor
+    (targets), the readers (sources), the target-identity resolver, and
+    the planner's dependency analysis all call it instead of duplicating
+    the lookup-and-build sequence.
+
+    Raises:
+        ValueError: If the connection is undeclared or ``table`` is absent.
+            Callers wrap this in their own error types with call-site
+            context (thread name, source alias).
+    """
+    if not connections or connection_name not in connections:
+        raise ValueError(f"undefined connection '{connection_name}'")
+    if table is None:
+        raise ValueError(f"connection '{connection_name}' requires 'table'")
+    return build_onelake_path(connections[connection_name], schema_override, table)

--- a/packages/weevr-core/src/weevr/engine/planner.py
+++ b/packages/weevr-core/src/weevr/engine/planner.py
@@ -6,6 +6,7 @@ from collections import deque
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from weevr.config.onelake import resolve_connection_path
 from weevr.errors.exceptions import ConfigError
 from weevr.model.base import FrozenBase
 from weevr.model.lookup import Lookup
@@ -91,23 +92,57 @@ def _normalize_path(path: str) -> str:
 def _extract_target_path(thread: Thread) -> str | None:
     """Return the resolved target path for a thread, normalized.
 
-    Prefers ``target.alias`` over ``target.path`` to match executor behaviour.
-    Returns ``None`` if neither is set.
+    Prefers ``target.alias`` over ``target.path`` to match executor
+    behaviour; connection+table declarations resolve to their abfss://
+    path so connection-form writers participate in dependency inference
+    and the same-target conflict guard exactly like path-form writers.
+    Returns ``None`` if nothing resolves.
     """
     raw = thread.target.alias or thread.target.path
+    if raw is None and thread.target.connection:
+        try:
+            raw = resolve_connection_path(
+                thread.target.connection,
+                thread.target.table,
+                thread.target.schema_override,
+                thread.connections,
+            )
+        except ValueError:
+            return None
     if raw is None:
         return None
     return _normalize_path(raw)
 
 
 def _extract_source_paths(thread: Thread) -> set[str]:
-    """Return all normalized source paths/aliases declared on a thread."""
+    """Return all normalized source paths/aliases declared on a thread.
+
+    Connection-declared sources resolve to their abfss:// path (matching
+    the target side), so a connection-form reader of a connection-form
+    writer's table gets a dependency edge. FUSE-vs-abfss notation for the
+    same table cannot be unified here (needs a live session) — a known
+    plan-time limitation.
+    """
     paths: set[str] = set()
     for source in thread.sources.values():
         if source.alias is not None:
             paths.add(_normalize_path(source.alias))
         if source.path is not None:
             paths.add(_normalize_path(source.path))
+        if source.connection is not None:
+            try:
+                paths.add(
+                    _normalize_path(
+                        resolve_connection_path(
+                            source.connection,
+                            source.table,
+                            source.schema_override,
+                            thread.connections,
+                        )
+                    )
+                )
+            except ValueError:
+                continue
     return paths
 
 

--- a/packages/weevr/src/weevr/config/paths.py
+++ b/packages/weevr/src/weevr/config/paths.py
@@ -37,6 +37,30 @@ def build_onelake_path(
     return f"{base}/{table}"
 
 
+def resolve_connection_path(
+    connection_name: str,
+    table: str | None,
+    schema_override: str | None,
+    connections: dict[str, OneLakeConnection] | None,
+) -> str:
+    """Resolve a connection+table declaration to its abfss:// path.
+
+    The one shared implementation of connection resolution — the executor
+    (targets), the readers (sources), and the target-identity resolver all
+    call it instead of duplicating the lookup-and-build sequence.
+
+    Raises:
+        ValueError: If the connection is undeclared or ``table`` is absent.
+            Callers wrap this in their own error types with call-site
+            context (thread name, source alias).
+    """
+    if not connections or connection_name not in connections:
+        raise ValueError(f"undefined connection '{connection_name}'")
+    if table is None:
+        raise ValueError(f"connection '{connection_name}' requires 'table'")
+    return build_onelake_path(connections[connection_name], schema_override, table)
+
+
 def resolve_fuse_path(path: str, spark: SparkSession) -> str:
     """Translate a FUSE mount path to its abfss:// equivalent.
 

--- a/packages/weevr/src/weevr/config/paths.py
+++ b/packages/weevr/src/weevr/config/paths.py
@@ -7,11 +7,15 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from pyspark.sql import SparkSession
 
-from weevr.config.onelake import (  # noqa: F401 — re-exported for compatibility
-    build_onelake_path,
-    resolve_connection_path,
-)
-from weevr.model.connection import OneLakeConnection  # noqa: F401
+from weevr.config.onelake import build_onelake_path, resolve_connection_path
+from weevr.model.connection import OneLakeConnection
+
+__all__ = [
+    "OneLakeConnection",
+    "build_onelake_path",
+    "resolve_connection_path",
+    "resolve_fuse_path",
+]
 
 _ONELAKE_HOST = "onelake.dfs.fabric.microsoft.com"
 _FUSE_PREFIX = "/lakehouse/"

--- a/packages/weevr/src/weevr/config/paths.py
+++ b/packages/weevr/src/weevr/config/paths.py
@@ -7,58 +7,14 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from pyspark.sql import SparkSession
 
-from weevr.model.connection import OneLakeConnection
+from weevr.config.onelake import (  # noqa: F401 — re-exported for compatibility
+    build_onelake_path,
+    resolve_connection_path,
+)
+from weevr.model.connection import OneLakeConnection  # noqa: F401
 
 _ONELAKE_HOST = "onelake.dfs.fabric.microsoft.com"
 _FUSE_PREFIX = "/lakehouse/"
-
-
-def build_onelake_path(
-    connection: OneLakeConnection,
-    schema: str | None,
-    table: str,
-) -> str:
-    """Build an abfss:// path from connection properties.
-
-    Args:
-        connection: OneLake connection declaration with workspace and lakehouse
-            identifiers.
-        schema: Schema name to use. When provided, takes precedence over
-            ``connection.default_schema``.
-        table: Table name to append to the path.
-
-    Returns:
-        A fully-qualified ``abfss://`` URI for the given table.
-    """
-    effective_schema = schema or connection.default_schema
-    base = f"abfss://{connection.workspace}@{_ONELAKE_HOST}/{connection.lakehouse}/Tables"
-    if effective_schema:
-        return f"{base}/{effective_schema}/{table}"
-    return f"{base}/{table}"
-
-
-def resolve_connection_path(
-    connection_name: str,
-    table: str | None,
-    schema_override: str | None,
-    connections: dict[str, OneLakeConnection] | None,
-) -> str:
-    """Resolve a connection+table declaration to its abfss:// path.
-
-    The one shared implementation of connection resolution — the executor
-    (targets), the readers (sources), and the target-identity resolver all
-    call it instead of duplicating the lookup-and-build sequence.
-
-    Raises:
-        ValueError: If the connection is undeclared or ``table`` is absent.
-            Callers wrap this in their own error types with call-site
-            context (thread name, source alias).
-    """
-    if not connections or connection_name not in connections:
-        raise ValueError(f"undefined connection '{connection_name}'")
-    if table is None:
-        raise ValueError(f"connection '{connection_name}' requires 'table'")
-    return build_onelake_path(connections[connection_name], schema_override, table)
 
 
 def resolve_fuse_path(path: str, spark: SparkSession) -> str:

--- a/packages/weevr/src/weevr/engine/cache_manager.py
+++ b/packages/weevr/src/weevr/engine/cache_manager.py
@@ -35,6 +35,7 @@ class CacheManager:
         self._cache_targets: set[str] = set(cache_targets)
         self._dependents = dependents
         self._cached: dict[str, DataFrame] = {}
+        self._by_identity: dict[str, str] = {}
         self._remaining_consumers: dict[str, int] = {
             name: len(dependents.get(name, [])) for name in cache_targets
         }
@@ -43,24 +44,41 @@ class CacheManager:
         """Return True if the thread's output should be cached."""
         return thread_name in self._cache_targets
 
-    def persist(self, thread_name: str, spark: SparkSession, target_path: str) -> None:
-        """Read and persist the thread's target DataFrame.
+    def persist(
+        self,
+        thread_name: str,
+        spark: SparkSession,
+        target_path: str,
+        identity: str | None = None,
+    ) -> None:
+        """Read, persist, and register the thread's target DataFrame.
 
-        The DataFrame is read from ``target_path`` using the provided SparkSession
-        and persisted at ``MEMORY_AND_DISK`` level. If the operation fails for any
-        reason, a warning is logged and execution continues without caching.
+        The DataFrame is read from ``target_path``, persisted at
+        ``MEMORY_AND_DISK``, eagerly materialized, and registered under the
+        target's canonical identity so consumers fetch it explicitly. If
+        the operation fails for any reason, a warning is logged and
+        execution continues without caching.
 
         Args:
             thread_name: Name of the thread whose output to cache.
             spark: Active SparkSession.
-            target_path: Delta path to read the DataFrame from.
+            target_path: Delta path or alias to read the DataFrame from.
+            identity: Canonical target identity for registry lookups; when
+                None the entry participates in lifecycle but is not
+                fetchable by identity.
         """
         if thread_name not in self._cache_targets:
             return
         try:
             df = read_delta(spark, target_path)
             df.persist(StorageLevel.MEMORY_AND_DISK)
+            # Materialize eagerly: parallel same-group consumers must never
+            # race to compute the cache — by the time any consumer fetches,
+            # the partitions exist
+            df.count()
             self._cached[thread_name] = df
+            if identity:
+                self._by_identity[identity] = thread_name
             logger.debug("Cached output of thread '%s' from path '%s'", thread_name, target_path)
         except Exception as exc:  # noqa: BLE001
             logger.warning(
@@ -70,6 +88,19 @@ class CacheManager:
                 target_path,
                 exc,
             )
+
+    def get(self, identity: str | None) -> DataFrame | None:
+        """The registered post-write snapshot for a canonical identity.
+
+        A miss IS the fallback — the caller reads from storage directly,
+        so cache failures stay non-fatal by construction.
+        """
+        if identity is None:
+            return None
+        thread_name = self._by_identity.get(identity)
+        if thread_name is None:
+            return None
+        return self._cached.get(thread_name)
 
     def notify_complete(self, consumer_name: str) -> None:
         """Notify the manager that a consumer thread has completed.
@@ -99,6 +130,7 @@ class CacheManager:
 
     def _unpersist(self, thread_name: str) -> None:
         df = self._cached.pop(thread_name, None)
+        self._by_identity = {k: v for k, v in self._by_identity.items() if v != thread_name}
         if df is None:
             return
         try:

--- a/packages/weevr/src/weevr/engine/executor.py
+++ b/packages/weevr/src/weevr/engine/executor.py
@@ -375,12 +375,14 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
                     connections=connections,
                 )
 
-                # Read secondary sources normally (skip lookup-resolved ones)
+                # Secondary sources (the primary keeps its filtered read —
+                # snapshot semantics don't apply to it) consult the cache
+                # registry like any full-mode source
                 sources_map = {primary_alias: primary_df}
                 for alias, source in thread.sources.items():
                     if alias != primary_alias and alias not in lookup_dfs:
-                        sources_map[alias] = read_source(
-                            spark, alias, source, connections=connections
+                        sources_map[alias] = _read_source_via_registry(
+                            spark, alias, source, connections, cache_registry
                         )
                 sources_map.update(lookup_dfs)
 
@@ -450,12 +452,14 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
                         prior_state is not None,
                     )
 
-                # Read secondary sources normally (skip lookup-resolved ones)
+                # Secondary sources (the primary keeps its filtered read —
+                # snapshot semantics don't apply to it) consult the cache
+                # registry like any full-mode source
                 sources_map = {primary_alias: primary_df}
                 for alias, source in thread.sources.items():
                     if alias != primary_alias and alias not in lookup_dfs:
-                        sources_map[alias] = read_source(
-                            spark, alias, source, connections=connections
+                        sources_map[alias] = _read_source_via_registry(
+                            spark, alias, source, connections, cache_registry
                         )
                 sources_map.update(lookup_dfs)
             else:
@@ -1247,8 +1251,12 @@ def _read_source_via_registry(
     Registry consultation is strictly the thread-target read path (the
     lookup lane has its own materialization); a hit hands back the
     producer's post-write snapshot with the source's own dedup applied —
-    identical to what a direct read would see absent interleaved writers,
-    which plan-time validation already rejects within a run.
+    identical to what a direct read would see absent interleaved writers.
+    Plan-time validation rejects unordered same-target writers across
+    alias, path, AND connection declaration forms; the one residual is
+    FUSE-vs-abfss notation for the same table, which plan time cannot
+    unify (no session) — such pairs miss the registry rather than hit it
+    wrongly, and their scheduling blindness predates the registry.
     """
     if cache_registry is not None and (source.type == "delta" or source.connection):
         identity = resolve_target_identity(

--- a/packages/weevr/src/weevr/engine/executor.py
+++ b/packages/weevr/src/weevr/engine/executor.py
@@ -237,19 +237,23 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
                 weave_lookups, thread.lookups, "lookup", "weave", "thread"
             )
 
-        # Merge thread-level column_sets with weave-level (thread wins)
+        # Merge thread-level column_sets with weave-level (thread wins).
+        # Only the THREAD's defs materialize here — the weave's mappings
+        # arrive already resolved and merge as plain dicts, so a weave set
+        # resolves once per weave regardless of thread count
         if thread.column_sets:
             merged_cs_defs = merge_resource_dicts(
                 column_set_defs, thread.column_sets, "column_set", "weave", "thread"
             )
             if merged_cs_defs:
                 effective_column_set_defs = merged_cs_defs
-                effective_column_sets, _ = materialize_column_sets(
-                    spark,
-                    merged_cs_defs,
-                    resolved_params or {},
-                    connections=connections,
-                )
+            thread_resolved_cs, _ = materialize_column_sets(
+                spark,
+                dict(thread.column_sets),
+                resolved_params or {},
+                connections=connections,
+            )
+            effective_column_sets = {**(column_sets or {}), **thread_resolved_cs}
 
         # Run thread-level pre_steps
         if thread.pre_steps:

--- a/packages/weevr/src/weevr/engine/executor.py
+++ b/packages/weevr/src/weevr/engine/executor.py
@@ -14,6 +14,7 @@ from pyspark.sql import Observation, SparkSession
 from pyspark.sql import functions as F
 
 from weevr.delta import read_delta
+from weevr.engine.cache_manager import CacheManager
 from weevr.engine.column_sets import materialize_column_sets
 from weevr.engine.hooks import run_hook_steps
 from weevr.engine.lookups import (
@@ -24,6 +25,7 @@ from weevr.engine.lookups import (
 )
 from weevr.engine.resources import merge_resource_dicts
 from weevr.engine.result import ThreadResult
+from weevr.engine.target_identity import resolve_target_identity
 from weevr.engine.variables import VariableContext
 from weevr.errors.exceptions import (
     DataValidationError,
@@ -51,11 +53,11 @@ from weevr.operations.pipeline import LookupMeta, ObservationRegistry, run_pipel
 from weevr.operations.pipeline._observations import read_observation
 from weevr.operations.quarantine import write_quarantine
 from weevr.operations.readers import (
+    apply_source_dedup,
     compute_generic_cdc_hwm,
     read_cdc_source,
     read_source,
     read_source_incremental,
-    read_sources,
 )
 from weevr.operations.seeding import build_system_member_rows, execute_seeds
 from weevr.operations.target_handle import TargetHandle
@@ -90,6 +92,7 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
     connections: dict[str, OneLakeConnection] | None = None,
     lookup_meta: dict[str, LookupMeta] | None = None,
     capture_samples: bool = False,
+    cache_registry: CacheManager | None = None,
 ) -> ThreadResult:
     """Execute a single thread from sources through transforms to a Delta target.
 
@@ -148,6 +151,10 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
         capture_samples: Whether to capture 10-row output/quarantine
             samples for display (effective ``execution.capture_samples``).
             Off by default — sampling re-executes the pipeline lineage.
+        cache_registry: Weave-level cache registry; Delta-backed sources
+            whose canonical identity matches a registered producer are
+            served the post-write snapshot instead of a storage read.
+            A miss falls back to a direct read.
 
     Returns:
         :class:`ThreadResult` with status, row count, write mode, target path,
@@ -443,9 +450,16 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
                         )
                 sources_map.update(lookup_dfs)
             else:
-                # Full mode or incremental_parameter — read non-lookup sources normally
+                # Full mode or incremental_parameter — read non-lookup
+                # sources, serving registered cache snapshots when the
+                # source's identity matches a same-run producer
                 normal_sources = {k: v for k, v in thread.sources.items() if k not in lookup_dfs}
-                sources_map = read_sources(spark, normal_sources, connections=connections)
+                sources_map = {
+                    alias_name: _read_source_via_registry(
+                        spark, alias_name, src, connections, cache_registry
+                    )
+                    for alias_name, src in normal_sources.items()
+                }
                 sources_map.update(lookup_dfs)
 
             # Step statistics attach as Observations (harvested after the
@@ -1210,6 +1224,38 @@ def _validate_cdc_write_config(thread: Thread) -> WriteConfig:
             thread_name=thread.name,
         )
     return thread.write
+
+
+def _read_source_via_registry(
+    spark: SparkSession,
+    alias_name: str,
+    source: Any,
+    connections: dict[str, OneLakeConnection] | None,
+    cache_registry: CacheManager | None,
+) -> Any:
+    """Serve a source from the weave cache registry, or read it directly.
+
+    Registry consultation is strictly the thread-target read path (the
+    lookup lane has its own materialization); a hit hands back the
+    producer's post-write snapshot with the source's own dedup applied —
+    identical to what a direct read would see absent interleaved writers,
+    which plan-time validation already rejects within a run.
+    """
+    if cache_registry is not None and (source.type == "delta" or source.connection):
+        identity = resolve_target_identity(
+            spark,
+            alias=source.alias,
+            path=source.path,
+            connection=source.connection,
+            table=source.table,
+            schema_override=source.schema_override,
+            connections=connections,
+        )
+        hit = cache_registry.get(identity)
+        if hit is not None:
+            logger.debug("Source '%s' served from cache registry", alias_name)
+            return apply_source_dedup(hit, source)
+    return read_source(spark, alias_name, source, connections=connections)
 
 
 def _build_telemetry(

--- a/packages/weevr/src/weevr/engine/executor.py
+++ b/packages/weevr/src/weevr/engine/executor.py
@@ -18,6 +18,7 @@ from weevr.engine.cache_manager import CacheManager
 from weevr.engine.column_sets import materialize_column_sets
 from weevr.engine.hooks import run_hook_steps
 from weevr.engine.lookups import (
+    UniqueKeyMemo,
     build_lookup_meta,
     cleanup_lookups,
     materialize_lookups,
@@ -93,6 +94,7 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
     lookup_meta: dict[str, LookupMeta] | None = None,
     capture_samples: bool = False,
     cache_registry: CacheManager | None = None,
+    uk_memo: UniqueKeyMemo | None = None,
 ) -> ThreadResult:
     """Execute a single thread from sources through transforms to a Delta target.
 
@@ -155,6 +157,8 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
             whose canonical identity matches a registered producer are
             served the post-write snapshot instead of a storage read.
             A miss falls back to a direct read.
+        uk_memo: Per-weave validate-exactly-once memo for non-materialized
+            ``unique_key`` lookups.
 
     Returns:
         :class:`ThreadResult` with status, row count, write mode, target path,
@@ -350,6 +354,7 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
                     effective_cached_lookups or {},
                     spark,
                     connections=connections,
+                    uk_memo=uk_memo,
                 )
 
             # --- Step 4: Read sources ---

--- a/packages/weevr/src/weevr/engine/executor.py
+++ b/packages/weevr/src/weevr/engine/executor.py
@@ -256,24 +256,20 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
             target_path = thread.target.alias or thread.target.path
             if target_path is None and thread.target.connection:
                 conn_name = thread.target.connection
-                if not connections or conn_name not in connections:
-                    raise ExecutionError(
-                        f"Target references undefined connection '{conn_name}'",
-                        thread_name=thread.name,
-                    )
-                from weevr.config.paths import build_onelake_path
+                from weevr.config.paths import resolve_connection_path
 
-                conn = connections[conn_name]
-                if thread.target.table is None:
-                    raise ExecutionError(
-                        "Target connection requires 'table'",
-                        thread_name=thread.name,
+                try:
+                    target_path = resolve_connection_path(
+                        conn_name,
+                        thread.target.table,
+                        thread.target.schema_override,
+                        connections,
                     )
-                target_path = build_onelake_path(
-                    conn,
-                    thread.target.schema_override,
-                    thread.target.table,
-                )
+                except ValueError as exc:
+                    raise ExecutionError(
+                        f"Target connection resolution failed: {exc}",
+                        thread_name=thread.name,
+                    ) from exc
                 logger.debug(
                     "Thread '%s': resolved target connection '%s' → %s",
                     thread.name,

--- a/packages/weevr/src/weevr/engine/lookups.py
+++ b/packages/weevr/src/weevr/engine/lookups.py
@@ -137,7 +137,9 @@ class UniqueKeyMemo:
                     raise
             outcome = self._outcomes[name]
         if isinstance(outcome, Exception):
-            raise outcome
+            # A fresh exception per consumer: re-raising one instance from
+            # several threads mutates its traceback concurrently
+            raise LookupResolutionError(str(outcome)) from outcome
 
 
 def build_lookup_meta(

--- a/packages/weevr/src/weevr/engine/lookups.py
+++ b/packages/weevr/src/weevr/engine/lookups.py
@@ -183,6 +183,8 @@ def _apply_narrow_pipeline(
     df: DataFrame,
     lookup: Lookup,
     name: str,
+    *,
+    run_unique_check: bool = True,
 ) -> tuple[DataFrame, bool, bool, bool | None]:
     """Apply filter, projection, and unique-key check to a lookup DataFrame.
 
@@ -193,6 +195,10 @@ def _apply_narrow_pipeline(
         df: Raw DataFrame from source read.
         lookup: Lookup definition with optional narrow fields.
         name: Lookup name for error messages.
+        run_unique_check: The materialized path passes False and runs the
+            check itself AGAINST THE CACHE after persisting — checking here
+            would read the source once for the check and again for the
+            cache fill. The on-demand path keeps the inline check.
 
     Returns:
         Tuple of (narrowed DataFrame, filter_applied, unique_key_checked,
@@ -220,7 +226,7 @@ def _apply_narrow_pipeline(
         _validate_columns(df, lookup.key, name)
 
     # 3. Unique-key check
-    if lookup.unique_key:
+    if lookup.unique_key and run_unique_check:
         if lookup.key is None:
             raise LookupResolutionError(f"Lookup '{name}': 'unique_key' requires 'key' to be set")
         unique_key_checked = True
@@ -270,18 +276,36 @@ def materialize_lookups(
             df = read_source(spark, name, lookup.source, connections=connections)
             source_size = _delta_source_size(spark, lookup.source, connections)
 
-            # Apply narrow pipeline (filter → project → unique_key)
-            df, filter_applied, uk_checked, uk_passed = _apply_narrow_pipeline(df, lookup, name)
+            # Narrow first (filter → project), check LATER against the
+            # cache: persist-before-check means the source is read exactly
+            # once — the warming count fills the cache and the unique-key
+            # check reuses it
+            df, filter_applied, _, _ = _apply_narrow_pipeline(
+                df, lookup, name, run_unique_check=False
+            )
+
+            from pyspark import StorageLevel
 
             if lookup.strategy == "broadcast":
+                # Persist AND hint — they compose: the warming count fills
+                # the cache, consuming joins build their broadcast exchange
+                # from cache instead of re-reading the source per join.
+                # Hint before persist so unpersist targets the cached plan.
                 df = F.broadcast(df)
-            else:
-                from pyspark import StorageLevel
+            df.persist(StorageLevel.MEMORY_AND_DISK)
 
-                df.persist(StorageLevel.MEMORY_AND_DISK)
-
-            # Trigger materialization and get count
+            # Trigger materialization and get count — the single source read
             row_count = df.count()
+
+            uk_checked = False
+            uk_passed: bool | None = None
+            if lookup.unique_key:
+                if lookup.key is None:
+                    raise LookupResolutionError(
+                        f"Lookup '{name}': 'unique_key' requires 'key' to be set"
+                    )
+                uk_checked = True
+                uk_passed = _check_unique_key(df, lookup.key, name, lookup.on_failure)
 
             cached[name] = df
             elapsed_ms = (time.monotonic() - start) * 1000

--- a/packages/weevr/src/weevr/engine/lookups.py
+++ b/packages/weevr/src/weevr/engine/lookups.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import threading
 import time
 from collections.abc import Mapping
 from typing import TYPE_CHECKING
@@ -97,6 +98,46 @@ def _delta_source_size(
     except Exception:
         logger.debug("Could not resolve Delta size for lookup source", exc_info=True)
         return None
+
+
+class UniqueKeyMemo:
+    """Validate-exactly-once memo for non-materialized lookups, per weave.
+
+    ``materialize: false`` keeps the user's per-thread re-read, but the
+    unique-key validation memoizes by lookup name: the first consumer
+    validates, the rest reuse the outcome — including a failure outcome.
+    Same-group threads run concurrently, so the check-and-set holds a
+    lock for the duration of the winner's validation; losers block on it
+    and then observe the settled outcome (a warn is logged once, an abort
+    raises consistently for every consumer).
+    """
+
+    def __init__(self) -> None:
+        """Create an empty memo (one per weave execution)."""
+        self._lock = threading.Lock()
+        self._outcomes: dict[str, Exception | bool | None] = {}
+
+    def validate(self, name: str, df: DataFrame, lookup: Lookup) -> None:
+        """Run or reuse the unique-key validation for one lookup.
+
+        Raises:
+            LookupResolutionError: The winner's abort, re-raised for every
+                consumer that reuses the memoized failure.
+        """
+        if not lookup.unique_key or lookup.key is None:
+            return
+        with self._lock:
+            if name not in self._outcomes:
+                try:
+                    self._outcomes[name] = _check_unique_key(
+                        df, lookup.key, name, lookup.on_failure
+                    )
+                except Exception as exc:
+                    self._outcomes[name] = exc
+                    raise
+            outcome = self._outcomes[name]
+        if isinstance(outcome, Exception):
+            raise outcome
 
 
 def build_lookup_meta(
@@ -380,6 +421,7 @@ def resolve_thread_lookups(
     cached_dfs: dict[str, DataFrame],
     spark: SparkSession,
     connections: dict[str, OneLakeConnection] | None = None,
+    uk_memo: UniqueKeyMemo | None = None,
 ) -> dict[str, DataFrame]:
     """Resolve thread source lookup references to DataFrames.
 
@@ -393,6 +435,9 @@ def resolve_thread_lookups(
         cached_dfs: Pre-materialized DataFrames from :func:`materialize_lookups`.
         spark: Active SparkSession for on-demand reads.
         connections: Named connection declarations forwarded to on-demand reads.
+        uk_memo: Per-weave validate-exactly-once memo for non-materialized
+            ``unique_key`` lookups; when absent (direct callers) the check
+            runs inline per call, as before.
 
     Returns:
         Mapping of source alias to resolved DataFrame.
@@ -417,8 +462,17 @@ def resolve_thread_lookups(
         else:
             lookup_def = weave_lookups[lookup_name]
             df = read_source(spark, lookup_name, lookup_def.source, connections=connections)
-            # Apply narrow pipeline for on-demand reads
-            df, _, _, _ = _apply_narrow_pipeline(df, lookup_def, lookup_name)
+            if uk_memo is not None:
+                # Narrow without the inline check; the memo validates
+                # exactly once per weave (first consumer wins, others —
+                # including concurrent group-mates — reuse the outcome)
+                df, _, _, _ = _apply_narrow_pipeline(
+                    df, lookup_def, lookup_name, run_unique_check=False
+                )
+                uk_memo.validate(lookup_name, df, lookup_def)
+            else:
+                # Direct callers keep today's inline per-call check
+                df, _, _, _ = _apply_narrow_pipeline(df, lookup_def, lookup_name)
             resolved[alias] = df
 
     return resolved

--- a/packages/weevr/src/weevr/engine/runner.py
+++ b/packages/weevr/src/weevr/engine/runner.py
@@ -25,6 +25,7 @@ from weevr.engine.lookups import (
 from weevr.engine.planner import ExecutionPlan, build_plan
 from weevr.engine.resources import merge_resource_dicts
 from weevr.engine.result import LoomResult, ThreadResult, WeaveResult
+from weevr.engine.target_identity import resolve_target_identity
 from weevr.engine.variables import VariableContext
 from weevr.errors.exceptions import HookError
 from weevr.model.column_set import ColumnSet
@@ -340,6 +341,7 @@ def execute_weave(
                                 capture_samples=(
                                     execution.capture_samples if execution is not None else False
                                 ),
+                                cache_registry=cache,
                                 weave_lookups=lookups,
                                 resolved_params=params,
                                 loom_name=loom_name,
@@ -363,6 +365,7 @@ def execute_weave(
                                 capture_samples=(
                                     execution.capture_samples if execution is not None else False
                                 ),
+                                cache_registry=cache,
                                 weave_lookups=lookups,
                                 resolved_params=params,
                                 loom_name=loom_name,
@@ -385,11 +388,24 @@ def execute_weave(
                         if name in thread_collectors and collector is not None:
                             collector.merge(thread_collectors[name])
 
-                        # Persist cache if this thread is a cache target
+                        # Persist cache if this thread is a cache target.
+                        # Identity covers alias, path, AND connection forms —
+                        # connection-declared cache targets previously never
+                        # persisted (identity was `alias or path` only)
                         if cache.is_cache_target(name):
-                            target_path = threads[name].target.alias or threads[name].target.path
+                            tgt = threads[name].target
+                            identity = resolve_target_identity(
+                                spark,
+                                alias=tgt.alias,
+                                path=tgt.path,
+                                connection=tgt.connection,
+                                table=tgt.table,
+                                schema_override=tgt.schema_override,
+                                connections=threads[name].connections,
+                            )
+                            target_path = tgt.alias or tgt.path or identity
                             if target_path:
-                                cache.persist(name, spark, target_path)
+                                cache.persist(name, spark, target_path, identity=identity)
 
                         # Notify cache manager so it can unpersist when all consumers done
                         cache.notify_complete(name)

--- a/packages/weevr/src/weevr/engine/runner.py
+++ b/packages/weevr/src/weevr/engine/runner.py
@@ -18,6 +18,7 @@ from weevr.engine.executor import execute_thread
 from weevr.engine.hooks import HookResult, run_hook_steps
 from weevr.engine.lookups import (
     LookupResult,
+    UniqueKeyMemo,
     build_lookup_meta,
     cleanup_lookups,
     materialize_lookups,
@@ -160,6 +161,7 @@ def execute_weave(
     thread_results: list[ThreadResult] = []
     threads_skipped: list[str] = []
     cache = CacheManager(plan.cache_targets, plan.dependents)
+    uk_memo = UniqueKeyMemo()
     aborted = False
     _weave_raised = False
     max_parallel_threads = execution.max_parallel_threads if execution is not None else None
@@ -342,6 +344,7 @@ def execute_weave(
                                     execution.capture_samples if execution is not None else False
                                 ),
                                 cache_registry=cache,
+                                uk_memo=uk_memo,
                                 weave_lookups=lookups,
                                 resolved_params=params,
                                 loom_name=loom_name,
@@ -366,6 +369,7 @@ def execute_weave(
                                     execution.capture_samples if execution is not None else False
                                 ),
                                 cache_registry=cache,
+                                uk_memo=uk_memo,
                                 weave_lookups=lookups,
                                 resolved_params=params,
                                 loom_name=loom_name,

--- a/packages/weevr/src/weevr/engine/runner.py
+++ b/packages/weevr/src/weevr/engine/runner.py
@@ -98,6 +98,8 @@ def execute_weave(
     connections: dict[str, OneLakeConnection] | None = None,
     execution: ExecutionConfig | None = None,
     pre_lookup_meta: dict[str, LookupMeta] | None = None,
+    pre_resolved_column_sets: dict[str, dict[str, str]] | None = None,
+    pre_column_set_results: list[ColumnSetResult] | None = None,
 ) -> WeaveResult:
     """Execute threads according to the execution plan.
 
@@ -151,6 +153,12 @@ def execute_weave(
             the pool is sized to the group.
         pre_lookup_meta: Materialization-time lookup facts from the parent
             scope (loom), merged under weave-level facts at dispatch.
+        pre_resolved_column_sets: Loom-level column sets already resolved
+            once at loom start (the ``pre_cached_lookups`` analogue —
+            overridden keys excluded by the caller so weave precedence
+            re-resolves them). Merged under weave-level resolutions.
+        pre_column_set_results: Resolution results for the pre-resolved
+            sets, carried into weave telemetry for value parity.
 
     Returns:
         :class:`~weevr.engine.result.WeaveResult` with aggregate status and
@@ -241,17 +249,30 @@ def execute_weave(
             cached_lookup_dfs.update(new_cached)
 
         # Materialize column sets — resolve all defs into name→mapping dicts
-        resolved_column_sets: dict[str, dict[str, str]] | None = None
-        all_column_set_results: list[ColumnSetResult] = []
+        # Loom-resolved mappings arrive pre-resolved; only defs the parent
+        # did not settle (weave-declared sets and weave overrides of loom
+        # sets) materialize here — one resolution per def per scope lifetime
+        resolved_column_sets: dict[str, dict[str, str]] | None = (
+            dict(pre_resolved_column_sets) if pre_resolved_column_sets else None
+        )
+        all_column_set_results: list[ColumnSetResult] = list(pre_column_set_results or [])
         if column_set_defs:
-            resolved_column_sets, all_column_set_results = materialize_column_sets(
-                spark,
-                column_set_defs,
-                params or {},
-                collector=collector,
-                parent_span_id=weave_span_id,
-                connections=connections,
-            )
+            to_materialize = {
+                k: v
+                for k, v in column_set_defs.items()
+                if k not in (pre_resolved_column_sets or {})
+            }
+            if to_materialize:
+                weave_resolved, weave_cs_results = materialize_column_sets(
+                    spark,
+                    to_materialize,
+                    params or {},
+                    collector=collector,
+                    parent_span_id=weave_span_id,
+                    connections=connections,
+                )
+                resolved_column_sets = {**(resolved_column_sets or {}), **weave_resolved}
+                all_column_set_results.extend(weave_cs_results)
 
         for group_idx, group in enumerate(plan.execution_order):
             # Materialize lookups whose producers completed in prior groups.
@@ -668,6 +689,21 @@ def execute_loom(
                 parent_span_id=loom_span_id,
             )
 
+        # Resolve loom-level column sets ONCE (shared across all weaves);
+        # per-weave passes hand down the resolved mappings, excluding keys
+        # a weave overrides so precedence still re-resolves those
+        loom_resolved_cs: dict[str, dict[str, str]] = {}
+        loom_cs_results: list[ColumnSetResult] = []
+        if loom.column_sets:
+            loom_resolved_cs, loom_cs_results = materialize_column_sets(
+                spark,
+                dict(loom.column_sets),
+                params or {},
+                collector=collector,
+                parent_span_id=loom_span_id,
+                connections=dict(loom.connections) if loom.connections else None,
+            )
+
         # Materialize loom-level lookups (shared across all weaves)
         loom_lookup_results: list[LookupResult] = []
         loom_connections = dict(loom.connections) if loom.connections else None
@@ -777,6 +813,14 @@ def execute_loom(
                     weave_name=weave_name,
                     column_set_defs=merged_column_set_defs,
                     pre_lookup_meta=build_lookup_meta(loom_lookup_results) or None,
+                    pre_resolved_column_sets={
+                        k: v for k, v in loom_resolved_cs.items() if k not in (weave_cs or {})
+                    }
+                    or None,
+                    pre_column_set_results=[
+                        r for r in loom_cs_results if r.name not in (weave_cs or {})
+                    ]
+                    or None,
                     pre_cached_lookups=loom_cached_lookup_dfs or None,
                     connections=merged_connections or None,
                     execution=effective_execution,

--- a/packages/weevr/src/weevr/engine/target_identity.py
+++ b/packages/weevr/src/weevr/engine/target_identity.py
@@ -1,0 +1,75 @@
+"""Canonical target identity — one key per physical table.
+
+Cache registration and consumption must agree on what "the same target"
+means across the three declaration forms (alias, path, connection+table).
+This resolver normalizes each form to one canonical string:
+
+- ``connection`` + ``table`` → the abfss:// path the connection resolves
+  to (the same resolution the readers and the executor perform inline
+  today).
+- metastore alias (``schema.table``) → the table's storage location from
+  the catalog — a driver-side metadata query, no Spark jobs. Falls back
+  to the lowercased alias when the location cannot be read; alias-form
+  producers and consumers still meet on that fallback key.
+- filesystem path → FUSE-translated, trailing-slash-normalized.
+
+Consumers treat any resolution failure as "no identity": a cache miss,
+never an error.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from pyspark.sql import SparkSession
+
+from weevr.config.paths import resolve_connection_path, resolve_fuse_path
+from weevr.delta import is_table_alias
+from weevr.model.connection import OneLakeConnection
+
+logger = logging.getLogger(__name__)
+
+
+def _normalize_path(path: str, spark: SparkSession) -> str:
+    return resolve_fuse_path(path, spark).rstrip("/")
+
+
+def _alias_location(alias: str, spark: SparkSession) -> str | None:
+    """Storage location of a metastore table, or None when unreadable."""
+    try:
+        rows = spark.sql(f"DESCRIBE DETAIL {alias}").select("location").collect()
+        if rows and rows[0][0]:
+            return str(rows[0][0])
+    except Exception:
+        logger.debug("Could not resolve location for alias '%s'", alias, exc_info=True)
+    return None
+
+
+def resolve_target_identity(
+    spark: SparkSession,
+    *,
+    alias: str | None = None,
+    path: str | None = None,
+    connection: str | None = None,
+    table: str | None = None,
+    schema_override: str | None = None,
+    connections: dict[str, OneLakeConnection] | None = None,
+) -> str | None:
+    """Canonical identity for a target reference, or None when unresolvable.
+
+    Exactly one declaration form is expected (the model validators enforce
+    this upstream); precedence mirrors the executor's resolution order.
+    """
+    if connection:
+        try:
+            location = resolve_connection_path(connection, table, schema_override, connections)
+        except ValueError:
+            return None
+        return _normalize_path(location, spark)
+    ref = alias or path
+    if not ref:
+        return None
+    if is_table_alias(ref):
+        location = _alias_location(ref, spark)
+        return _normalize_path(location, spark) if location else ref.lower()
+    return _normalize_path(ref, spark)

--- a/packages/weevr/src/weevr/engine/target_identity.py
+++ b/packages/weevr/src/weevr/engine/target_identity.py
@@ -9,9 +9,14 @@ This resolver normalizes each form to one canonical string:
   today).
 - metastore alias (``schema.table``) → the table's storage location from
   the catalog — a driver-side metadata query, no Spark jobs. Falls back
-  to the lowercased alias when the location cannot be read; alias-form
-  producers and consumers still meet on that fallback key.
+  to a namespaced lowercased-alias key (``alias:…``) when the location
+  cannot be read; alias-form producers and consumers still meet on that
+  fallback key, and it can never collide with a location-derived key.
 - filesystem path → FUSE-translated, trailing-slash-normalized.
+  Normalization is deliberately shallow — equivalent hand-authored
+  spellings (double slashes, ``..`` segments, case variants on
+  case-insensitive filesystems) are distinct keys; a mismatch costs a
+  cache miss, never a wrong hit.
 
 Consumers treat any resolution failure as "no identity": a cache miss,
 never an error.
@@ -35,9 +40,16 @@ def _normalize_path(path: str, spark: SparkSession) -> str:
 
 
 def _alias_location(alias: str, spark: SparkSession) -> str | None:
-    """Storage location of a metastore table, or None when unreadable."""
+    """Storage location of a metastore table, or None when unreadable.
+
+    Uses the parameterized DeltaTable API rather than interpolated SQL —
+    the alias is config-supplied text and must never be spliced into a
+    statement.
+    """
     try:
-        rows = spark.sql(f"DESCRIBE DETAIL {alias}").select("location").collect()
+        from delta.tables import DeltaTable
+
+        rows = DeltaTable.forName(spark, alias).detail().select("location").collect()
         if rows and rows[0][0]:
             return str(rows[0][0])
     except Exception:
@@ -71,5 +83,8 @@ def resolve_target_identity(
         return None
     if is_table_alias(ref):
         location = _alias_location(ref, spark)
-        return _normalize_path(location, spark) if location else ref.lower()
+        # The fallback lives in its own key namespace: an unresolved alias
+        # must never collide with a location-derived key (two DIFFERENT
+        # tables whose aliases differ only by case would otherwise merge)
+        return _normalize_path(location, spark) if location else f"alias:{ref.lower()}"
     return _normalize_path(ref, spark)

--- a/packages/weevr/src/weevr/operations/readers.py
+++ b/packages/weevr/src/weevr/operations/readers.py
@@ -89,16 +89,17 @@ def _read_raw(
     """Read source data without applying deduplication."""
     # Connection-based read: resolve to an abfss:// path via the named connection.
     if source.connection:
-        if not connections or source.connection not in connections:
+        from weevr.config.paths import resolve_connection_path
+
+        try:
+            path = resolve_connection_path(
+                source.connection, source.table, source.schema_override, connections
+            )
+        except ValueError as exc:
             raise ExecutionError(
                 f"Source references undefined connection '{source.connection}'",
                 source_name=source.connection,
-            )
-        from weevr.config.paths import build_onelake_path
-
-        conn = connections[source.connection]
-        assert source.table is not None  # guaranteed by Source validator
-        path = build_onelake_path(conn, source.schema_override, source.table)
+            ) from exc
         return spark.read.format("delta").load(path)
 
     if source.type == "delta":

--- a/packages/weevr/src/weevr/operations/readers.py
+++ b/packages/weevr/src/weevr/operations/readers.py
@@ -61,6 +61,17 @@ def read_source(
         ) from exc
 
 
+def apply_source_dedup(df: DataFrame, source: Source) -> DataFrame:
+    """Apply a source's dedup configuration to an already-read DataFrame.
+
+    Registry-served snapshots go through the same post-read semantics a
+    direct :func:`read_source` would apply.
+    """
+    if source.dedup is not None:
+        return _apply_dedup(df, source.dedup)
+    return df
+
+
 def read_sources(
     spark: SparkSession,
     sources: dict[str, Source],

--- a/tests/weevr/engine/test_cache_manager.py
+++ b/tests/weevr/engine/test_cache_manager.py
@@ -147,3 +147,120 @@ class TestRegistryThroughWeave:
         result = execute_weave(spark, plan, {"solo": t})
         assert result.status == "success"
         assert spark.read.format("delta").load(out).count() == 1
+
+
+@pytest.mark.spark
+class TestConnectionFormRegistry:
+    """Connection-declared cache targets persist AND serve (the latent gap)."""
+
+    def test_connection_target_registers_resolvable_identity(
+        self, spark: SparkSession, tmp_delta_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The runner's registration path resolves a connection-form target
+        # to a canonical identity — previously `alias or path` yielded None
+        # and the entry was silently unfetchable
+        import weevr.engine.runner as runner_mod
+
+        registrations: list[tuple[str, str | None]] = []
+
+        def _persist_spy(self, thread_name, spark_arg, target_path, identity=None):  # type: ignore[no-untyped-def]
+            registrations.append((thread_name, identity))
+            # Skip the actual read: abfss:// is unreachable in tests — the
+            # registration IDENTITY is what this locks
+
+        monkeypatch.setattr(runner_mod.CacheManager, "persist", _persist_spy)
+
+        def _fake_execute_thread(spark_arg, thread, **kwargs):  # type: ignore[no-untyped-def]
+            from weevr.engine.result import ThreadResult
+
+            return ThreadResult(
+                status="success",
+                thread_name=thread.name,
+                rows_written=1,
+                write_mode="overwrite",
+                target_path="unused",
+            )
+
+        monkeypatch.setattr(runner_mod, "execute_thread", _fake_execute_thread)
+
+        conn = {"lake": {"type": "onelake", "workspace": "w", "lakehouse": "l"}}
+        producer = Thread.model_validate(
+            {
+                "name": "producer",
+                "config_version": "1",
+                "sources": {"main": {"type": "delta", "alias": "raw.x"}},
+                "steps": [],
+                "target": {"connection": "lake", "table": "shared"},
+                "connections": conn,
+            }
+        )
+
+        def _consumer(name: str) -> Thread:
+            return Thread.model_validate(
+                {
+                    "name": name,
+                    "config_version": "1",
+                    "sources": {"main": {"connection": "lake", "table": "shared"}},
+                    "steps": [],
+                    "target": {"path": f"/tmp/{name}"},
+                    "connections": conn,
+                }
+            )
+
+        threads = {
+            "producer": producer,
+            "c1": _consumer("c1"),
+            "c2": _consumer("c2"),
+        }
+        plan = build_plan(
+            "conn_weave",
+            threads,
+            [ThreadEntry(name="producer"), ThreadEntry(name="c1"), ThreadEntry(name="c2")],
+        )
+        assert plan.cache_targets == ["producer"]  # planner sees connection form
+
+        result = execute_weave(spark, plan, threads)
+        assert result.status == "success"
+        assert len(registrations) == 1
+        name, identity = registrations[0]
+        assert name == "producer"
+        assert identity is not None and identity.startswith("abfss://")
+        assert identity.endswith("shared")
+
+    def test_connection_declared_source_served_from_registry(
+        self, spark: SparkSession, tmp_delta_path
+    ) -> None:
+        # Consumer side: a connection-declared source whose identity matches
+        # a registered entry is served the snapshot (with dedup applied)
+        from weevr.engine.cache_manager import CacheManager
+        from weevr.engine.executor import _read_source_via_registry
+        from weevr.engine.target_identity import resolve_target_identity
+        from weevr.model.connection import OneLakeConnection
+        from weevr.model.source import Source
+
+        conns = {"lake": OneLakeConnection(type="onelake", workspace="w", lakehouse="l")}
+        source = Source.model_validate(
+            {
+                "connection": "lake",
+                "table": "shared",
+                "dedup": {"keys": ["id"]},
+            }
+        )
+        identity = resolve_target_identity(
+            spark, connection="lake", table="shared", connections=conns
+        )
+        assert identity is not None
+
+        # Register a snapshot under that identity (backing table is local)
+        path = tmp_delta_path("connreg_tbl")
+        spark.createDataFrame(
+            [{"id": 1, "v": "a"}, {"id": 1, "v": "b"}, {"id": 2, "v": "c"}]
+        ).write.format("delta").save(path)
+        cache = CacheManager(["producer"], {"producer": ["c"]})
+        cache.persist("producer", spark, path, identity=identity)
+        try:
+            served = _read_source_via_registry(spark, "main", source, conns, cache)
+            # Served from the registry — and the source's dedup applied
+            assert served.count() == 2
+        finally:
+            cache.cleanup()

--- a/tests/weevr/engine/test_cache_manager.py
+++ b/tests/weevr/engine/test_cache_manager.py
@@ -77,7 +77,7 @@ class TestRegistryThroughWeave:
         # Producer writes shared; consumer declares it as a source. The
         # consumer's read must be served from the registry — read_source is
         # never called for that alias.
-        import weevr.engine.executor as executor_mod
+        from weevr.engine import executor as executor_mod
 
         src = tmp_delta_path("cmw_src")
         shared = tmp_delta_path("cmw_shared")
@@ -159,7 +159,7 @@ class TestConnectionFormRegistry:
         # The runner's registration path resolves a connection-form target
         # to a canonical identity — previously `alias or path` yielded None
         # and the entry was silently unfetchable
-        import weevr.engine.runner as runner_mod
+        from weevr.engine import runner as runner_mod
 
         registrations: list[tuple[str, str | None]] = []
 

--- a/tests/weevr/engine/test_cache_manager.py
+++ b/tests/weevr/engine/test_cache_manager.py
@@ -1,0 +1,149 @@
+"""Explicit cache registry: deterministic consumption, non-fatal misses."""
+
+from typing import Any
+
+import pytest
+from pyspark.sql import SparkSession
+
+from weevr.engine.cache_manager import CacheManager
+from weevr.engine.planner import build_plan
+from weevr.engine.runner import execute_weave
+from weevr.model.thread import Thread
+from weevr.model.weave import ThreadEntry
+
+pytestmark = pytest.mark.spark
+
+
+def _thread(name: str, src: str, tgt: str, *, depends: list[str] | None = None) -> Thread:
+    cfg: dict[str, Any] = {
+        "name": name,
+        "config_version": "1",
+        "sources": {"main": {"type": "delta", "alias": src}},
+        "steps": [],
+        "target": {"path": tgt},
+        "write": {"mode": "overwrite"},
+    }
+    if depends:
+        cfg["depends_on"] = depends
+    return Thread.model_validate(cfg)
+
+
+class TestRegistryUnit:
+    def test_get_returns_registered_snapshot_and_misses_none(
+        self, spark: SparkSession, tmp_delta_path
+    ) -> None:
+        path = tmp_delta_path("cmreg_tbl")
+        spark.createDataFrame([{"id": 1}, {"id": 2}]).write.format("delta").save(path)
+
+        cache = CacheManager(["producer"], {"producer": ["consumer"]})
+        cache.persist("producer", spark, path, identity=path.rstrip("/"))
+
+        hit = cache.get(path.rstrip("/"))
+        assert hit is not None
+        assert hit.count() == 2
+        assert cache.get("something/else") is None
+        assert cache.get(None) is None
+        cache.cleanup()
+        assert cache.get(path.rstrip("/")) is None  # unpersist deregisters
+
+    def test_persist_materializes_eagerly(
+        self, spark: SparkSession, tmp_delta_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from pyspark.sql import DataFrame
+
+        path = tmp_delta_path("cmreg_eager")
+        spark.createDataFrame([{"id": 1}]).write.format("delta").save(path)
+
+        counts: list[int] = []
+        original = DataFrame.count
+
+        def _spy(inner_self):  # type: ignore[no-untyped-def]
+            counts.append(1)
+            return original(inner_self)
+
+        monkeypatch.setattr(DataFrame, "count", _spy)
+        cache = CacheManager(["p"], {"p": ["c"]})
+        cache.persist("p", spark, path, identity=path)
+        # One eager materialization at persist — consumers never race the
+        # cache compute
+        assert counts == [1]
+        cache.cleanup()
+
+
+class TestRegistryThroughWeave:
+    def test_consumer_served_from_registry_single_storage_read(
+        self, spark: SparkSession, tmp_delta_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Producer writes shared; consumer declares it as a source. The
+        # consumer's read must be served from the registry — read_source is
+        # never called for that alias.
+        import weevr.engine.executor as executor_mod
+
+        src = tmp_delta_path("cmw_src")
+        shared = tmp_delta_path("cmw_shared")
+        out = tmp_delta_path("cmw_out")
+        spark.createDataFrame([{"id": i} for i in range(5)]).write.format("delta").save(src)
+
+        reads: list[str] = []
+        original = executor_mod.read_source
+
+        def _spy(spark_arg, alias_arg, source_arg, connections=None):  # type: ignore[no-untyped-def]
+            reads.append(source_arg.alias or source_arg.path or "")
+            return original(spark_arg, alias_arg, source_arg, connections=connections)
+
+        monkeypatch.setattr(executor_mod, "read_source", _spy)
+
+        out2 = tmp_delta_path("cmw_out2")
+        producer = _thread("producer", src, shared)
+
+        def _consumer(name: str, tgt: str) -> Thread:
+            return Thread.model_validate(
+                {
+                    "name": name,
+                    "config_version": "1",
+                    "sources": {"main": {"type": "delta", "alias": shared}},
+                    "steps": [],
+                    "target": {"path": tgt},
+                    "write": {"mode": "overwrite"},
+                    "depends_on": ["producer"],
+                }
+            )
+
+        threads = {
+            "producer": producer,
+            "consumer_a": _consumer("consumer_a", out),
+            "consumer_b": _consumer("consumer_b", out2),
+        }
+        plan = build_plan(
+            "cmw_weave",
+            threads,
+            [
+                ThreadEntry(name="producer"),
+                ThreadEntry(name="consumer_a"),
+                ThreadEntry(name="consumer_b"),
+            ],
+        )
+        assert plan.cache_targets == ["producer"]  # >= 2 dependents
+
+        result = execute_weave(spark, plan, threads)
+        assert result.status == "success"
+        # NEITHER consumer read the shared table from storage — both were
+        # served the registered post-write snapshot
+        assert all(r != shared for r in reads)
+        assert spark.read.format("delta").load(out).count() == 5
+        assert spark.read.format("delta").load(out2).count() == 5
+
+    def test_registry_miss_falls_back_to_direct_read(
+        self, spark: SparkSession, tmp_delta_path
+    ) -> None:
+        # A consumer whose source is NOT any producer's target reads
+        # directly and succeeds — a miss is the fallback
+        src = tmp_delta_path("cmw_miss_src")
+        out = tmp_delta_path("cmw_miss_out")
+        spark.createDataFrame([{"id": 1}]).write.format("delta").save(src)
+
+        t = _thread("solo", src, out)
+        plan = build_plan("cmw_miss", {"solo": t}, [ThreadEntry(name="solo")])
+        result = execute_weave(spark, plan, {"solo": t})
+        assert result.status == "success"
+        assert spark.read.format("delta").load(out).count() == 1

--- a/tests/weevr/engine/test_column_sets.py
+++ b/tests/weevr/engine/test_column_sets.py
@@ -683,7 +683,7 @@ class TestResolveOncePerScope:
     @pytest.fixture()
     def materialize_spy(self, monkeypatch: pytest.MonkeyPatch) -> list[list[str]]:
         """Record the def-name sets each materialization call resolves."""
-        import weevr.engine.runner as runner_mod
+        from weevr.engine import runner as runner_mod
 
         calls: list[list[str]] = []
         original = runner_mod.materialize_column_sets

--- a/tests/weevr/engine/test_column_sets.py
+++ b/tests/weevr/engine/test_column_sets.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from pyspark.sql import SparkSession
 
 from weevr.engine.column_sets import materialize_column_sets, resolve_column_set
 from weevr.errors.exceptions import ConfigError, ExecutionError
@@ -673,3 +674,172 @@ class TestMaterializeColumnSets:
         assert resolved == {}
         assert results == []
         mock_read.assert_not_called()
+
+
+@pytest.mark.spark
+class TestResolveOncePerScope:
+    """Column sets resolve once per declaring scope; precedence unchanged."""
+
+    @pytest.fixture()
+    def materialize_spy(self, monkeypatch: pytest.MonkeyPatch) -> list[list[str]]:
+        """Record the def-name sets each materialization call resolves."""
+        import weevr.engine.runner as runner_mod
+
+        calls: list[list[str]] = []
+        original = runner_mod.materialize_column_sets
+
+        def _spy(spark_arg, defs, *args, **kwargs):  # type: ignore[no-untyped-def]
+            calls.append(sorted(defs))
+            return original(spark_arg, defs, *args, **kwargs)
+
+        monkeypatch.setattr(runner_mod, "materialize_column_sets", _spy)
+        return calls
+
+    def test_loom_set_resolves_once_across_weaves(
+        self, spark: SparkSession, tmp_path, materialize_spy: list[list[str]]
+    ) -> None:
+        from weevr.engine.runner import execute_loom
+        from weevr.model.loom import Loom
+        from weevr.model.thread import Thread
+        from weevr.model.weave import Weave
+
+        src = str(tmp_path / "rps_src")
+        spark.createDataFrame([{"from_a": 1}]).write.format("delta").save(src)
+
+        def _weave(name: str, tgt: str) -> Weave:
+            return Weave.model_validate(
+                {
+                    "name": name,
+                    "config_version": "1",
+                    "threads": [{"name": f"{name}_t"}],
+                }
+            )
+
+        def _thread(name: str, tgt: str) -> Thread:
+            return Thread.model_validate(
+                {
+                    "name": name,
+                    "config_version": "1",
+                    "sources": {"main": {"type": "delta", "alias": src}},
+                    "steps": [{"rename": {"column_set": "loomset"}}],
+                    "target": {"path": tgt},
+                    "write": {"mode": "overwrite"},
+                }
+            )
+
+        loom = Loom.model_validate(
+            {
+                "name": "rps_loom",
+                "config_version": "1",
+                "weaves": [{"name": "w1"}, {"name": "w2"}],
+                "column_sets": {"loomset": {"param": "cs_param"}},
+            }
+        )
+        weaves = {
+            "w1": _weave("w1", str(tmp_path / "t1")),
+            "w2": _weave("w2", str(tmp_path / "t2")),
+        }
+        threads = {
+            "w1": {"w1_t": _thread("w1_t", str(tmp_path / "t1"))},
+            "w2": {"w2_t": _thread("w2_t", str(tmp_path / "t2"))},
+        }
+        result = execute_loom(
+            spark,
+            loom,
+            weaves,
+            threads,
+            params={"cs_param": {"from_a": "to_a"}},
+        )
+        assert result.status == "success"
+        # The loom set materialized exactly once, at loom scope — neither
+        # weave re-resolved it
+        assert materialize_spy == [["loomset"]]
+        # Params-invariance: both weaves observed the SAME loom-resolved
+        # mapping (params flow as one unchanged object loom→weave→thread)
+        cols1 = spark.read.format("delta").load(str(tmp_path / "t1")).columns
+        cols2 = spark.read.format("delta").load(str(tmp_path / "t2")).columns
+        assert "to_a" in cols1 and "to_a" in cols2
+
+    def test_weave_override_still_wins(
+        self, spark: SparkSession, tmp_path, materialize_spy: list[list[str]]
+    ) -> None:
+        from weevr.engine.planner import build_plan
+        from weevr.engine.runner import execute_weave
+        from weevr.model.thread import Thread
+        from weevr.model.weave import ThreadEntry
+
+        src = str(tmp_path / "rps_ov_src")
+        tgt = str(tmp_path / "rps_ov_tgt")
+        spark.createDataFrame([{"src_col": 1}]).write.format("delta").save(src)
+
+        thread = Thread.model_validate(
+            {
+                "name": "ov_t",
+                "config_version": "1",
+                "sources": {"main": {"type": "delta", "alias": src}},
+                "steps": [{"rename": {"column_set": "shared"}}],
+                "target": {"path": tgt},
+                "write": {"mode": "overwrite"},
+            }
+        )
+        threads = {"ov_t": thread}
+        plan = build_plan("rps_ov", threads, [ThreadEntry(name="ov_t")])
+
+        from weevr.model.column_set import ColumnSet
+
+        weave_def = ColumnSet(param="weave_map")  # type: ignore[arg-type]
+        # Loom pre-resolved a DIFFERENT mapping under the same name; the
+        # caller (execute_loom) excludes overridden keys, so here the weave
+        # def must be the one that materializes
+        result = execute_weave(
+            spark,
+            plan,
+            threads,
+            column_set_defs={"shared": weave_def},
+            params={"weave_map": {"src_col": "renamed_by_weave"}},
+            pre_resolved_column_sets=None,
+            pre_column_set_results=None,
+        )
+        assert result.status == "success"
+        out_cols = spark.read.format("delta").load(tgt).columns
+        assert "renamed_by_weave" in out_cols  # weave mapping applied
+        assert materialize_spy == [["shared"]]
+
+    def test_pre_resolved_sets_skip_weave_materialization(
+        self, spark: SparkSession, tmp_path, materialize_spy: list[list[str]]
+    ) -> None:
+        from weevr.engine.planner import build_plan
+        from weevr.engine.runner import execute_weave
+        from weevr.model.column_set import ColumnSet
+        from weevr.model.thread import Thread
+        from weevr.model.weave import ThreadEntry
+
+        src = str(tmp_path / "rps_pre_src")
+        tgt = str(tmp_path / "rps_pre_tgt")
+        spark.createDataFrame([{"src_col": 1}]).write.format("delta").save(src)
+
+        thread = Thread.model_validate(
+            {
+                "name": "pre_t",
+                "config_version": "1",
+                "sources": {"main": {"type": "delta", "alias": src}},
+                "steps": [{"rename": {"column_set": "loomset"}}],
+                "target": {"path": tgt},
+                "write": {"mode": "overwrite"},
+            }
+        )
+        threads = {"pre_t": thread}
+        plan = build_plan("rps_pre", threads, [ThreadEntry(name="pre_t")])
+
+        loom_def = ColumnSet(param="unused")  # type: ignore[arg-type]
+        result = execute_weave(
+            spark,
+            plan,
+            threads,
+            column_set_defs={"loomset": loom_def},
+            pre_resolved_column_sets={"loomset": {"src_col": "renamed_by_loom"}},
+        )
+        assert result.status == "success"
+        out_cols = spark.read.format("delta").load(tgt).columns
+        assert "renamed_by_loom" in out_cols  # pre-resolved mapping served
+        assert materialize_spy == []  # nothing re-resolved at weave scope

--- a/tests/weevr/engine/test_lookups.py
+++ b/tests/weevr/engine/test_lookups.py
@@ -1,5 +1,6 @@
 """Tests for lookup materializer."""
 
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -7,6 +8,7 @@ from pyspark.sql import SparkSession
 
 from weevr.engine.lookups import (
     LookupResult,
+    UniqueKeyMemo,
     _apply_narrow_pipeline,
     _check_unique_key,
     _validate_columns,
@@ -645,7 +647,6 @@ class TestSingleReadMaterialization:
         # The check must run against the CACHE: spy on _check_unique_key's
         # input — after the fix it receives a persisted frame
         from weevr.engine import lookups as lookups_mod
-        from weevr.model.lookup import Lookup
 
         path = tmp_delta_path("srm_dim")
         spark.createDataFrame([{"code": "A", "sk": 1}, {"code": "B", "sk": 2}]).write.format(
@@ -681,9 +682,6 @@ class TestSingleReadMaterialization:
     def test_broadcast_strategy_persists_and_hints(
         self, spark: SparkSession, tmp_delta_path
     ) -> None:
-        from typing import Any
-
-        from weevr.model.lookup import Lookup
 
         path = tmp_delta_path("srm_bc")
         spark.createDataFrame([{"code": "A", "sk": 1}]).write.format("delta").save(path)
@@ -708,8 +706,6 @@ class TestSingleReadMaterialization:
             cleanup_lookups(cached)
 
     def test_on_demand_path_never_persists(self, spark: SparkSession, tmp_delta_path) -> None:
-        from weevr.model.lookup import Lookup
-        from weevr.model.source import Source
 
         path = tmp_delta_path("srm_od")
         spark.createDataFrame([{"code": "A", "sk": 1}]).write.format("delta").save(path)
@@ -764,8 +760,6 @@ class TestUniqueKeyMemo:
     ) -> None:
         from concurrent.futures import ThreadPoolExecutor as PoolExecutor
 
-        from weevr.engine.lookups import UniqueKeyMemo
-
         path = tmp_delta_path("ukm_dim")
         spark.createDataFrame([{"code": "A", "sk": 1}, {"code": "B", "sk": 2}]).write.format(
             "delta"
@@ -787,8 +781,6 @@ class TestUniqueKeyMemo:
     def test_memoized_abort_raises_for_every_consumer(
         self, spark: SparkSession, tmp_delta_path, check_spy: list[str]
     ) -> None:
-        from weevr.engine.lookups import UniqueKeyMemo
-
         path = tmp_delta_path("ukm_dup")
         spark.createDataFrame([{"code": "A", "sk": 1}, {"code": "A", "sk": 2}]).write.format(
             "delta"
@@ -809,8 +801,6 @@ class TestUniqueKeyMemo:
     def test_warn_outcome_memoized(
         self, spark: SparkSession, tmp_delta_path, check_spy: list[str]
     ) -> None:
-        from weevr.engine.lookups import UniqueKeyMemo
-
         path = tmp_delta_path("ukm_warn")
         spark.createDataFrame([{"code": "A", "sk": 1}, {"code": "A", "sk": 2}]).write.format(
             "delta"
@@ -828,8 +818,6 @@ class TestUniqueKeyMemo:
     def test_fresh_memo_revalidates_next_weave(
         self, spark: SparkSession, tmp_delta_path, check_spy: list[str]
     ) -> None:
-        from weevr.engine.lookups import UniqueKeyMemo
-
         path = tmp_delta_path("ukm_scope")
         spark.createDataFrame([{"code": "A", "sk": 1}]).write.format("delta").save(path)
 

--- a/tests/weevr/engine/test_lookups.py
+++ b/tests/weevr/engine/test_lookups.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from pyspark.sql import SparkSession
 
 from weevr.engine.lookups import (
     LookupResult,
@@ -632,3 +633,97 @@ class TestConnectionPassthrough:
         mock_read.assert_called_once()
         _, kwargs = mock_read.call_args
         assert kwargs.get("connections") is None
+
+
+@pytest.mark.spark
+class TestSingleReadMaterialization:
+    """Materialized lookups read their source exactly once end-to-end."""
+
+    def test_unique_key_lookup_single_source_read(
+        self, spark: SparkSession, tmp_delta_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The check must run against the CACHE: spy on _check_unique_key's
+        # input — after the fix it receives a persisted frame
+        from weevr.engine import lookups as lookups_mod
+        from weevr.model.lookup import Lookup
+
+        path = tmp_delta_path("srm_dim")
+        spark.createDataFrame([{"code": "A", "sk": 1}, {"code": "B", "sk": 2}]).write.format(
+            "delta"
+        ).save(path)
+
+        checked_persisted: list[bool] = []
+        original = lookups_mod._check_unique_key
+
+        def _spy(df, key_columns, name, on_failure):  # type: ignore[no-untyped-def]
+            checked_persisted.append(df.storageLevel.useMemory or df.storageLevel.useDisk)
+            return original(df, key_columns, name, on_failure)
+
+        monkeypatch.setattr(lookups_mod, "_check_unique_key", _spy)
+
+        lookup = Lookup.model_validate(
+            {
+                "source": {"type": "delta", "alias": path},
+                "materialize": True,
+                "key": ["code"],
+                "unique_key": True,
+            }
+        )
+        cached, results = materialize_lookups(spark, {"dim": lookup})
+        try:
+            assert checked_persisted == [True]  # check ran on the cached frame
+            assert results[0].unique_key_checked is True
+            assert results[0].unique_key_passed is True
+            assert results[0].row_count == 2
+        finally:
+            cleanup_lookups(cached)
+
+    def test_broadcast_strategy_persists_and_hints(
+        self, spark: SparkSession, tmp_delta_path
+    ) -> None:
+        from typing import Any
+
+        from weevr.model.lookup import Lookup
+
+        path = tmp_delta_path("srm_bc")
+        spark.createDataFrame([{"code": "A", "sk": 1}]).write.format("delta").save(path)
+
+        lookup = Lookup.model_validate(
+            {
+                "source": {"type": "delta", "alias": path},
+                "materialize": True,
+                "strategy": "broadcast",
+            }
+        )
+        cached, results = materialize_lookups(spark, {"dim": lookup})
+        try:
+            df = cached["dim"]
+            # Persisted (cache-resident)…
+            assert df.storageLevel.useMemory or df.storageLevel.useDisk
+            # …AND hinted — the two compose
+            jdf: Any = df._jdf
+            assert "broadcast" in str(jdf.queryExecution().analyzed()).lower()
+            assert results[0].strategy == "broadcast"
+        finally:
+            cleanup_lookups(cached)
+
+    def test_on_demand_path_never_persists(self, spark: SparkSession, tmp_delta_path) -> None:
+        from weevr.model.lookup import Lookup
+        from weevr.model.source import Source
+
+        path = tmp_delta_path("srm_od")
+        spark.createDataFrame([{"code": "A", "sk": 1}]).write.format("delta").save(path)
+
+        lookup = Lookup.model_validate(
+            {
+                "source": {"type": "delta", "alias": path},
+                "materialize": False,
+                "key": ["code"],
+                "unique_key": True,
+            }
+        )
+        sources = {"dim_src": Source(lookup="dim")}
+        resolved = resolve_thread_lookups(sources, {"dim": lookup}, {}, spark)
+        df = resolved["dim_src"]
+        # Single-use path: no persist, no orphaned cache entries
+        assert not (df.storageLevel.useMemory or df.storageLevel.useDisk)

--- a/tests/weevr/engine/test_lookups.py
+++ b/tests/weevr/engine/test_lookups.py
@@ -727,3 +727,115 @@ class TestSingleReadMaterialization:
         df = resolved["dim_src"]
         # Single-use path: no persist, no orphaned cache entries
         assert not (df.storageLevel.useMemory or df.storageLevel.useDisk)
+
+
+@pytest.mark.spark
+class TestUniqueKeyMemo:
+    """Non-materialized unique_key lookups validate exactly once per weave."""
+
+    @pytest.fixture()
+    def check_spy(self, monkeypatch: pytest.MonkeyPatch) -> list[str]:
+        from weevr.engine import lookups as lookups_mod
+
+        calls: list[str] = []
+        original = lookups_mod._check_unique_key
+
+        def _spy(df, key_columns, name, on_failure):  # type: ignore[no-untyped-def]
+            calls.append(name)
+            return original(df, key_columns, name, on_failure)
+
+        monkeypatch.setattr(lookups_mod, "_check_unique_key", _spy)
+        return calls
+
+    @staticmethod
+    def _lookup(path: str, *, on_failure: str = "abort") -> Lookup:
+        return Lookup.model_validate(
+            {
+                "source": {"type": "delta", "alias": path},
+                "materialize": False,
+                "key": ["code"],
+                "unique_key": True,
+                "on_failure": on_failure,
+            }
+        )
+
+    def test_concurrent_consumers_validate_once(
+        self, spark: SparkSession, tmp_delta_path, check_spy: list[str]
+    ) -> None:
+        from concurrent.futures import ThreadPoolExecutor as PoolExecutor
+
+        from weevr.engine.lookups import UniqueKeyMemo
+
+        path = tmp_delta_path("ukm_dim")
+        spark.createDataFrame([{"code": "A", "sk": 1}, {"code": "B", "sk": 2}]).write.format(
+            "delta"
+        ).save(path)
+
+        memo = UniqueKeyMemo()
+        sources = {"dim_src": Source(lookup="dim")}
+        lookups = {"dim": self._lookup(path)}
+
+        def _consume(_: int):  # type: ignore[no-untyped-def]
+            return resolve_thread_lookups(sources, lookups, {}, spark, uk_memo=memo)
+
+        with PoolExecutor(max_workers=4) as pool:
+            results = list(pool.map(_consume, range(4)))
+
+        assert len(results) == 4
+        assert check_spy == ["dim"]  # exactly one validation across the race
+
+    def test_memoized_abort_raises_for_every_consumer(
+        self, spark: SparkSession, tmp_delta_path, check_spy: list[str]
+    ) -> None:
+        from weevr.engine.lookups import UniqueKeyMemo
+
+        path = tmp_delta_path("ukm_dup")
+        spark.createDataFrame([{"code": "A", "sk": 1}, {"code": "A", "sk": 2}]).write.format(
+            "delta"
+        ).save(path)
+
+        memo = UniqueKeyMemo()
+        sources = {"dim_src": Source(lookup="dim")}
+        lookups = {"dim": self._lookup(path, on_failure="abort")}
+
+        with pytest.raises(LookupResolutionError):
+            resolve_thread_lookups(sources, lookups, {}, spark, uk_memo=memo)
+        # Second consumer reuses the memoized failure — same outcome, no
+        # second scan
+        with pytest.raises(LookupResolutionError):
+            resolve_thread_lookups(sources, lookups, {}, spark, uk_memo=memo)
+        assert check_spy == ["dim"]
+
+    def test_warn_outcome_memoized(
+        self, spark: SparkSession, tmp_delta_path, check_spy: list[str]
+    ) -> None:
+        from weevr.engine.lookups import UniqueKeyMemo
+
+        path = tmp_delta_path("ukm_warn")
+        spark.createDataFrame([{"code": "A", "sk": 1}, {"code": "A", "sk": 2}]).write.format(
+            "delta"
+        ).save(path)
+
+        memo = UniqueKeyMemo()
+        sources = {"dim_src": Source(lookup="dim")}
+        lookups = {"dim": self._lookup(path, on_failure="warn")}
+
+        r1 = resolve_thread_lookups(sources, lookups, {}, spark, uk_memo=memo)
+        r2 = resolve_thread_lookups(sources, lookups, {}, spark, uk_memo=memo)
+        assert "dim_src" in r1 and "dim_src" in r2
+        assert check_spy == ["dim"]  # warn validated once, both proceed
+
+    def test_fresh_memo_revalidates_next_weave(
+        self, spark: SparkSession, tmp_delta_path, check_spy: list[str]
+    ) -> None:
+        from weevr.engine.lookups import UniqueKeyMemo
+
+        path = tmp_delta_path("ukm_scope")
+        spark.createDataFrame([{"code": "A", "sk": 1}]).write.format("delta").save(path)
+
+        sources = {"dim_src": Source(lookup="dim")}
+        lookups = {"dim": self._lookup(path)}
+        resolve_thread_lookups(sources, lookups, {}, spark, uk_memo=UniqueKeyMemo())
+        resolve_thread_lookups(sources, lookups, {}, spark, uk_memo=UniqueKeyMemo())
+        # A new weave's memo carries nothing over
+        assert check_spy == ["dim", "dim"]

--- a/tests/weevr/engine/test_planner.py
+++ b/tests/weevr/engine/test_planner.py
@@ -770,3 +770,78 @@ class TestExecutionPlanDisplay:
         # Thread names appear in the HTML
         assert ">a<" in html_out
         assert ">b<" in html_out
+
+
+class TestConnectionFormIdentity:
+    """Connection-declared targets/sources join dependency + conflict analysis."""
+
+    _CONN = {
+        "lake": {
+            "type": "onelake",
+            "workspace": "ws-guid",
+            "lakehouse": "lh-guid",
+        }
+    }
+
+    def _producer(self) -> Thread:
+        return Thread.model_validate(
+            {
+                "name": "producer",
+                "config_version": "1.0",
+                "sources": {"main": {"type": "delta", "alias": "raw.orders"}},
+                "steps": [],
+                "target": {"connection": "lake", "table": "shared_dim"},
+                "connections": self._CONN,
+            }
+        )
+
+    def test_connection_reader_depends_on_connection_writer(self):
+        consumer = Thread.model_validate(
+            {
+                "name": "consumer",
+                "config_version": "1.0",
+                "sources": {"main": {"connection": "lake", "table": "shared_dim"}},
+                "steps": [],
+                "target": {"path": "/tmp/out"},
+                "connections": self._CONN,
+            }
+        )
+        threads = {"producer": self._producer(), "consumer": consumer}
+        plan = build_plan("w", threads, _entries("producer", "consumer"))
+        assert "producer" in plan.dependencies["consumer"]
+        # Sequential groups: the reader never shares a group with its writer
+        producer_group = next(i for i, g in enumerate(plan.execution_order) if "producer" in g)
+        consumer_group = next(i for i, g in enumerate(plan.execution_order) if "consumer" in g)
+        assert consumer_group > producer_group
+
+    def test_two_connection_writers_same_table_rejected(self):
+        writer_b = Thread.model_validate(
+            {
+                "name": "writer_b",
+                "config_version": "1.0",
+                "sources": {"main": {"type": "delta", "alias": "raw.other"}},
+                "steps": [],
+                "target": {"connection": "lake", "table": "shared_dim"},
+                "connections": self._CONN,
+            }
+        )
+        threads = {"producer": self._producer(), "writer_b": writer_b}
+        with pytest.raises(ConfigError):
+            build_plan("w", threads, _entries("producer", "writer_b"))
+
+    def test_path_reader_of_connection_writer_gets_edge(self):
+        # A consumer declaring the literal abfss URI meets the connection
+        # writer on the same normalized identity
+        abfss = "abfss://ws-guid@onelake.dfs.fabric.microsoft.com/lh-guid/Tables/shared_dim"
+        consumer = Thread.model_validate(
+            {
+                "name": "consumer",
+                "config_version": "1.0",
+                "sources": {"main": {"type": "delta", "alias": abfss}},
+                "steps": [],
+                "target": {"path": "/tmp/out2"},
+            }
+        )
+        threads = {"producer": self._producer(), "consumer": consumer}
+        plan = build_plan("w", threads, _entries("producer", "consumer"))
+        assert "producer" in plan.dependencies["consumer"]

--- a/tests/weevr/engine/test_target_identity.py
+++ b/tests/weevr/engine/test_target_identity.py
@@ -1,0 +1,52 @@
+"""Canonical target identity across the three declaration forms."""
+
+import pytest
+from pyspark.sql import SparkSession
+
+from weevr.engine.target_identity import resolve_target_identity
+from weevr.model.connection import OneLakeConnection
+
+pytestmark = pytest.mark.spark
+
+
+class TestIdentityEquality:
+    def test_path_and_trailing_slash_agree(self, spark: SparkSession, tmp_path) -> None:
+        p = str(tmp_path / "tid_tbl")
+        a = resolve_target_identity(spark, path=p)
+        b = resolve_target_identity(spark, path=p + "/")
+        assert a == b
+
+    def test_alias_and_path_agree_on_location(self, spark: SparkSession, tmp_path) -> None:
+        p = str(tmp_path / "tid_alias_tbl")
+        spark.createDataFrame([{"id": 1}]).write.format("delta").save(p)
+        spark.sql(f"CREATE TABLE IF NOT EXISTS tid_alias USING DELTA LOCATION '{p}'")
+        try:
+            by_alias = resolve_target_identity(spark, alias="tid_alias")
+            by_path = resolve_target_identity(spark, path=p)
+            assert by_alias is not None and by_path is not None
+            # Alias resolves to the catalog location; both keys name one table
+            assert by_alias.rstrip("/").endswith(by_path.rsplit("/", 1)[-1])
+            assert by_alias == resolve_target_identity(spark, alias="TID_ALIAS") or (
+                by_alias == by_path
+            )
+        finally:
+            spark.sql("DROP TABLE IF EXISTS tid_alias")
+
+    def test_connection_form_matches_its_path(self, spark: SparkSession) -> None:
+        conn = OneLakeConnection(
+            type="onelake", workspace="ws-guid", lakehouse="lh-guid", default_schema="dbo"
+        )
+        ident = resolve_target_identity(
+            spark,
+            connection="main_lake",
+            table="dim_customer",
+            schema_override=None,
+            connections={"main_lake": conn},
+        )
+        assert ident is not None
+        assert ident.startswith("abfss://")
+        assert ident.endswith("dim_customer")
+
+    def test_unresolvable_returns_none(self, spark: SparkSession) -> None:
+        assert resolve_target_identity(spark, connection="ghost", table="t") is None
+        assert resolve_target_identity(spark) is None

--- a/tests/weevr/engine/test_target_identity.py
+++ b/tests/weevr/engine/test_target_identity.py
@@ -26,9 +26,10 @@ class TestIdentityEquality:
             assert by_alias is not None and by_path is not None
             # Alias resolves to the catalog location; both keys name one table
             assert by_alias.rstrip("/").endswith(by_path.rsplit("/", 1)[-1])
-            assert by_alias == resolve_target_identity(spark, alias="TID_ALIAS") or (
-                by_alias == by_path
-            )
+            # Case-variant references to the SAME table meet on one key
+            # (the metastore is case-insensitive, so both resolve to the
+            # same location)
+            assert by_alias == resolve_target_identity(spark, alias="TID_ALIAS")
         finally:
             spark.sql("DROP TABLE IF EXISTS tid_alias")
 
@@ -50,3 +51,14 @@ class TestIdentityEquality:
     def test_unresolvable_returns_none(self, spark: SparkSession) -> None:
         assert resolve_target_identity(spark, connection="ghost", table="t") is None
         assert resolve_target_identity(spark) is None
+
+
+class TestFallbackNamespace:
+    def test_unresolved_alias_fallback_cannot_collide_with_locations(
+        self, spark: SparkSession
+    ) -> None:
+        # No such table: the fallback key carries the alias: namespace so it
+        # can never equal any location-derived key
+        ident = resolve_target_identity(spark, alias="ghost.schema_table")
+        assert ident == "alias:ghost.schema_table"
+        assert not ident.startswith("/") and "://" not in ident

--- a/tests/weevr/engine/test_warp_integration.py
+++ b/tests/weevr/engine/test_warp_integration.py
@@ -60,8 +60,8 @@ class TestDefaultBehavior:
         thread = _make_thread(target_alias=path)
 
         source_df = spark.read.format("delta").load(path + "_src")
-        with patch("weevr.engine.executor.read_sources") as mock_read:
-            mock_read.return_value = {"src": source_df}
+        with patch("weevr.engine.executor.read_source") as mock_read:
+            mock_read.side_effect = lambda *a, **k: source_df
             result = execute_thread(spark, thread)
 
         assert result.status == "success"
@@ -74,8 +74,8 @@ class TestDefaultBehavior:
         path = tmp_delta_path("no_auto_discover")
         thread = _make_thread(target_alias=path)
         source_df = spark.createDataFrame([(1,)], ["id"])
-        with patch("weevr.engine.executor.read_sources") as mock_read:
-            mock_read.return_value = {"src": source_df}
+        with patch("weevr.engine.executor.read_source") as mock_read:
+            mock_read.side_effect = lambda *a, **k: source_df
             result = execute_thread(spark, thread)
         assert result.status == "success"
         assert result.warp_findings is None
@@ -93,8 +93,8 @@ class TestWarpEnforcementIntegration:
             warp_enforcement="warn",
         )
         source_df = spark.createDataFrame([(1, "Alice")], ["id", "name"])
-        with patch("weevr.engine.executor.read_sources") as mock_read:
-            mock_read.return_value = {"src": source_df}
+        with patch("weevr.engine.executor.read_source") as mock_read:
+            mock_read.side_effect = lambda *a, **k: source_df
             result = execute_thread(spark, thread)
         assert result.status == "success"
 
@@ -111,8 +111,8 @@ class TestDriftDetectionIntegration:
             schema_drift="lenient",
         )
         source_df = spark.createDataFrame([(1, "Alice", "extra")], ["id", "name", "new_col"])
-        with patch("weevr.engine.executor.read_sources") as mock_read:
-            mock_read.return_value = {"src": source_df}
+        with patch("weevr.engine.executor.read_source") as mock_read:
+            mock_read.side_effect = lambda *a, **k: source_df
             result = execute_thread(spark, thread)
         assert result.status == "success"
         output_df = spark.read.format("delta").load(path)
@@ -153,8 +153,8 @@ class TestDriftDetectionIntegration:
         )
         # Source has extra column not declared in warp
         source_df = spark.createDataFrame([(2, "Bob", "extra")], ["id", "name", "new_col"])
-        with patch("weevr.engine.executor.read_sources") as mock_read:
-            mock_read.return_value = {"src": source_df}
+        with patch("weevr.engine.executor.read_source") as mock_read:
+            mock_read.side_effect = lambda *a, **k: source_df
             with pytest.raises(SchemaDriftError) as exc_info:
                 execute_thread(spark, thread)
             assert exc_info.value.thread_name == "test_thread"
@@ -194,8 +194,8 @@ class TestDriftDetectionIntegration:
             warp_path.open("w"),
         )
         source_df = spark.createDataFrame([(2, "Bob", "extra")], ["id", "name", "new_col"])
-        with patch("weevr.engine.executor.read_sources") as mock_read:
-            mock_read.return_value = {"src": source_df}
+        with patch("weevr.engine.executor.read_source") as mock_read:
+            mock_read.side_effect = lambda *a, **k: source_df
             result = execute_thread(spark, thread)
         assert result.status == "success"
         assert result.drift_report is not None


### PR DESCRIPTION
## Summary

- Weave- and loom-scoped shared resources were materialized more than once and
  consumed by luck: cached thread outputs were persisted but never fetched,
  lookups double-read their sources around the unique-key check,
  broadcast-strategy lookups warmed nothing, non-materialized lookups
  revalidated per consuming thread, and column sets re-resolved per thread and
  per weave. Shared resources now materialize once and are consumed
  deterministically.
- Closes #198

## Why

- The cache manager's implicit plan-matching consumption silently missed, so
  producers paid persists nothing used; every other resource class paid
  repeated reads or validations that scale with thread count.

## What changed

- **Explicit cache registry.** Cache-target outputs register under a canonical
  target identity — alias, path, and connection+table declarations all resolve
  to one key — and consumers fetch the post-write snapshot explicitly, with the
  source's own dedup re-applied. A miss falls back to a direct read, so cache
  failures stay non-fatal by construction. Entries materialize eagerly at
  registration, so parallel same-group consumers never race the cache compute.
  Connection-declared cache targets now participate (previously they silently
  never persisted).
- **Plan-time identity hardening.** Dependency inference and the same-target
  conflict guard now resolve connection+table declarations to their physical
  path: connection-form readers get dependency edges on connection-form
  writers, and two unordered connection-form writers to one table are rejected
  at plan time — closing a pre-existing blind spot in the concurrent-writer
  guard. The pure connection→path builder moved to the core wheel
  (`weevr/config/onelake.py`) so plan-time and runtime agree; existing imports
  keep working via re-exports. FUSE-vs-abfss notation for the same table
  remains a documented plan-time limitation (such pairs miss the cache rather
  than wrongly hit).
- **Lookups read once.** Materialized lookups persist the narrowed frame first;
  the warming count fills the cache and the unique-key check runs against it —
  one source read end-to-end. Broadcast-strategy lookups persist AND keep their
  hint: consuming joins build their exchange from the resident cache instead of
  re-reading the source per join. Non-materialized `unique_key` lookups keep
  their per-thread re-read but validate once per weave: the first consumer
  validates (concurrent group-mates block on that outcome under a lock), and a
  failure outcome is re-raised consistently for every later consumer.
- **Column sets resolve once per declaring scope.** Loom-level sets resolve at
  loom start and pass down as resolved mappings; weaves materialize only their
  own declarations (overrides included — precedence unchanged); threads merge
  the already-resolved parent mappings. A params-invariance regression lock
  pins why loom-level resolve-once is safe.
- Alias identity resolves through the catalog's table location via the
  parameterized DeltaTable API; unresolvable aliases fall back to a namespaced
  key that cannot collide with location-derived keys.

## How to test

- [x] uv sync --dev
- [x] uv run ruff check .
- [x] uv run ruff format .
- [x] uv run pyright .
- [x] uv run pytest (2537 passed) and the full Spark-marked suite (exit 0)

## Release / Versioning

- [x] PR title follows Conventional Commit format (feat:, fix:, chore:, docs:, ci:, etc.)
- [ ] Breaking change indicated (feat!: / fix!: or BREAKING CHANGE in body) — not breaking

## Notes

- No YAML surface changes; outputs are identical — the changes are visible only
  as performance and telemetry.
- Two behavior callouts for release notes: connection-declared cache targets
  begin persisting (they silently never did), and broadcast-strategy lookups
  become cache-resident (memory posture documented in the engine internals
  guide).