### PR TITLE
chore(engine): answer metadata questions without full scans

### DIFF
--- a/packages/weevr/src/weevr/context.py
+++ b/packages/weevr/src/weevr/context.py
@@ -612,7 +612,17 @@ class Context:
         return errors
 
     def _source_location_exists(self, source_type: str, resolve_path: str) -> bool:
-        """Job-free existence probe for a single source location."""
+        """Job-free existence probe for a single source location.
+
+        Existence, not readability: a location that exists but holds
+        nothing parseable (an empty directory for a csv source, say)
+        counts as present here, where the old reader-based probe failed
+        schema inference and reported it missing. Deliberate — validate
+        mode answers "is the config pointed at something real", and
+        parse problems surface at execution with a better error. Same
+        posture as the catalog-vs-Delta-readable gap documented on
+        ``delta_table_exists``.
+        """
         try:
             if source_type == "delta":
                 return delta_table_exists(self._spark, resolve_path)

--- a/packages/weevr/src/weevr/context.py
+++ b/packages/weevr/src/weevr/context.py
@@ -33,7 +33,7 @@ from weevr.config.validation import (
     collect_trace_composition_warnings,
     validate_schema,
 )
-from weevr.delta import is_table_alias
+from weevr.delta import delta_table_exists
 from weevr.engine.executor import execute_thread
 from weevr.engine.planner import build_plan
 from weevr.engine.runner import execute_loom, execute_weave
@@ -586,7 +586,12 @@ class Context:
         )
 
     def _check_source_existence(self, threads: dict[str, Thread]) -> list[str]:
-        """Check that all sources referenced by threads exist."""
+        """Check that all sources referenced by threads exist.
+
+        Existence is a metadata question: Delta sources go through the
+        catalog or Delta-log check, file sources through a filesystem
+        probe — no reads, no schema inference, no Spark jobs.
+        """
         errors: list[str] = []
         checked: set[str] = set()
 
@@ -599,18 +604,25 @@ class Context:
                     continue
                 checked.add(resolve_path)
 
-                try:
-                    fmt = source.type if source.type != "excel" else "com.crealytics.spark.excel"
-                    if source.type == "delta" and is_table_alias(resolve_path):
-                        self._spark.read.format(fmt).table(resolve_path).limit(0).collect()
-                    else:
-                        self._spark.read.format(fmt).load(resolve_path).limit(0).collect()
-                except Exception:
+                if not self._source_location_exists(source.type, resolve_path):
                     errors.append(
                         f"Source '{source_name}' in thread '{thread_name}' "
                         f"not found: {resolve_path}"
                     )
         return errors
+
+    def _source_location_exists(self, source_type: str, resolve_path: str) -> bool:
+        """Job-free existence probe for a single source location."""
+        try:
+            if source_type == "delta":
+                return delta_table_exists(self._spark, resolve_path)
+            jvm: Any = self._spark._jvm  # noqa: SLF001
+            jsc: Any = self._spark._jsc  # noqa: SLF001
+            location = jvm.org.apache.hadoop.fs.Path(resolve_path)
+            fs = location.getFileSystem(jsc.hadoopConfiguration())
+            return bool(fs.exists(location))
+        except Exception:
+            return False
 
     @staticmethod
     def _collect_all_threads(resolved: _ResolvedConfig) -> dict[str, Thread]:

--- a/packages/weevr/src/weevr/delta.py
+++ b/packages/weevr/src/weevr/delta.py
@@ -35,14 +35,21 @@ def read_delta(spark: SparkSession, path: str) -> DataFrame:
 def delta_table_exists(spark: SparkSession, path: str) -> bool:
     """Return True if a Delta table exists at the given path or alias.
 
+    The alias branch asks the catalog rather than resolving the table
+    through a reader, so no Delta log is read and no job is launched.
+    ``tableExists`` answers "any table exists" — not "a Delta-readable
+    table exists" — which is equivalent on Fabric, where lakehouse
+    tables are Delta by platform contract. If parity evidence ever
+    demands distinguishing non-Delta catalog entries, the fallback is a
+    provider check (catalog provider field or ``DESCRIBE DETAIL``).
+
     Args:
         spark: Active SparkSession.
         path: Table alias or file path.
     """
     try:
         if is_table_alias(path):
-            spark.read.format("delta").table(path).limit(0).collect()
-            return True
+            return spark.catalog.tableExists(path)
         from delta.tables import DeltaTable
 
         return DeltaTable.isDeltaTable(spark, path)

--- a/packages/weevr/src/weevr/engine/conditions.py
+++ b/packages/weevr/src/weevr/engine/conditions.py
@@ -63,15 +63,29 @@ def _resolve_params(expr: str, params: dict[str, Any]) -> str:
     return _PARAM_REF.sub(_replace, expr)
 
 
-def _evaluate_builtins(expr: str, spark: SparkSession | None) -> str:
-    """Replace built-in function calls with their boolean/int results."""
+def _evaluate_builtins(
+    expr: str,
+    spark: SparkSession | None,
+    memo: dict[tuple[str, str], Any] | None = None,
+) -> str:
+    """Replace built-in function calls with their boolean/int results.
+
+    When *memo* is provided, each (builtin, argument) pair is computed
+    once and reused for the rest of the batch sharing the container.
+    """
 
     def _replace(match: re.Match[str]) -> str:
         func_name = match.group(1)
         arg = match.group(2)
         if spark is None:
             raise ExecutionError(f"Built-in check '{func_name}' requires a SparkSession")
-        result = _BUILTIN_FUNCS[func_name](spark, arg)
+        key = (func_name, arg)
+        if memo is not None and key in memo:
+            result = memo[key]
+        else:
+            result = _BUILTIN_FUNCS[func_name](spark, arg)
+            if memo is not None:
+                memo[key] = result
         if isinstance(result, bool):
             return "True" if result else "False"
         return str(result)
@@ -190,6 +204,7 @@ def evaluate_condition(
     condition: ConditionSpec,
     spark: SparkSession | None = None,
     params: dict[str, Any] | None = None,
+    memo: dict[tuple[str, str], Any] | None = None,
 ) -> bool:
     """Evaluate a condition specification.
 
@@ -202,6 +217,11 @@ def evaluate_condition(
             condition uses ``table_exists()``, ``table_empty()``, or
             ``row_count()``.
         params: Parameter dictionary for ``${param.x}`` references.
+        memo: Optional builtin-result cache shared by one evaluation
+            batch. Only pass a container whose evaluations are
+            semantically simultaneous — results are keyed by
+            (builtin, argument) with no invalidation, so a memo that
+            outlives its batch replays stale table state.
 
     Returns:
         True if the condition is met, False otherwise.
@@ -218,7 +238,7 @@ def evaluate_condition(
     expr = _resolve_params(expr, resolved_params)
 
     # Step 2: Evaluate built-in function calls
-    expr = _evaluate_builtins(expr, spark)
+    expr = _evaluate_builtins(expr, spark, memo)
 
     # Step 3: Evaluate boolean expression
     return _safe_eval(expr)

--- a/packages/weevr/src/weevr/engine/hooks.py
+++ b/packages/weevr/src/weevr/engine/hooks.py
@@ -180,8 +180,8 @@ def _execute_sql_statement(
     result = spark.sql(resolved_sql)  # noqa: S608
 
     if step.set_var:
-        rows = result.collect()
-        value = rows[0][0] if rows else None
+        row = result.first()
+        value = row[0] if row is not None else None
         variable_ctx.set(step.set_var, value)
 
 

--- a/packages/weevr/src/weevr/engine/runner.py
+++ b/packages/weevr/src/weevr/engine/runner.py
@@ -289,13 +289,19 @@ def execute_weave(
                         threads_skipped.append(name)
                 continue
 
-            # Evaluate conditions for pending threads before execution
+            # Evaluate conditions for pending threads before execution.
+            # The builtin memo lives strictly within this group's batch —
+            # all evaluations here are semantically simultaneous, while a
+            # later group must observe writes made by this one.
             conditions = thread_conditions or {}
+            condition_memo: dict[tuple[str, str], Any] = {}
             for name in group:
                 if (
                     thread_states[name] == "pending"
                     and name in conditions
-                    and not evaluate_condition(conditions[name], spark=spark, params=params)
+                    and not evaluate_condition(
+                        conditions[name], spark=spark, params=params, memo=condition_memo
+                    )
                 ):
                     thread_states[name] = "skipped"
                     threads_skipped.append(name)
@@ -719,7 +725,9 @@ def execute_loom(
         for weave_entry in loom.weaves:
             weave_name = weave_entry.name or (Path(weave_entry.ref).stem if weave_entry.ref else "")
 
-            # Evaluate weave-level condition
+            # Evaluate weave-level condition. Deliberately memo-less:
+            # each weave's condition runs once, with weave executions in
+            # between, so any carried cache would be stale by construction.
             if weave_entry.condition is not None and not evaluate_condition(
                 weave_entry.condition, spark=spark, params=params
             ):

--- a/packages/weevr/src/weevr/operations/assertions.py
+++ b/packages/weevr/src/weevr/operations/assertions.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import uuid
-from typing import Any
+from typing import Any, NamedTuple
 
 from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql import functions as F
@@ -11,6 +11,15 @@ from pyspark.sql import functions as F
 from weevr.delta import read_delta
 from weevr.model.validation import Assertion
 from weevr.telemetry.results import AssertionResult
+
+
+class _SentinelCheck(NamedTuple):
+    """One (column, sentinel group) pair to rate-check against a threshold."""
+
+    col: str
+    group: str
+    sentinel: Any
+    threshold: float
 
 
 def evaluate_assertions(
@@ -281,17 +290,17 @@ def _eval_fk_sentinel_rate(
 
     shared_max_rate = assertion.max_rate
 
-    checks: list[tuple[str, str, Any, float]] = []
+    checks: list[_SentinelCheck] = []
     for col_name in check_cols:
         for group_name, group in groups.items():
             threshold = group.max_rate if group.max_rate is not None else shared_max_rate
             if threshold is None:
                 continue
-            checks.append((col_name, group_name, group.value, threshold))
+            checks.append(_SentinelCheck(col_name, group_name, group.value, threshold))
 
     agg_exprs = [F.count(F.lit(1)).alias("__total")] + [
-        F.count(F.when(df[col_name] == sentinel_val, 1)).alias(f"__sentinel_{i}")
-        for i, (col_name, _, sentinel_val, _) in enumerate(checks)
+        F.count(F.when(df[check.col] == check.sentinel, 1)).alias(f"__sentinel_{i}")
+        for i, check in enumerate(checks)
     ]
     agg_row = df.agg(*agg_exprs).first()
     assert agg_row is not None
@@ -315,15 +324,15 @@ def _eval_fk_sentinel_rate(
         )
 
     failures: list[str] = []
-    for i, (col_name, group_name, sentinel_val, threshold) in enumerate(checks):
+    for i, check in enumerate(checks):
         sentinel_count = agg_row[f"__sentinel_{i}"]
         rate = sentinel_count / total
 
-        if rate > threshold:
+        if rate > check.threshold:
             failures.append(
-                f"column '{col_name}' sentinel group '{group_name}': "
-                f"rate {rate:.2%} exceeds threshold {threshold:.2%} "
-                f"(sentinel={sentinel_val}, count={sentinel_count}/{total})"
+                f"column '{check.col}' sentinel group '{check.group}': "
+                f"rate {rate:.2%} exceeds threshold {check.threshold:.2%} "
+                f"(sentinel={check.sentinel}, count={sentinel_count}/{total})"
             )
 
     if failures:

--- a/packages/weevr/src/weevr/operations/assertions.py
+++ b/packages/weevr/src/weevr/operations/assertions.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import uuid
+from typing import Any
 
-from pyspark.sql import SparkSession
+from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql import functions as F
 
 from weevr.delta import read_delta
 from weevr.model.validation import Assertion
@@ -22,6 +24,9 @@ def evaluate_assertions(
     and expression. Each assertion produces an AssertionResult with
     pass/fail status, details, and the configured severity.
 
+    The target is read once and shared across all assertions; each
+    assertion type answers its question in a single aggregation.
+
     Args:
         spark: Active SparkSession.
         assertions: List of assertion definitions to evaluate.
@@ -32,9 +37,23 @@ def evaluate_assertions(
     """
     results: list[AssertionResult] = []
 
+    try:
+        df = read_delta(spark, target_path)
+    except Exception as exc:
+        return [
+            AssertionResult(
+                assertion_type=assertion.type,
+                severity=assertion.severity,
+                passed=False,
+                details=f"Evaluation error: {exc}",
+                columns=assertion.columns,
+            )
+            for assertion in assertions
+        ]
+
     for assertion in assertions:
         try:
-            result = _evaluate_one(spark, assertion, target_path)
+            result = _evaluate_one(spark, assertion, df)
         except Exception as exc:
             result = AssertionResult(
                 assertion_type=assertion.type,
@@ -51,19 +70,19 @@ def evaluate_assertions(
 def _evaluate_one(
     spark: SparkSession,
     assertion: Assertion,
-    target_path: str,
+    df: DataFrame,
 ) -> AssertionResult:
-    """Evaluate a single assertion against the target."""
+    """Evaluate a single assertion against the target DataFrame."""
     if assertion.type == "row_count":
-        return _eval_row_count(spark, assertion, target_path)
+        return _eval_row_count(assertion, df)
     if assertion.type == "column_not_null":
-        return _eval_column_not_null(spark, assertion, target_path)
+        return _eval_column_not_null(assertion, df)
     if assertion.type == "unique":
-        return _eval_unique(spark, assertion, target_path)
+        return _eval_unique(assertion, df)
     if assertion.type == "expression":
-        return _eval_expression(spark, assertion, target_path)
+        return _eval_expression(spark, assertion, df)
     if assertion.type == "fk_sentinel_rate":
-        return _eval_fk_sentinel_rate(spark, assertion, target_path)
+        return _eval_fk_sentinel_rate(assertion, df)
     return AssertionResult(
         assertion_type=assertion.type,
         severity=assertion.severity,
@@ -73,12 +92,10 @@ def _evaluate_one(
 
 
 def _eval_row_count(
-    spark: SparkSession,
     assertion: Assertion,
-    target_path: str,
+    df: DataFrame,
 ) -> AssertionResult:
     """Check row count is within min/max bounds."""
-    df = read_delta(spark, target_path)
     count = df.count()
 
     if assertion.min is not None and count < assertion.min:
@@ -104,9 +121,8 @@ def _eval_row_count(
 
 
 def _eval_column_not_null(
-    spark: SparkSession,
     assertion: Assertion,
-    target_path: str,
+    df: DataFrame,
 ) -> AssertionResult:
     """Check that specified columns have no null values."""
     columns = assertion.columns or []
@@ -118,11 +134,19 @@ def _eval_column_not_null(
             details="No columns specified for column_not_null assertion",
         )
 
-    df = read_delta(spark, target_path)
+    # count() over a when() with no otherwise counts only the null rows,
+    # and is 0 (never NULL) on an empty table.
+    agg_row = df.agg(
+        *[
+            F.count(F.when(df[col].isNull(), 1)).alias(f"__null_{i}")
+            for i, col in enumerate(columns)
+        ]
+    ).first()
+    assert agg_row is not None
 
     null_counts: dict[str, int] = {}
-    for col in columns:
-        null_count = df.filter(df[col].isNull()).count()
+    for i, col in enumerate(columns):
+        null_count = agg_row[f"__null_{i}"]
         if null_count > 0:
             null_counts[col] = null_count
 
@@ -145,9 +169,8 @@ def _eval_column_not_null(
 
 
 def _eval_unique(
-    spark: SparkSession,
     assertion: Assertion,
-    target_path: str,
+    df: DataFrame,
 ) -> AssertionResult:
     """Check that specified columns form a unique key."""
     columns = assertion.columns or []
@@ -159,11 +182,20 @@ def _eval_unique(
             details="No columns specified for unique assertion",
         )
 
-    df = read_delta(spark, target_path)
-
-    total = df.count()
-    distinct = df.select(*columns).distinct().count()
-    duplicates = total - distinct
+    # groupBy groups NULL keys (unlike countDistinct, which drops them),
+    # so group count matches distinct().count() while sharing one pass
+    # with the total.
+    agg_row = (
+        df.groupBy(*columns)
+        .agg(F.count(F.lit(1)).alias("__group_rows"))
+        .agg(
+            F.coalesce(F.sum("__group_rows"), F.lit(0)).alias("__total"),
+            F.count(F.lit(1)).alias("__distinct"),
+        )
+        .first()
+    )
+    assert agg_row is not None
+    duplicates = agg_row["__total"] - agg_row["__distinct"]
 
     if duplicates > 0:
         return AssertionResult(
@@ -185,10 +217,9 @@ def _eval_unique(
 def _eval_expression(
     spark: SparkSession,
     assertion: Assertion,
-    target_path: str,
+    df: DataFrame,
 ) -> AssertionResult:
     """Evaluate a Spark SQL expression against the target table."""
-    df = read_delta(spark, target_path)
     expr = assertion.expression
 
     if not expr:
@@ -223,19 +254,48 @@ def _eval_expression(
 
 
 def _eval_fk_sentinel_rate(
-    spark: SparkSession,
     assertion: Assertion,
-    target_path: str,
+    df: DataFrame,
 ) -> AssertionResult:
     """Check FK sentinel value rates against thresholds.
 
     Supports single sentinel, named sentinel groups with shared or
-    per-group max_rate, and column/columns specification.
+    per-group max_rate, and column/columns specification. All sentinel
+    counts and the row total come from one aggregation.
     """
     from weevr.model.validation import SentinelGroup
 
-    df = read_delta(spark, target_path)
-    total = df.count()
+    # Determine columns to check
+    check_cols: list[str] = []
+    if assertion.column is not None:
+        check_cols = [assertion.column]
+    elif assertion.columns is not None:
+        check_cols = list(assertion.columns)
+
+    # Build sentinel groups to evaluate
+    groups: dict[str, SentinelGroup] = {}
+    if assertion.sentinels is not None:
+        groups = dict(assertion.sentinels)
+    elif assertion.sentinel is not None:
+        groups = {"default": SentinelGroup(value=assertion.sentinel)}
+
+    shared_max_rate = assertion.max_rate
+
+    checks: list[tuple[str, str, Any, float]] = []
+    for col_name in check_cols:
+        for group_name, group in groups.items():
+            threshold = group.max_rate if group.max_rate is not None else shared_max_rate
+            if threshold is None:
+                continue
+            checks.append((col_name, group_name, group.value, threshold))
+
+    agg_exprs = [F.count(F.lit(1)).alias("__total")] + [
+        F.count(F.when(df[col_name] == sentinel_val, 1)).alias(f"__sentinel_{i}")
+        for i, (col_name, _, sentinel_val, _) in enumerate(checks)
+    ]
+    agg_row = df.agg(*agg_exprs).first()
+    assert agg_row is not None
+    total = agg_row["__total"]
 
     if total == 0:
         return AssertionResult(
@@ -246,13 +306,6 @@ def _eval_fk_sentinel_rate(
             columns=assertion.columns or ([assertion.column] if assertion.column else None),
         )
 
-    # Determine columns to check
-    check_cols: list[str] = []
-    if assertion.column is not None:
-        check_cols = [assertion.column]
-    elif assertion.columns is not None:
-        check_cols = list(assertion.columns)
-
     if not check_cols:
         return AssertionResult(
             assertion_type="fk_sentinel_rate",
@@ -261,32 +314,17 @@ def _eval_fk_sentinel_rate(
             details="fk_sentinel_rate requires column or columns to be set",
         )
 
-    # Build sentinel groups to evaluate
-    groups: dict[str, SentinelGroup] = {}
-    if assertion.sentinels is not None:
-        groups = dict(assertion.sentinels)
-    elif assertion.sentinel is not None:
-        groups = {"default": SentinelGroup(value=assertion.sentinel)}
-
-    shared_max_rate = assertion.max_rate
     failures: list[str] = []
+    for i, (col_name, group_name, sentinel_val, threshold) in enumerate(checks):
+        sentinel_count = agg_row[f"__sentinel_{i}"]
+        rate = sentinel_count / total
 
-    for col_name in check_cols:
-        for group_name, group in groups.items():
-            sentinel_val = group.value
-            threshold = group.max_rate if group.max_rate is not None else shared_max_rate
-            if threshold is None:
-                continue
-
-            sentinel_count = df.filter(df[col_name] == sentinel_val).count()
-            rate = sentinel_count / total
-
-            if rate > threshold:
-                failures.append(
-                    f"column '{col_name}' sentinel group '{group_name}': "
-                    f"rate {rate:.2%} exceeds threshold {threshold:.2%} "
-                    f"(sentinel={sentinel_val}, count={sentinel_count}/{total})"
-                )
+        if rate > threshold:
+            failures.append(
+                f"column '{col_name}' sentinel group '{group_name}': "
+                f"rate {rate:.2%} exceeds threshold {threshold:.2%} "
+                f"(sentinel={sentinel_val}, count={sentinel_count}/{total})"
+            )
 
     if failures:
         msg = assertion.message or "FK sentinel rate exceeded"

--- a/packages/weevr/src/weevr/operations/seeding.py
+++ b/packages/weevr/src/weevr/operations/seeding.py
@@ -36,17 +36,17 @@ class SeedResult:
     skipped_reason: str | None = field(default=None)
 
 
-def _table_row_count(spark: SparkSession, path: str) -> int:
-    """Return the number of rows in an existing Delta table.
+def _table_is_empty(spark: SparkSession, path: str) -> bool:
+    """Return True if an existing Delta table has no rows.
+
+    Probes for a single row rather than counting the table — the
+    trigger only needs to know whether any row exists.
 
     Args:
         spark: Active SparkSession.
         path: File path to the Delta table.
-
-    Returns:
-        Row count as an integer.
     """
-    return spark.read.format("delta").load(path).count()
+    return spark.read.format("delta").load(path).first() is None
 
 
 def check_seed_trigger(
@@ -80,7 +80,7 @@ def check_seed_trigger(
     # on == "empty"
     if not exists:
         return True
-    return _table_row_count(spark, table_path) == 0
+    return _table_is_empty(spark, table_path)
 
 
 def build_seed_dataframe(

--- a/packages/weevr/src/weevr/state/metadata_table.py
+++ b/packages/weevr/src/weevr/state/metadata_table.py
@@ -40,6 +40,7 @@ class MetadataTableStore(WatermarkStore):
                 store_type="metadata_table",
             )
         self._table_path = table_path
+        self._table_ensured = False
 
     @property
     def table_path(self) -> str:
@@ -47,7 +48,13 @@ class MetadataTableStore(WatermarkStore):
         return self._table_path
 
     def _ensure_table_exists(self, spark: SparkSession) -> None:
-        """Create the watermarks table if it does not exist."""
+        """Create the watermarks table if it does not exist.
+
+        Runs the DDL at most once per store instance — table existence
+        is monotonic within a run, so later reads and writes skip it.
+        """
+        if self._table_ensured:
+            return
         if is_table_alias(self._table_path):
             table_ref = self._table_path
         else:
@@ -63,6 +70,7 @@ class MetadataTableStore(WatermarkStore):
             )
             USING DELTA
         """)
+        self._table_ensured = True
 
     def read(self, spark: SparkSession, thread_name: str) -> WatermarkState | None:
         """Load watermark state for a thread from the metadata table."""

--- a/tests/weevr/conftest.py
+++ b/tests/weevr/conftest.py
@@ -32,7 +32,7 @@ def spark() -> Generator[SparkSession, None, None]:
             "org.apache.spark.sql.delta.catalog.DeltaCatalog",
         )
         .config("spark.sql.shuffle.partitions", "2")
-        .config("spark.driver.memory", "2g")
+        .config("spark.driver.memory", "3g")
         .config("spark.ui.enabled", "false")
         .config("spark.driver.bindAddress", "127.0.0.1")
         .config("spark.driver.host", "127.0.0.1")

--- a/tests/weevr/engine/test_conditions.py
+++ b/tests/weevr/engine/test_conditions.py
@@ -108,3 +108,86 @@ class TestParamConditions:
         cond = ConditionSpec(when="??? invalid")
         with pytest.raises(ConfigError, match="Cannot evaluate"):
             evaluate_condition(cond)
+
+
+@pytest.mark.spark
+class TestBuiltinMemo:
+    """Memoization of builtin probes within one evaluation batch."""
+
+    def _counting_read(self, monkeypatch):
+        import weevr.engine.conditions as conditions_mod
+
+        calls = {"n": 0}
+        real_read = conditions_mod.read_delta
+
+        def counting(spark_arg, path_arg):
+            calls["n"] += 1
+            return real_read(spark_arg, path_arg)
+
+        monkeypatch.setattr(conditions_mod, "read_delta", counting)
+        return calls
+
+    def test_shared_memo_computes_builtin_once(self, spark, tmp_delta_path, monkeypatch):
+        from spark_helpers import create_delta_table
+
+        path = tmp_delta_path("memo_shared")
+        create_delta_table(spark, path, [{"id": 1}, {"id": 2}])
+        calls = self._counting_read(monkeypatch)
+
+        memo: dict = {}
+        for _ in range(3):
+            cond = ConditionSpec(when=f"row_count('{path}') > 0")
+            assert evaluate_condition(cond, spark=spark, memo=memo) is True
+        assert calls["n"] == 1
+
+    def test_distinct_arguments_memoized_separately(self, spark, tmp_delta_path, monkeypatch):
+        from spark_helpers import create_delta_table
+
+        path_a = tmp_delta_path("memo_arg_a")
+        path_b = tmp_delta_path("memo_arg_b")
+        create_delta_table(spark, path_a, [{"id": 1}])
+        create_delta_table(spark, path_b, [{"id": 1}, {"id": 2}])
+        calls = self._counting_read(monkeypatch)
+
+        memo: dict = {}
+        assert (
+            evaluate_condition(
+                ConditionSpec(when=f"row_count('{path_a}') > 1"), spark=spark, memo=memo
+            )
+            is False
+        )
+        assert (
+            evaluate_condition(
+                ConditionSpec(when=f"row_count('{path_b}') > 1"), spark=spark, memo=memo
+            )
+            is True
+        )
+        assert calls["n"] == 2
+
+    def test_fresh_containers_observe_new_writes(self, spark, tmp_delta_path, monkeypatch):
+        """A new memo container sees writes made after the previous batch."""
+        from spark_helpers import create_delta_table
+
+        path = tmp_delta_path("memo_fresh")
+        create_delta_table(spark, path, [{"id": 1}])
+        cond = ConditionSpec(when=f"row_count('{path}') > 1")
+
+        batch_one: dict = {}
+        assert evaluate_condition(cond, spark=spark, memo=batch_one) is False
+
+        spark.createDataFrame([(2,)], "id BIGINT").write.format("delta").mode("append").save(path)
+
+        batch_two: dict = {}
+        assert evaluate_condition(cond, spark=spark, memo=batch_two) is True
+
+    def test_no_memo_evaluates_fresh_every_time(self, spark, tmp_delta_path, monkeypatch):
+        from spark_helpers import create_delta_table
+
+        path = tmp_delta_path("memo_absent")
+        create_delta_table(spark, path, [{"id": 1}])
+        calls = self._counting_read(monkeypatch)
+
+        cond = ConditionSpec(when=f"row_count('{path}') > 0")
+        assert evaluate_condition(cond, spark=spark) is True
+        assert evaluate_condition(cond, spark=spark) is True
+        assert calls["n"] == 2

--- a/tests/weevr/engine/test_conditions.py
+++ b/tests/weevr/engine/test_conditions.py
@@ -115,7 +115,7 @@ class TestBuiltinMemo:
     """Memoization of builtin probes within one evaluation batch."""
 
     def _counting_read(self, monkeypatch):
-        import weevr.engine.conditions as conditions_mod
+        from weevr.engine import conditions as conditions_mod
 
         calls = {"n": 0}
         real_read = conditions_mod.read_delta
@@ -164,7 +164,7 @@ class TestBuiltinMemo:
         )
         assert calls["n"] == 2
 
-    def test_fresh_containers_observe_new_writes(self, spark, tmp_delta_path, monkeypatch):
+    def test_fresh_containers_observe_new_writes(self, spark, tmp_delta_path):
         """A new memo container sees writes made after the previous batch."""
         from spark_helpers import create_delta_table
 

--- a/tests/weevr/engine/test_hooks.py
+++ b/tests/weevr/engine/test_hooks.py
@@ -134,7 +134,7 @@ class TestRunHookStepsSqlStatement:
         spark = MagicMock()
         mock_row = MagicMock()
         mock_row.__getitem__ = MagicMock(return_value=42)
-        spark.sql.return_value.collect.return_value = [mock_row]
+        spark.sql.return_value.first.return_value = mock_row
 
         specs = {"result": VariableSpec(type="int")}
         ctx = VariableContext(specs)
@@ -149,7 +149,7 @@ class TestRunHookStepsSqlStatement:
     def test_sql_set_var_empty_result(self):
         """SQL with set_var and empty result sets variable to None."""
         spark = MagicMock()
-        spark.sql.return_value.collect.return_value = []
+        spark.sql.return_value.first.return_value = None
 
         specs = {"val": VariableSpec(type="string")}
         ctx = VariableContext(specs)
@@ -158,6 +158,29 @@ class TestRunHookStepsSqlStatement:
         run_hook_steps(spark, [step], "pre", ctx)
 
         assert ctx.get("val") is None
+
+    @pytest.mark.spark
+    def test_sql_set_var_multi_row_stores_bare_scalar(self, spark):
+        """set_var takes the first row's first column as a plain value.
+
+        A Row object stored here would corrupt ``${var.*}`` interpolation,
+        so the extraction is asserted on a real multi-row result.
+        """
+        from pyspark.sql import Row
+
+        specs = {"val": VariableSpec(type="int")}
+        ctx = VariableContext(specs)
+        step = SqlStatementStep(
+            type="sql_statement",
+            sql="SELECT id FROM VALUES (7), (8), (9) AS t(id) ORDER BY id",
+            set_var="val",
+        )
+
+        run_hook_steps(spark, [step], "pre", ctx)
+
+        value = ctx.get("val")
+        assert value == 7
+        assert not isinstance(value, Row)
 
     def test_sql_resolves_variables(self):
         """SQL statement text resolves ${var.name} refs."""

--- a/tests/weevr/engine/test_orchestration.py
+++ b/tests/weevr/engine/test_orchestration.py
@@ -421,7 +421,7 @@ class TestConditionMemoScope:
         self, spark: SparkSession, tmp_delta_path, monkeypatch
     ) -> None:
         """Two same-group threads with the same builtin probe share one scan."""
-        import weevr.engine.conditions as conditions_mod
+        from weevr.engine import conditions as conditions_mod
         from weevr.model.weave import ConditionSpec
 
         src_c = tmp_delta_path("memo_group_src_c")

--- a/tests/weevr/engine/test_orchestration.py
+++ b/tests/weevr/engine/test_orchestration.py
@@ -409,3 +409,132 @@ class TestEC010PartialStatus:
         assert any(r.thread_name == "C" for r in succeeded)
         assert "B" in result.threads_skipped
         assert result.duration_ms >= 0
+
+
+# ---------------------------------------------------------------------------
+# Condition memo scope — shared within a group batch, fresh across groups
+# ---------------------------------------------------------------------------
+
+
+class TestConditionMemoScope:
+    def test_same_builtin_shared_within_group(
+        self, spark: SparkSession, tmp_delta_path, monkeypatch
+    ) -> None:
+        """Two same-group threads with the same builtin probe share one scan."""
+        import weevr.engine.conditions as conditions_mod
+        from weevr.model.weave import ConditionSpec
+
+        src_c = tmp_delta_path("memo_group_src_c")
+        src_d = tmp_delta_path("memo_group_src_d")
+        gate = tmp_delta_path("memo_group_gate")
+        tgt_c = tmp_delta_path("memo_group_tgt_c")
+        tgt_d = tmp_delta_path("memo_group_tgt_d")
+        create_delta_table(spark, src_c, [{"id": 1}])
+        create_delta_table(spark, src_d, [{"id": 2}])
+        create_delta_table(spark, gate, [{"id": 9}])
+
+        calls = {"n": 0}
+        real_read = conditions_mod.read_delta
+
+        def counting(spark_arg, path_arg):
+            calls["n"] += 1
+            return real_read(spark_arg, path_arg)
+
+        monkeypatch.setattr(conditions_mod, "read_delta", counting)
+
+        threads = {
+            "C": _thread("C", src_c, tgt_c),
+            "D": _thread("D", src_d, tgt_d),
+        }
+        plan = build_plan("test_weave", threads, _entries("C", "D"))
+        condition = ConditionSpec(when=f"row_count('{gate}') > 0")
+        result = execute_weave(
+            spark,
+            plan,
+            threads,
+            thread_conditions={"C": condition, "D": condition},
+        )
+
+        assert result.status == "success"
+        assert result.threads_skipped == []
+        assert calls["n"] == 1
+
+    def test_group_two_condition_observes_group_one_write(
+        self, spark: SparkSession, tmp_delta_path
+    ) -> None:
+        """The stale-memo trap: a later group's condition must evaluate fresh.
+
+        C (group 1) probes A's yet-unwritten target and is skipped; B
+        (group 2, downstream of A) probes the same table after A has
+        written it and must run. A memo outliving the group batch would
+        replay C's zero and wrongly skip B.
+        """
+        from weevr.model.weave import ConditionSpec
+
+        src_a = tmp_delta_path("memo_stale_src_a")
+        src_c = tmp_delta_path("memo_stale_src_c")
+        tgt_a = tmp_delta_path("memo_stale_tgt_a")
+        tgt_b = tmp_delta_path("memo_stale_tgt_b")
+        tgt_c = tmp_delta_path("memo_stale_tgt_c")
+        create_delta_table(spark, src_a, [{"id": 1}])
+        create_delta_table(spark, src_c, [{"id": 3}])
+
+        threads = {
+            "A": _thread("A", src_a, tgt_a),
+            "B": _thread("B", tgt_a, tgt_b),
+            "C": _thread("C", src_c, tgt_c),
+        }
+        plan = build_plan("test_weave", threads, _entries("A", "B", "C"))
+        assert "A" in plan.dependencies["B"]
+
+        condition = ConditionSpec(when=f"row_count('{tgt_a}') > 0")
+        result = execute_weave(
+            spark,
+            plan,
+            threads,
+            thread_conditions={"B": condition, "C": condition},
+        )
+
+        assert result.threads_skipped == ["C"]
+        statuses = {r.thread_name: r.status for r in result.thread_results}
+        assert statuses["A"] == "success"
+        assert statuses["B"] == "success"
+
+    def test_weave_condition_observes_earlier_weave_write(
+        self, spark: SparkSession, tmp_delta_path
+    ) -> None:
+        """The loom-level site carries no memo: each weave probes fresh."""
+        src1 = tmp_delta_path("memo_loom_src1")
+        tgt1 = tmp_delta_path("memo_loom_tgt1")
+        src2 = tmp_delta_path("memo_loom_src2")
+        tgt2 = tmp_delta_path("memo_loom_tgt2")
+        create_delta_table(spark, src1, [{"id": 1}])
+        create_delta_table(spark, src2, [{"id": 2}])
+
+        loom = Loom.model_validate(
+            {
+                "name": "memo_loom",
+                "config_version": "1",
+                "weaves": [
+                    {"name": "weave1", "condition": {"when": f"row_count('{tgt1}') == 0"}},
+                    {"name": "weave2", "condition": {"when": f"row_count('{tgt1}') > 0"}},
+                ],
+            }
+        )
+        weaves = {
+            "weave1": Weave.model_validate(
+                {"config_version": "1", "name": "weave1", "threads": ["t1"]}
+            ),
+            "weave2": Weave.model_validate(
+                {"config_version": "1", "name": "weave2", "threads": ["t2"]}
+            ),
+        }
+        threads = {
+            "weave1": {"t1": _thread("t1", src1, tgt1)},
+            "weave2": {"t2": _thread("t2", src2, tgt2)},
+        }
+
+        result = execute_loom(spark, loom, weaves, threads)
+
+        assert result.status == "success"
+        assert [w.status for w in result.weave_results] == ["success", "success"]

--- a/tests/weevr/operations/test_assertions.py
+++ b/tests/weevr/operations/test_assertions.py
@@ -272,7 +272,7 @@ class TestFkSentinelRate:
 class TestScanHygiene:
     def test_one_read_for_many_assertions(self, spark, target_df, monkeypatch):
         """The target is read once no matter how many assertions run."""
-        import weevr.operations.assertions as assertions_mod
+        from weevr.operations import assertions as assertions_mod
 
         calls = {"n": 0}
         real_read = assertions_mod.read_delta

--- a/tests/weevr/operations/test_assertions.py
+++ b/tests/weevr/operations/test_assertions.py
@@ -262,3 +262,92 @@ class TestFkSentinelRate:
         ]
         results = evaluate_assertions(spark, assertions, path)
         assert results[0].passed is True
+
+
+# ---------------------------------------------------------------------------
+# Scan hygiene: one read per evaluation, one aggregation per assertion type
+# ---------------------------------------------------------------------------
+
+
+class TestScanHygiene:
+    def test_one_read_for_many_assertions(self, spark, target_df, monkeypatch):
+        """The target is read once no matter how many assertions run."""
+        import weevr.operations.assertions as assertions_mod
+
+        calls = {"n": 0}
+        real_read = assertions_mod.read_delta
+
+        def counting_read(spark_arg, path_arg):
+            calls["n"] += 1
+            return real_read(spark_arg, path_arg)
+
+        monkeypatch.setattr(assertions_mod, "read_delta", counting_read)
+        assertions = [
+            Assertion(type="row_count", min=1),
+            Assertion(type="column_not_null", columns=["id", "amount"]),
+            Assertion(type="unique", columns=["id"]),
+            Assertion(type="expression", expression=SparkExpr("count(*) >= 1")),
+        ]
+        results = evaluate_assertions(spark, assertions, target_df)
+        assert [r.passed for r in results] == [True, True, True, True]
+        assert calls["n"] == 1
+
+    def test_missing_table_errors_every_assertion(self, spark, tmp_delta_path):
+        """A failed read surfaces as an evaluation error on each assertion."""
+        path = tmp_delta_path("assertion_missing")
+        assertions = [
+            Assertion(type="row_count", min=1),
+            Assertion(type="unique", columns=["id"]),
+        ]
+        results = evaluate_assertions(spark, assertions, path)
+        assert len(results) == 2
+        assert all(r.passed is False for r in results)
+        assert all("Evaluation error" in r.details for r in results)
+        assert results[1].columns == ["id"]
+
+    def test_column_not_null_single_aggregation(self, spark, target_df, spark_action_counter):
+        """Multi-column not-null resolves in one aggregation, not one scan per column."""
+        assertions = [Assertion(type="column_not_null", columns=["id", "name", "amount"])]
+        results = evaluate_assertions(spark, assertions, target_df)
+        assert results[0].passed is False
+        assert "'name' has 1 nulls" in results[0].details
+        assert spark_action_counter["total"] == 1
+
+    def test_column_not_null_empty_table_passes(self, spark, tmp_delta_path):
+        path = tmp_delta_path("not_null_empty")
+        spark.createDataFrame([], "id: int, name: string").write.format("delta").save(path)
+        results = evaluate_assertions(
+            spark, [Assertion(type="column_not_null", columns=["id", "name"])], path
+        )
+        assert results[0].passed is True
+
+    def test_unique_single_pass(self, spark, dup_target_df, spark_action_counter):
+        """Unique check computes total and distinct in one action over the table."""
+        results = evaluate_assertions(
+            spark, [Assertion(type="unique", columns=["id", "name"])], dup_target_df
+        )
+        assert results[0].passed is False
+        assert "1 duplicate rows" in results[0].details
+        assert spark_action_counter["total"] == 1
+
+    def test_unique_counts_null_keys_as_distinct_values(self, spark, tmp_delta_path):
+        """NULL key rows group together — same answer distinct() gave."""
+        path = tmp_delta_path("null_key_unique")
+        spark.createDataFrame([(1,), (None,), (None,)], "id INT").write.format("delta").save(path)
+        results = evaluate_assertions(spark, [Assertion(type="unique", columns=["id"])], path)
+        assert results[0].passed is False
+        assert "1 duplicate rows" in results[0].details
+
+    def test_fk_sentinel_single_aggregation(self, spark, fk_target_df, spark_action_counter):
+        """Columns x groups resolve in one aggregation, not one scan per pair."""
+        assertions = [
+            Assertion(
+                type="fk_sentinel_rate",
+                columns=["plant_id", "company_id"],
+                sentinels={"invalid": -4, "unknown": -1},  # type: ignore[arg-type]
+                max_rate=0.25,
+            )
+        ]
+        results = evaluate_assertions(spark, assertions, fk_target_df)
+        assert results[0].passed is True
+        assert spark_action_counter["total"] == 1

--- a/tests/weevr/operations/test_seeding.py
+++ b/tests/weevr/operations/test_seeding.py
@@ -454,3 +454,23 @@ class TestBuildSystemMemberRows:
         assert unknown_row["_valid_from"] == "1970-01-01"
         assert unknown_row["_valid_to"] == "9999-12-31"
         assert unknown_row["_is_current"] is True
+
+
+@pytest.mark.spark
+class TestEmptyProbeIsCheap:
+    """The 'empty' trigger answers without counting the whole table."""
+
+    def test_emptiness_probe_avoids_full_count(
+        self, spark: SparkSession, tmp_delta_path, monkeypatch
+    ) -> None:
+        from pyspark.sql import DataFrame
+
+        path = tmp_delta_path("empty_probe_cheap")
+        create_delta_table(spark, path, [{"id": i, "name": "x"} for i in range(50)])
+
+        def no_full_count(self, *args, **kwargs):
+            raise AssertionError("emptiness probe must not count() the table")
+
+        monkeypatch.setattr(DataFrame, "count", no_full_count)
+        config = SeedConfig(on="empty", rows=[{"id": 99}])
+        assert check_seed_trigger(spark, path, config) is False

--- a/tests/weevr/state/test_metadata_table.py
+++ b/tests/weevr/state/test_metadata_table.py
@@ -137,3 +137,53 @@ class TestMetadataTableStore:
         y = store.read(spark, "thread_y")
         assert x is not None and x.last_value == "10"
         assert y is not None and y.last_value == "20"
+
+
+@pytest.mark.spark
+class TestEnsureDdlOnce:
+    """The ensure-DDL runs at most once per store instance."""
+
+    def test_ddl_once_across_reads_and_writes(
+        self, spark: SparkSession, tmp_delta_path, monkeypatch
+    ) -> None:
+        path = tmp_delta_path("wm_ddl_once")
+        store = MetadataTableStore(path)
+        calls = {"ddl": 0}
+        real_sql = spark.sql
+
+        def counting_sql(query, *args, **kwargs):
+            if "CREATE TABLE IF NOT EXISTS" in query:
+                calls["ddl"] += 1
+            return real_sql(query, *args, **kwargs)
+
+        monkeypatch.setattr(spark, "sql", counting_sql)
+
+        state = WatermarkState(
+            thread_name="t1",
+            watermark_column="ts",
+            watermark_type="timestamp",
+            last_value="2024-01-01T00:00:00",
+            last_updated=datetime(2024, 6, 1, tzinfo=UTC),
+        )
+        assert store.read(spark, "t1") is None
+        store.write(spark, state)
+        assert store.read(spark, "t1") is not None
+        store.write(spark, state)
+
+        assert calls["ddl"] == 1
+
+    def test_fresh_instance_still_creates_table(self, spark: SparkSession, tmp_delta_path) -> None:
+        """The once-guard is per instance — a new store still ensures."""
+        path = tmp_delta_path("wm_ddl_fresh")
+        first = MetadataTableStore(path)
+        state = WatermarkState(
+            thread_name="t1",
+            watermark_column="ts",
+            watermark_type="timestamp",
+            last_value="2024-01-01T00:00:00",
+            last_updated=datetime(2024, 6, 1, tzinfo=UTC),
+        )
+        first.write(spark, state)
+
+        second = MetadataTableStore(path)
+        assert second.read(spark, "t1") is not None

--- a/tests/weevr/test_context.py
+++ b/tests/weevr/test_context.py
@@ -1274,3 +1274,70 @@ write:
         assert "samples" not in meta
         assert "step_stats" not in meta
         assert result.preview_data is not None and "pdeg" in result.preview_data
+
+
+@pytest.mark.spark
+class TestValidateModeSourceProbes:
+    """Validate-mode existence probes: same reports, zero Spark jobs."""
+
+    def _thread_with_source(self, stype: str, location: str, tgt: str) -> Thread:
+        source: dict = {"type": stype}
+        if stype == "delta":
+            source["alias"] = location
+        else:
+            source["path"] = location
+        return Thread.model_validate(
+            {
+                "name": "probe_t",
+                "config_version": "1",
+                "sources": {"main": source},
+                "target": {"path": tgt},
+            }
+        )
+
+    def test_validate_mode_probe_matrix(self, spark: SparkSession, tmp_path: Path) -> None:
+        delta_src = str(tmp_path / "probe_delta")
+        spark.createDataFrame([{"id": 1}]).write.format("delta").save(delta_src)
+        csv_src = tmp_path / "probe.csv"
+        csv_src.write_text("id,val\n1,a\n")
+        json_src = tmp_path / "probe.json"
+        json_src.write_text('{"id": 1}\n')
+        tgt = str(tmp_path / "probe_tgt")
+
+        ctx = Context(spark=spark, project=_project_dir(tmp_path))
+        present = {
+            "d": self._thread_with_source("delta", delta_src, tgt),
+            "c": self._thread_with_source("csv", str(csv_src), tgt),
+            "j": self._thread_with_source("json", str(json_src), tgt),
+        }
+        assert ctx._check_source_existence(present) == []
+
+        missing = {
+            "d": self._thread_with_source("delta", str(tmp_path / "no_delta"), tgt),
+            "c": self._thread_with_source("csv", str(tmp_path / "no.csv"), tgt),
+            "j": self._thread_with_source("json", str(tmp_path / "no.json"), tgt),
+        }
+        errors = ctx._check_source_existence(missing)
+        assert len(errors) == 3
+        assert all("not found" in e for e in errors)
+
+    def test_validate_mode_probes_launch_zero_jobs(
+        self, spark: SparkSession, tmp_path: Path, job_counter
+    ) -> None:
+        delta_src = str(tmp_path / "zerojob_delta")
+        spark.createDataFrame([{"id": 1}]).write.format("delta").save(delta_src)
+        csv_src = tmp_path / "zerojob.csv"
+        csv_src.write_text("id,val\n1,a\n2,b\n")
+        json_src = tmp_path / "zerojob.json"
+        json_src.write_text('{"id": 1}\n{"id": 2}\n')
+        tgt = str(tmp_path / "zerojob_tgt")
+
+        ctx = Context(spark=spark, project=_project_dir(tmp_path))
+        threads = {
+            "d": self._thread_with_source("delta", delta_src, tgt),
+            "c": self._thread_with_source("csv", str(csv_src), tgt),
+            "j": self._thread_with_source("json", str(json_src), tgt),
+        }
+        with job_counter() as jc:
+            assert ctx._check_source_existence(threads) == []
+        assert jc.jobs == 0

--- a/tests/weevr/test_context.py
+++ b/tests/weevr/test_context.py
@@ -1341,3 +1341,20 @@ class TestValidateModeSourceProbes:
         with job_counter() as jc:
             assert ctx._check_source_existence(threads) == []
         assert jc.jobs == 0
+
+    def test_validate_mode_existing_but_empty_directory_counts_as_present(
+        self, spark: SparkSession, tmp_path: Path
+    ) -> None:
+        """Existence, not readability: an empty directory passes the probe.
+
+        The old reader-based probe failed schema inference here and
+        reported the source missing; the job-free probe answers the
+        existence question only.
+        """
+        empty_dir = tmp_path / "empty_csv_dir"
+        empty_dir.mkdir()
+        tgt = str(tmp_path / "empty_dir_tgt")
+
+        ctx = Context(spark=spark, project=_project_dir(tmp_path))
+        threads = {"c": self._thread_with_source("csv", str(empty_dir), tgt)}
+        assert ctx._check_source_existence(threads) == []

--- a/tests/weevr/test_delta.py
+++ b/tests/weevr/test_delta.py
@@ -1,0 +1,77 @@
+"""Tests for shared Delta Lake utilities."""
+
+import pytest
+
+from weevr.delta import delta_table_exists, is_table_alias
+
+pytestmark = pytest.mark.spark
+
+
+class TestIsTableAlias:
+    def test_dotted_name_is_alias(self):
+        assert is_table_alias("staging.customers") is True
+
+    def test_uri_is_not_alias(self):
+        assert is_table_alias("abfss://ws@onelake/lh/Tables/t") is False
+
+    def test_local_path_is_not_alias(self):
+        assert is_table_alias("/tmp/tables/t") is False
+
+
+class TestDeltaTableExists:
+    """Equivalence matrix: alias form, path form, and missing table."""
+
+    @pytest.fixture()
+    def alias_table(self, spark):
+        name = "default.exists_probe_present"
+        spark.sql(f"DROP TABLE IF EXISTS {name}")
+        spark.createDataFrame([(1, "a")], "id INT, val STRING").write.format("delta").saveAsTable(
+            name
+        )
+        yield name
+        spark.sql(f"DROP TABLE IF EXISTS {name}")
+
+    def test_alias_present(self, spark, alias_table):
+        assert delta_table_exists(spark, alias_table) is True
+
+    def test_alias_missing(self, spark):
+        assert delta_table_exists(spark, "default.exists_probe_absent") is False
+
+    def test_path_present(self, spark, tmp_delta_path):
+        path = tmp_delta_path("exists_path_present")
+        spark.createDataFrame([(1,)], "id INT").write.format("delta").mode("overwrite").save(path)
+        assert delta_table_exists(spark, path) is True
+
+    def test_path_missing(self, spark, tmp_delta_path):
+        path = tmp_delta_path("exists_path_absent")
+        assert delta_table_exists(spark, path) is False
+
+    def test_alias_probe_never_constructs_a_dataframe(self, spark, alias_table, monkeypatch):
+        """Existence by alias is a metastore question.
+
+        The job counter can't discriminate here — even the old
+        ``limit(0).collect()`` probe completes without a JVM job. The
+        cost being removed is the reader's Delta-log resolution, so the
+        lock is that no DataFrameReader method ever runs.
+        """
+        from pyspark.sql.readwriter import DataFrameReader
+
+        calls = {"n": 0}
+
+        def _count(original):
+            def wrapper(self, *args, **kwargs):
+                calls["n"] += 1
+                return original(self, *args, **kwargs)
+
+            return wrapper
+
+        monkeypatch.setattr(DataFrameReader, "table", _count(DataFrameReader.table))
+        monkeypatch.setattr(DataFrameReader, "load", _count(DataFrameReader.load))
+        assert delta_table_exists(spark, alias_table) is True
+        assert delta_table_exists(spark, "default.exists_probe_absent") is False
+        assert calls["n"] == 0
+
+    def test_alias_probe_launches_zero_jobs(self, spark, alias_table, job_counter):
+        with job_counter() as jc:
+            assert delta_table_exists(spark, alias_table) is True
+        assert jc.jobs == 0


### PR DESCRIPTION
## Summary

- Hot paths answered metadata questions — does this table exist, is it
  empty, did the assertions pass — with Spark jobs and full scans. Each
  site now uses the cheapest mechanism that answers the question.
- Closes #201

## What changed

- **Table existence by alias** asks the catalog (`catalog.tableExists`)
  instead of resolving the table through a reader, skipping the
  driver-side Delta-log read; every caller of the shared helper
  (conditions, writers, seeding) benefits at once. `tableExists` answers
  "any table exists" rather than "a Delta-readable table exists" — on
  Fabric lakehouse tables are Delta by platform contract, and the
  fallback provider check is documented at the decision site.
- **Post-write assertions** read the target once per evaluation and
  answer each assertion type in a single aggregation: conditional counts
  for multi-column not-null, one grouped pass for unique (grouping
  preserves NULL-key semantics that `countDistinct` would drop — locked
  by test), and one aggregation across all columns×sentinel-groups for
  FK sentinel rates. Results are unchanged byte-for-byte, including
  error paths and empty-table edges.
- **Seed triggers** probe emptiness with a single-row fetch instead of a
  full count; the **watermark store** issues its ensure-DDL once per
  store instance (existence is monotonic within a run); **set_var**
  fetches its scalar with `first()` instead of collecting the whole
  result.
- **Condition builtins** (`row_count`, `table_empty`, `table_exists`)
  are memoized strictly within one group's evaluation batch, where all
  evaluations are semantically simultaneous — N threads gating on the
  same probe share one scan. The memo container is created per group
  iteration and discarded at group end, and the loom-level weave
  condition site carries no memo at all, so later groups and later
  weaves always observe earlier writes. Both staleness traps are locked
  by dependency-graph tests, and the review verified the locks fail
  under the rejected memo scopes.
- **Validate mode** checks source existence without launching jobs:
  catalog/Delta-log checks for Delta sources, filesystem existence for
  file sources — no reads, no schema inference. Existence rather than
  readability: an existing-but-unparseable location now validates and
  fails at execution with a better error (documented and test-locked).
- Test-session memory raised 2g→3g: the grown suite's tail merge stages
  exhausted the old execution-memory ceiling.

## How to test

- [x] uv sync --dev
- [x] uv run ruff check .
- [x] uv run ruff format .
- [x] uv run pyright .
- [x] uv run pytest (2551 passed) and the full Spark-marked suite (958 passed)

## Release / Versioning

- [x] PR title follows Conventional Commit format (feat:, fix:, chore:, docs:, ci:, etc.)
- [ ] Breaking change indicated (feat!: / fix!: or BREAKING CHANGE in body) — not breaking

## Notes

- No config surface change. Identical outcomes per site; only job/scan
  counts and driver latency change.