### PR TITLE
chore(engine): render results from stored metadata without spark jobs

### DIFF
--- a/docs/how-to/add-validation-rules.md
+++ b/docs/how-to/add-validation-rules.md
@@ -116,6 +116,11 @@ it straightforward to inspect and reprocess quarantined records.
     `fatal` for invariants that indicate corrupted or fundamentally invalid
     source data.
 
+    Preview mode is the one exception: it skips the per-rule result
+    computation, so fatal rules are not detected there and sampled data is
+    always shown with error-severity rows split out — the view you are
+    previewing for. Execute mode still aborts.
+
 ## Step 3 -- Add post-execution assertions
 
 Assertions validate outcomes after data is written. They check properties of

--- a/packages/weevr-core/src/weevr/result.py
+++ b/packages/weevr-core/src/weevr/result.py
@@ -471,12 +471,14 @@ class RunResult:
         if self.preview_data:
             lines.append("")
             lines.append("Preview:")
-            for name, df in self.preview_data.items():
-                try:
-                    cols = len(df.columns)
-                    rows = df.count()
-                    lines.append(f"  {name}  {cols} cols \u00d7 {rows} rows")
-                except Exception:
+            preview_meta = self._preview_metadata or {}
+            for name in self.preview_data:
+                meta = preview_meta.get(name) or {}
+                output_schema = meta.get("output_schema")
+                rows = meta.get("row_count")
+                if output_schema is not None and rows is not None:
+                    lines.append(f"  {name}  {len(output_schema)} cols \u00d7 {rows} rows")
+                else:
                     lines.append(f"  {name}  (unavailable)")
 
         return lines

--- a/packages/weevr-core/src/weevr/result.py
+++ b/packages/weevr-core/src/weevr/result.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from enum import StrEnum
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, TypedDict
 
 from weevr.engine.formatting import format_duration as _format_duration
 
@@ -44,6 +44,22 @@ class ExecutionMode(StrEnum):
     VALIDATE = "validate"
     PLAN = "plan"
     PREVIEW = "preview"
+
+
+class PreviewThreadMetadata(TypedDict, total=False):
+    """Per-thread metadata captured once at preview build time.
+
+    The single definition of the contract between the preview builder
+    (``Context._run_preview``, which writes it) and the renderers
+    (``weevr.engine.display`` and :meth:`RunResult.summary`, which read
+    it). Every key is optional: each capture degrades independently, and
+    readers must treat a missing key as "(unavailable)".
+    """
+
+    output_schema: list[tuple[str, str]]
+    row_count: int
+    samples: dict[str, list[dict[str, Any]]]
+    step_stats: dict[str, dict[str, Any]]
 
 
 class RunResult:
@@ -111,7 +127,7 @@ class RunResult:
         self.validation_errors = validation_errors
         self.warnings: list[str] = warnings if warnings is not None else []
         self._resolved_threads: dict[str, Any] | None = None
-        self._preview_metadata: dict[str, dict[str, Any]] | None = None
+        self._preview_metadata: dict[str, PreviewThreadMetadata] | None = None
 
     def dag(self, *, dark: bool | None = None) -> Any:
         """Return a DAG diagram for plan mode results.

--- a/packages/weevr/src/weevr/context.py
+++ b/packages/weevr/src/weevr/context.py
@@ -781,7 +781,11 @@ class Context:
                 df = run_pipeline(df, thread.steps, sources_map, observations=obs_registry)
 
                 if thread.validations:
-                    outcome = validate_dataframe(df, thread.validations)
+                    # Preview discards the per-rule results, so skip their
+                    # aggregation. Consequence (chosen behavior): no fatal
+                    # detection here — sampled data failing a fatal rule
+                    # still renders the error-split view.
+                    outcome = validate_dataframe(df, thread.validations, compute_results=False)
                     df = outcome.clean_df
 
                 if thread.keys is not None:

--- a/packages/weevr/src/weevr/context.py
+++ b/packages/weevr/src/weevr/context.py
@@ -48,7 +48,7 @@ from weevr.model.execution import LogLevel, resolve_effective_execution
 from weevr.model.loom import Loom
 from weevr.model.thread import Thread
 from weevr.model.weave import ConditionSpec, Weave
-from weevr.result import ExecutionMode, LoadedConfig, RunResult
+from weevr.result import ExecutionMode, LoadedConfig, PreviewThreadMetadata, RunResult
 from weevr.telemetry.logging import configure_logging
 
 logger = logging.getLogger(__name__)
@@ -763,7 +763,7 @@ class Context:
         )
 
         preview_data: dict[str, Any] = {}
-        preview_metadata: dict[str, dict[str, Any]] = {}
+        preview_metadata: dict[str, PreviewThreadMetadata] = {}
         errors: list[str] = []
 
         for thread_name, thread in all_threads.items():
@@ -796,7 +796,7 @@ class Context:
                 preview_data[thread_name] = df
 
                 # Capture preview metadata for enhanced HTML rendering
-                meta: dict[str, Any] = {
+                meta: PreviewThreadMetadata = {
                     "output_schema": [(name, str(dtype)) for name, dtype in df.dtypes],
                 }
                 with contextlib.suppress(Exception):
@@ -822,6 +822,9 @@ class Context:
                 # compute it. Rides its own suppress — a flaky count must
                 # degrade to a missing key (renderers show "(unavailable)"),
                 # never demote the whole thread to errors via the outer try.
+                # Unlike the harvest above, deliberately NOT gated on the
+                # sample capture: every metadata key degrades independently,
+                # so a thread can render a count without a sample table.
                 with contextlib.suppress(Exception):
                     meta["row_count"] = df.count()
                 preview_metadata[thread_name] = meta

--- a/packages/weevr/src/weevr/context.py
+++ b/packages/weevr/src/weevr/context.py
@@ -814,6 +814,12 @@ class Context:
                             "Preview step-statistics harvest failed for thread '%s'",
                             thread_name,
                         )
+                # Row count captured once here so rendering never has to
+                # compute it. Rides its own suppress — a flaky count must
+                # degrade to a missing key (renderers show "(unavailable)"),
+                # never demote the whole thread to errors via the outer try.
+                with contextlib.suppress(Exception):
+                    meta["row_count"] = df.count()
                 preview_metadata[thread_name] = meta
             except Exception as exc:
                 errors.append(f"Preview failed for thread '{thread_name}': {exc}")

--- a/packages/weevr/src/weevr/engine/display.py
+++ b/packages/weevr/src/weevr/engine/display.py
@@ -9,11 +9,14 @@ from typing import TYPE_CHECKING, Any
 
 from weevr.engine.formatting import format_duration as _format_duration
 from weevr.model.pipeline import STEP_TYPES
-from weevr.result import PreviewThreadMetadata
 
 if TYPE_CHECKING:
     from weevr.engine.planner import ExecutionPlan
     from weevr.model.thread import Thread
+
+    # Annotation-only: weevr.result lazily imports this module for
+    # _repr_html_, so a runtime import here would be cyclic.
+    from weevr.result import PreviewThreadMetadata
 
 # ---------------------------------------------------------------------------
 # SVG layout constants

--- a/packages/weevr/src/weevr/engine/display.py
+++ b/packages/weevr/src/weevr/engine/display.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import contextlib
 import html
 import types
 from pathlib import Path
@@ -3338,17 +3337,18 @@ def _render_preview_html(result: Any) -> str:
             f'<th style="{_S_TH}">Columns</th>'
             f'<th style="{_S_TH}">Rows</th></tr>'
         )
-        for name, df in preview_data.items():
+        for name in preview_data:
             name_esc = html.escape(name)
-            try:
-                cols = len(df.columns)
-                rows = df.count()
+            meta = preview_meta.get(name, {})
+            output_schema = meta.get("output_schema")
+            row_count = meta.get("row_count")
+            if output_schema is not None and row_count is not None:
                 parts.append(
                     f'<tr><td style="{_S_TD}">{name_esc}</td>'
-                    f'<td style="{_S_TD}">{cols}</td>'
-                    f'<td style="{_S_TD}">{rows:,}</td></tr>'
+                    f'<td style="{_S_TD}">{len(output_schema)}</td>'
+                    f'<td style="{_S_TD}">{row_count:,}</td></tr>'
                 )
-            except Exception:
+            else:
                 parts.append(
                     f'<tr><td style="{_S_TD}">{name_esc}</td>'
                     f'<td style="{_S_TD}" colspan="2">'
@@ -3377,11 +3377,7 @@ def _render_preview_html(result: Any) -> str:
         # Data flow waterfall SVG (partial: preview mode)
         if meta:
             try:
-                row_count = 0
-                df = preview_data.get(name)
-                if df is not None:
-                    with contextlib.suppress(Exception):
-                        row_count = df.count()
+                row_count = meta.get("row_count", 0)
                 pt = types.SimpleNamespace(
                     rows_read=row_count,
                     rows_after_transforms=row_count,

--- a/packages/weevr/src/weevr/engine/display.py
+++ b/packages/weevr/src/weevr/engine/display.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 
 from weevr.engine.formatting import format_duration as _format_duration
 from weevr.model.pipeline import STEP_TYPES
+from weevr.result import PreviewThreadMetadata
 
 if TYPE_CHECKING:
     from weevr.engine.planner import ExecutionPlan
@@ -3294,7 +3295,9 @@ def _render_preview_html(result: Any) -> str:
     config_name = html.escape(str(getattr(result, "config_name", "")))
     duration_ms = getattr(result, "duration_ms", 0) or 0
     preview_data: dict[str, Any] = getattr(result, "preview_data", None) or {}
-    preview_meta: dict[str, dict[str, Any]] = getattr(result, "_preview_metadata", None) or {}
+    preview_meta: dict[str, PreviewThreadMetadata] = (
+        getattr(result, "_preview_metadata", None) or {}
+    )
     telemetry = getattr(result, "telemetry", None)
     resolved = getattr(result, "_resolved_threads", None) or {}
     warnings: list[str] = getattr(result, "warnings", []) or []

--- a/packages/weevr/src/weevr/engine/display.py
+++ b/packages/weevr/src/weevr/engine/display.py
@@ -14,10 +14,6 @@ if TYPE_CHECKING:
     from weevr.engine.planner import ExecutionPlan
     from weevr.model.thread import Thread
 
-    # Annotation-only: weevr.result lazily imports this module for
-    # _repr_html_, so a runtime import here would be cyclic.
-    from weevr.result import PreviewThreadMetadata
-
 # ---------------------------------------------------------------------------
 # SVG layout constants
 # ---------------------------------------------------------------------------
@@ -3298,9 +3294,11 @@ def _render_preview_html(result: Any) -> str:
     config_name = html.escape(str(getattr(result, "config_name", "")))
     duration_ms = getattr(result, "duration_ms", 0) or 0
     preview_data: dict[str, Any] = getattr(result, "preview_data", None) or {}
-    preview_meta: dict[str, PreviewThreadMetadata] = (
-        getattr(result, "_preview_metadata", None) or {}
-    )
+    # Duck-typed like every other field read here; the metadata shape is
+    # defined once as PreviewThreadMetadata in weevr.result (not imported —
+    # weevr.result lazily imports this module, so any import edge back
+    # would be cyclic).
+    preview_meta: dict[str, dict[str, Any]] = getattr(result, "_preview_metadata", None) or {}
     telemetry = getattr(result, "telemetry", None)
     resolved = getattr(result, "_resolved_threads", None) or {}
     warnings: list[str] = getattr(result, "warnings", []) or []

--- a/packages/weevr/src/weevr/engine/display.py
+++ b/packages/weevr/src/weevr/engine/display.py
@@ -351,16 +351,22 @@ def _compute_layout(
 
         y += _NODE_HEIGHT + _V_SPACING
 
-    # Center rows horizontally
+    # Center rows horizontally. Group membership and per-group row widths
+    # are precomputed once so this pass stays linear in node count.
     canvas_width = max_row_width + _SVG_PADDING * 2
+    group_of: dict[str, int] = {
+        name: group_idx for group_idx, group in enumerate(plan.execution_order) for name in group
+    }
+    group_row_widths: dict[int, float] = {}
+    group_sizes: dict[int, int] = {}
+    for name in nodes:
+        group_idx = group_of.get(name, -1)
+        group_row_widths[group_idx] = group_row_widths.get(group_idx, 0.0) + nodes[name][2]
+        group_sizes[group_idx] = group_sizes.get(group_idx, 0) + 1
+    for group_idx, size in group_sizes.items():
+        group_row_widths[group_idx] += _H_SPACING * max(size - 1, 0)
     for name, (nx, ny, nw, nh) in list(nodes.items()):
-        group_idx = _find_group_index(name, plan.execution_order)
-        ordered_in_group = [
-            n for n in nodes if _find_group_index(n, plan.execution_order) == group_idx
-        ]
-        row_width = sum(nodes[n][2] for n in ordered_in_group) + _H_SPACING * max(
-            len(ordered_in_group) - 1, 0
-        )
+        row_width = group_row_widths[group_of.get(name, -1)]
         offset = (canvas_width - row_width) / 2 - _SVG_PADDING
         nodes[name] = (nx + offset, ny, nw, nh)
         node_x_center[name] = nx + offset + nw / 2
@@ -395,14 +401,6 @@ def _compute_layout(
 
     canvas_height = y - _V_SPACING + _NODE_HEIGHT + _SVG_PADDING
     return nodes, edges, canvas_width, canvas_height, lookup_nodes, lookup_edges
-
-
-def _find_group_index(name: str, execution_order: list[list[str]]) -> int:
-    """Find which execution group a thread belongs to."""
-    for idx, group in enumerate(execution_order):
-        if name in group:
-            return idx
-    return 0
 
 
 def _build_svg_style(dark: bool | None = None) -> str:

--- a/packages/weevr/src/weevr/operations/validation.py
+++ b/packages/weevr/src/weevr/operations/validation.py
@@ -43,6 +43,7 @@ class ValidationOutcome:
 def validate_dataframe(
     df: DataFrame,
     rules: list[ValidationRule],
+    compute_results: bool = True,
 ) -> ValidationOutcome:
     """Evaluate all validation rules in a single pass with severity routing.
 
@@ -55,6 +56,11 @@ def validate_dataframe(
     Args:
         df: Input DataFrame to validate.
         rules: Validation rules to evaluate.
+        compute_results: When False, skip the per-rule results aggregation
+            (a collect job) for callers that discard it — preview mode.
+            ``validation_results`` comes back empty and, with no computed
+            counts, there is no fatal detection: the error-rule split
+            always runs. Execute-mode callers must keep the default.
 
     Returns:
         ValidationOutcome with clean/quarantine split and per-rule results.
@@ -96,17 +102,19 @@ def validate_dataframe(
         tagged = tagged.withColumns(tag_exprs)
 
     # Step 2: Compute validation results in a single aggregation
-    validation_results = _compute_results(tagged, applied, unapplied)
+    validation_results: list[ValidationResult] = []
+    if compute_results:
+        validation_results = _compute_results(tagged, applied, unapplied)
 
-    # Step 3: Check for fatal failures
-    has_fatal = any(vr.severity == "fatal" and vr.rows_failed > 0 for vr in validation_results)
-    if has_fatal:
-        return ValidationOutcome(
-            clean_df=df,
-            quarantine_df=None,
-            validation_results=validation_results,
-            has_fatal=True,
-        )
+        # Step 3: Check for fatal failures
+        has_fatal = any(vr.severity == "fatal" and vr.rows_failed > 0 for vr in validation_results)
+        if has_fatal:
+            return ValidationOutcome(
+                clean_df=df,
+                quarantine_df=None,
+                validation_results=validation_results,
+                has_fatal=True,
+            )
 
     # Step 4: Identify error-severity rules for split
     error_rules = [(i, col, rule) for i, col, rule in applied if rule.severity == "error"]

--- a/tests/weevr/engine/fixtures/dag_layout_baseline.svg
+++ b/tests/weevr/engine/fixtures/dag_layout_baseline.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 264 450" width="264" height="450"><style>
+  .dag-node{fill:#f7fafc;stroke:#a0aec0;stroke-width:1.5}
+  .dag-node-cached{fill:#ebf8ff;stroke:#3182ce;stroke-width:2}
+  .dag-label{fill:#2d3748;font-family:system-ui, -apple-system, sans-serif;font-size:13px;text-anchor:middle;dominant-baseline:central}
+  .dag-label-cached{fill:#2c5282;font-family:system-ui, -apple-system, sans-serif;font-size:13px;text-anchor:middle;dominant-baseline:central}
+  .dag-edge{stroke:#a0aec0;stroke-width:1.5;fill:none}
+  .dag-arrow{fill:#a0aec0}
+  .dag-lookup-node{fill:#fffaf0;stroke:#dd6b20;stroke-width:1.5;stroke-dasharray:4 2}
+  .dag-lookup-node-label{fill:#c05621;font-family:system-ui, -apple-system, sans-serif;font-size:11px;text-anchor:middle;dominant-baseline:central}
+  .dag-lookup-edge{stroke:#dd6b20;stroke-width:1.5;fill:none;stroke-dasharray:6 3}
+  .dag-lookup-line{stroke:#dd6b20;stroke-width:1;stroke-dasharray:6 3}
+  .dag-lookup-label{fill:#c05621;font-family:system-ui, -apple-system, sans-serif;font-size:11px;text-anchor:middle;dominant-baseline:central}
+  .dag-swimlane{fill:none;stroke:#a0aec0;stroke-width:1;rx:8}
+  .dag-swimlane-header{fill:#2d3748;font-family:system-ui, -apple-system, sans-serif;font-size:13px;text-anchor:middle;dominant-baseline:central;font-weight:600}
+  .dag-bg{fill:#ffffff}
+  @media(prefers-color-scheme:dark){
+    .dag-node{fill:#2d3748;stroke:#718096}
+    .dag-node-cached{fill:#2a4365;stroke:#63b3ed}
+    .dag-label{fill:#e2e8f0}
+    .dag-label-cached{fill:#bee3f8}
+    .dag-edge{stroke:#718096}
+    .dag-arrow{fill:#718096}
+    .dag-lookup-node{fill:#744210;stroke:#ed8936}
+    .dag-lookup-node-label{fill:#fbd38d}
+    .dag-lookup-edge{stroke:#ed8936}
+    .dag-lookup-line{stroke:#ed8936}
+    .dag-lookup-label{fill:#fbd38d}
+    .dag-swimlane{stroke:#718096}
+    .dag-swimlane-header{fill:#e2e8f0}
+    .dag-bg{fill:#1a202c}
+  }
+</style><defs><marker id="dag-arrowhead" markerWidth="8" markerHeight="8" refX="8" refY="4" orient="auto-start-reverse"><polygon points="0 0, 8 4, 0 8" class="dag-arrow"/></marker><marker id="dag-arrowhead-lookup" markerWidth="8" markerHeight="8" refX="8" refY="4" orient="auto-start-reverse"><polygon points="0 0, 8 4, 0 8" fill="#dd6b20"/></marker></defs><rect width="264" height="450" class="dag-bg"/><line x1="70.0" y1="56.0" x2="80.0" y2="176.0" class="dag-lookup-edge" marker-end="url(#dag-arrowhead-lookup)"/><line x1="80.0" y1="202.0" x2="194.0" y2="242.0" class="dag-lookup-edge" marker-end="url(#dag-arrowhead-lookup)"/><line x1="189.2" y1="202.0" x2="194.0" y2="358.0" class="dag-lookup-edge" marker-end="url(#dag-arrowhead-lookup)"/><rect x="34.8" y="176.0" width="90.4" height="26.0" rx="13" class="dag-lookup-node"/><text x="80.0" y="189.0" class="dag-lookup-node-label">lk_rates</text><rect x="149.2" y="176.0" width="80.0" height="26.0" rx="13" class="dag-lookup-node"/><text x="189.2" y="189.0" class="dag-lookup-node-label">lk_geo</text><line x1="70.0" y1="56.0" x2="70.0" y2="242.0" class="dag-edge" marker-end="url(#dag-arrowhead)"/><line x1="70.0" y1="56.0" x2="194.0" y2="242.0" class="dag-edge" marker-end="url(#dag-arrowhead)"/><line x1="194.0" y1="56.0" x2="194.0" y2="242.0" class="dag-edge" marker-end="url(#dag-arrowhead)"/><line x1="70.0" y1="278.0" x2="70.0" y2="358.0" class="dag-edge" marker-end="url(#dag-arrowhead)"/><line x1="70.0" y1="278.0" x2="194.0" y2="358.0" class="dag-edge" marker-end="url(#dag-arrowhead)"/><line x1="194.0" y1="278.0" x2="194.0" y2="358.0" class="dag-edge" marker-end="url(#dag-arrowhead)"/><rect x="20.0" y="20.0" width="100.0" height="36.0" rx="6" class="dag-node-cached"/><text x="70.0" y="38.0" class="dag-label-cached">alpha</text><rect x="144.0" y="20.0" width="100.0" height="36.0" rx="6" class="dag-node"/><text x="194.0" y="38.0" class="dag-label">beta</text><rect x="20.0" y="242.0" width="100.0" height="36.0" rx="6" class="dag-node"/><text x="70.0" y="260.0" class="dag-label">gamma</text><rect x="144.0" y="242.0" width="100.0" height="36.0" rx="6" class="dag-node"/><text x="194.0" y="260.0" class="dag-label">delta</text><rect x="20.0" y="358.0" width="100.0" height="36.0" rx="6" class="dag-node"/><text x="70.0" y="376.0" class="dag-label">epsilon</text><rect x="144.0" y="358.0" width="100.0" height="36.0" rx="6" class="dag-node"/><text x="194.0" y="376.0" class="dag-label">zeta</text></svg>

--- a/tests/weevr/engine/test_display.py
+++ b/tests/weevr/engine/test_display.py
@@ -2088,3 +2088,27 @@ class TestDisplayPurity:
         )
         hits = [pattern for pattern in forbidden if pattern in source]
         assert hits == [], f"DataFrame computation crept into display.py: {hits}"
+
+
+class TestPreviewZeroRows:
+    """A 0-row preview renders '0', never '(unavailable)'."""
+
+    def test_output_shape_renders_zero_not_unavailable(self) -> None:
+        import types as _types
+
+        from weevr.engine.display import _render_preview_html
+
+        result = _types.SimpleNamespace(
+            status="success",
+            config_type="thread",
+            config_name="empty_t",
+            duration_ms=0,
+            preview_data={"empty_t": object()},
+            _preview_metadata={"empty_t": {"output_schema": [("id", "bigint")], "row_count": 0}},
+            telemetry=None,
+            _resolved_threads=None,
+            warnings=[],
+        )
+        html_out = _render_preview_html(result)
+        assert ">0<" in html_out
+        assert "(unavailable)" not in html_out

--- a/tests/weevr/engine/test_display.py
+++ b/tests/weevr/engine/test_display.py
@@ -2067,3 +2067,24 @@ class TestLayoutBaseline:
         )
         baseline = (Path(__file__).parent / "fixtures" / "dag_layout_baseline.svg").read_text()
         assert render_dag_svg(plan) == baseline
+
+
+class TestDisplayPurity:
+    """display.py is pure formatting — it never computes over DataFrames."""
+
+    def test_no_dataframe_method_calls_in_source(self) -> None:
+        import inspect
+
+        from weevr.engine import display
+
+        source = Path(inspect.getfile(display)).read_text()
+        forbidden = (
+            ".count()",
+            ".collect()",
+            ".toPandas()",
+            ".first()",
+            ".take(",
+            ".limit(",
+        )
+        hits = [pattern for pattern in forbidden if pattern in source]
+        assert hits == [], f"DataFrame computation crept into display.py: {hits}"

--- a/tests/weevr/engine/test_display.py
+++ b/tests/weevr/engine/test_display.py
@@ -2043,3 +2043,27 @@ class TestPartialData:
         # Row counts should still be present
         assert "Row Counts" in html_out
         assert "100" in html_out
+
+
+class TestLayoutBaseline:
+    """The layout refactor is locked by byte-identical SVG output."""
+
+    def test_multi_group_dag_matches_baseline(self) -> None:
+        plan = _make_plan(
+            threads=["alpha", "beta", "gamma", "delta", "epsilon", "zeta"],
+            dependencies={
+                "alpha": [],
+                "beta": [],
+                "gamma": ["alpha"],
+                "delta": ["alpha", "beta"],
+                "epsilon": ["gamma"],
+                "zeta": ["gamma", "delta"],
+            },
+            execution_order=[["alpha", "beta"], ["gamma", "delta"], ["epsilon", "zeta"]],
+            cache_targets=["alpha"],
+            lookup_schedule={1: ["lk_rates", "lk_geo"]},
+            lookup_producers={"lk_rates": "alpha", "lk_geo": None},
+            lookup_consumers={"lk_rates": ["delta"], "lk_geo": ["zeta"]},
+        )
+        baseline = (Path(__file__).parent / "fixtures" / "dag_layout_baseline.svg").read_text()
+        assert render_dag_svg(plan) == baseline

--- a/tests/weevr/operations/test_validation.py
+++ b/tests/weevr/operations/test_validation.py
@@ -210,3 +210,48 @@ class TestTagBatching:
         with job_counter() as jc:
             validate_dataframe(df, rules)
         assert jc.jobs == 0  # probing is catalyst analysis, never a job
+
+
+@pytest.mark.spark
+class TestComputeResultsFlag:
+    """compute_results=False skips the aggregation preview discards."""
+
+    def test_false_skips_results_and_always_splits(self, spark) -> None:
+        """Error split happens even alongside a failing fatal rule.
+
+        Without computed results there is no fatal detection, so the
+        split path always runs — the chosen preview behavior.
+        """
+        df = spark.createDataFrame([(1, 100), (2, -5), (None, 50)], "id INT, amount INT")
+        rules = [
+            ValidationRule(rule=SparkExpr("amount > 0"), severity="error", name="positive"),
+            ValidationRule(rule=SparkExpr("id IS NOT NULL"), severity="fatal", name="id_fatal"),
+        ]
+        outcome = validate_dataframe(df, rules, compute_results=False)
+
+        assert outcome.validation_results == []
+        assert outcome.has_fatal is False
+        clean_rows = {r["amount"] for r in outcome.clean_df.collect()}
+        assert clean_rows == {100, 50}
+        assert outcome.quarantine_df is not None
+        assert outcome.quarantine_df.count() == 1
+
+    def test_false_launches_no_results_aggregation(self, spark, monkeypatch) -> None:
+        from weevr.operations import validation as validation_mod
+
+        def refuse(*args, **kwargs):
+            raise AssertionError("results aggregation must be skipped")
+
+        monkeypatch.setattr(validation_mod, "_compute_results", refuse)
+        df = spark.createDataFrame([(1,), (2,)], "id INT")
+        rules = [ValidationRule(rule=SparkExpr("id IS NOT NULL"), severity="error", name="nn")]
+        outcome = validate_dataframe(df, rules, compute_results=False)
+        assert outcome.clean_df.count() == 2
+
+    def test_default_still_computes_and_short_circuits_fatal(self, spark) -> None:
+        df = spark.createDataFrame([(1,), (None,)], "id INT")
+        rules = [ValidationRule(rule=SparkExpr("id IS NOT NULL"), severity="fatal", name="f")]
+        outcome = validate_dataframe(df, rules)
+        assert outcome.has_fatal is True
+        assert outcome.validation_results
+        assert outcome.clean_df is df

--- a/tests/weevr/test_context.py
+++ b/tests/weevr/test_context.py
@@ -1473,3 +1473,36 @@ write:
         # the -2 row (error rule) is split out; the NULL row (fatal) stays.
         ids = {r["id"] for r in result.preview_data["valprev1"].collect()}
         assert ids == {1, None}
+
+
+@pytest.mark.spark
+class TestPreviewPartialMetadata:
+    """Each preview metadata key degrades independently."""
+
+    def test_sample_capture_failure_keeps_count(
+        self, spark: SparkSession, tmp_path: Path, monkeypatch
+    ) -> None:
+        from pyspark.sql import DataFrame
+
+        src = str(tmp_path / "src_partial")
+        tgt = str(tmp_path / "tgt_partial")
+        rows = [{"id": i} for i in range(3)]
+        spark.createDataFrame(rows, "id INT").write.format("delta").save(src)
+        yaml_path = _create_thread_yaml(tmp_path, "prevs1", src, tgt)
+        ctx = Context(spark=spark, project=_project_dir(tmp_path))
+
+        def refuse_pandas(self, *args, **kwargs):
+            raise RuntimeError("sample capture blocked")
+
+        monkeypatch.setattr(DataFrame, "toPandas", refuse_pandas)
+        result = ctx.run(yaml_path, mode="preview")
+
+        assert result.status == "success"
+        assert result._preview_metadata is not None
+        meta = result._preview_metadata["prevs1"]
+        assert meta["row_count"] == 3
+        assert "samples" not in meta
+
+        html_out = result._repr_html_()
+        assert html_out is not None
+        assert ">3<" in html_out

--- a/tests/weevr/test_context.py
+++ b/tests/weevr/test_context.py
@@ -1417,3 +1417,59 @@ class TestPreviewRenderPurity:
         assert html_out is not None
         assert "(unavailable)" in html_out
         assert "Output Schema" in html_out or "output_schema" not in html_out
+
+
+@pytest.mark.spark
+class TestPreviewValidationSkipsResults:
+    """Preview never pays for validation results it discards."""
+
+    def _thread_yaml_with_validations(self, base: Path, name: str, src: str, tgt: str) -> Path:
+        thread_dir = base / "threads"
+        thread_dir.mkdir(parents=True, exist_ok=True)
+        file_path = thread_dir / f"{name}.thread"
+        file_path.write_text(
+            f"""\
+config_version: "1.0"
+sources:
+  main:
+    type: delta
+    alias: "{src}"
+validations:
+  - name: positive_val
+    rule: "id IS NULL OR id >= 0"
+    severity: error
+  - name: id_present
+    rule: "id IS NOT NULL"
+    severity: fatal
+target:
+  path: "{tgt}"
+write:
+  mode: overwrite
+"""
+        )
+        return file_path
+
+    def test_preview_skips_results_aggregation_and_splits(
+        self, spark: SparkSession, tmp_path: Path, monkeypatch
+    ) -> None:
+        from weevr.operations import validation as validation_mod
+
+        src = str(tmp_path / "src_valprev")
+        tgt = str(tmp_path / "tgt_valprev")
+        rows = [{"id": 1}, {"id": -2}, {"id": None}]
+        spark.createDataFrame(rows, "id INT").write.format("delta").save(src)
+
+        def refuse(*args, **kwargs):
+            raise AssertionError("preview must not compute validation results")
+
+        monkeypatch.setattr(validation_mod, "_compute_results", refuse)
+        yaml_path = self._thread_yaml_with_validations(tmp_path, "valprev1", src, tgt)
+        ctx = Context(spark=spark, project=_project_dir(tmp_path))
+        result = ctx.run(yaml_path, mode="preview")
+
+        assert result.status == "success"
+        assert result.preview_data is not None
+        # Error-split view even though the fatal rule fails on the sample:
+        # the -2 row (error rule) is split out; the NULL row (fatal) stays.
+        ids = {r["id"] for r in result.preview_data["valprev1"].collect()}
+        assert ids == {1, None}

--- a/tests/weevr/test_context.py
+++ b/tests/weevr/test_context.py
@@ -1358,3 +1358,62 @@ class TestValidateModeSourceProbes:
         ctx = Context(spark=spark, project=_project_dir(tmp_path))
         threads = {"c": self._thread_with_source("csv", str(empty_dir), tgt)}
         assert ctx._check_source_existence(threads) == []
+
+
+@pytest.mark.spark
+class TestPreviewRenderPurity:
+    """Preview rendering is pure formatting over metadata captured at build."""
+
+    def test_render_and_rerender_fire_zero_jobs(
+        self, spark: SparkSession, tmp_path: Path, job_counter
+    ) -> None:
+        src = str(tmp_path / "src_purity")
+        tgt = str(tmp_path / "tgt_purity")
+        data = [{"id": i, "val": f"v{i}"} for i in range(25)]
+        spark.createDataFrame(data).write.format("delta").save(src)
+
+        yaml_path = _create_thread_yaml(tmp_path, "prevp1", src, tgt)
+        ctx = Context(spark=spark, project=_project_dir(tmp_path))
+        result = ctx.run(yaml_path, mode="preview", sample_rows=50)
+
+        assert result._preview_metadata is not None
+        assert result._preview_metadata["prevp1"]["row_count"] == 25
+
+        with job_counter() as jc:
+            html_first = result._repr_html_()
+            html_second = result._repr_html_()
+        assert jc.jobs == 0
+        assert html_first is not None
+        assert "(unavailable)" not in html_first
+        assert ">25<" in html_first
+        assert html_first == html_second
+
+    def test_count_capture_failure_degrades_cleanly(
+        self, spark: SparkSession, tmp_path: Path, monkeypatch
+    ) -> None:
+        """A failed count leaves the preview intact, never demotes to errors."""
+        from pyspark.sql import DataFrame
+
+        src = str(tmp_path / "src_degrade")
+        tgt = str(tmp_path / "tgt_degrade")
+        spark.createDataFrame([{"id": 1, "val": "a"}]).write.format("delta").save(src)
+        yaml_path = _create_thread_yaml(tmp_path, "prevd1", src, tgt)
+        ctx = Context(spark=spark, project=_project_dir(tmp_path))
+
+        def refuse_count(self, *args, **kwargs):
+            raise RuntimeError("count blocked for degrade test")
+
+        monkeypatch.setattr(DataFrame, "count", refuse_count)
+        result = ctx.run(yaml_path, mode="preview")
+
+        assert result.status == "success"
+        assert not [w for w in (result.warnings or []) if "Preview failed" in w]
+        assert result._preview_metadata is not None
+        meta = result._preview_metadata["prevd1"]
+        assert "row_count" not in meta
+        assert "output_schema" in meta
+
+        html_out = result._repr_html_()
+        assert html_out is not None
+        assert "(unavailable)" in html_out
+        assert "Output Schema" in html_out or "output_schema" not in html_out

--- a/tests/weevr/test_result.py
+++ b/tests/weevr/test_result.py
@@ -1554,11 +1554,9 @@ class TestSummaryExports:
 class TestSummaryPreviewMetadata:
     """summary() on preview results is pure formatting over stored metadata."""
 
-    class _Poison:
-        """Fails loudly on any attribute access — a stand-in DataFrame."""
-
-        def __getattr__(self, name: str):
-            raise AssertionError("summary must not touch preview DataFrames")
+    # A bare object() stands in for the DataFrame: it has no DataFrame
+    # surface at all, so any attribute access (df.count, df.columns)
+    # raises AttributeError and errors the test.
 
     def test_summary_reads_metadata_not_dataframes(self) -> None:
         result = RunResult(
@@ -1566,7 +1564,7 @@ class TestSummaryPreviewMetadata:
             mode=ExecutionMode.PREVIEW,
             config_type="thread",
             config_name="dim_customer",
-            preview_data={"dim_customer": self._Poison()},
+            preview_data={"dim_customer": object()},
         )
         result._preview_metadata = {
             "dim_customer": {
@@ -1584,7 +1582,7 @@ class TestSummaryPreviewMetadata:
             mode=ExecutionMode.PREVIEW,
             config_type="thread",
             config_name="dim_customer",
-            preview_data={"dim_customer": self._Poison()},
+            preview_data={"dim_customer": object()},
         )
         s = result.summary()
         assert "(unavailable)" in s
@@ -1596,7 +1594,7 @@ class TestSummaryPreviewMetadata:
             mode=ExecutionMode.PREVIEW,
             config_type="thread",
             config_name="dim_customer",
-            preview_data={"dim_customer": self._Poison()},
+            preview_data={"dim_customer": object()},
         )
         result._preview_metadata = {
             "dim_customer": {"output_schema": [("id", "bigint")], "row_count": 0}

--- a/tests/weevr/test_result.py
+++ b/tests/weevr/test_result.py
@@ -1588,3 +1588,19 @@ class TestSummaryPreviewMetadata:
         )
         s = result.summary()
         assert "(unavailable)" in s
+
+    def test_summary_zero_row_preview_renders_zero(self) -> None:
+        """A 0-row preview is a real answer, not a degrade case."""
+        result = RunResult(
+            status="success",
+            mode=ExecutionMode.PREVIEW,
+            config_type="thread",
+            config_name="dim_customer",
+            preview_data={"dim_customer": self._Poison()},
+        )
+        result._preview_metadata = {
+            "dim_customer": {"output_schema": [("id", "bigint")], "row_count": 0}
+        }
+        s = result.summary()
+        assert "1 cols × 0 rows" in s
+        assert "(unavailable)" not in s

--- a/tests/weevr/test_result.py
+++ b/tests/weevr/test_result.py
@@ -1549,3 +1549,42 @@ class TestSummaryExports:
         )
         text = result.summary()
         assert "Exports:" not in text
+
+
+class TestSummaryPreviewMetadata:
+    """summary() on preview results is pure formatting over stored metadata."""
+
+    class _Poison:
+        """Fails loudly on any attribute access — a stand-in DataFrame."""
+
+        def __getattr__(self, name: str):
+            raise AssertionError("summary must not touch preview DataFrames")
+
+    def test_summary_reads_metadata_not_dataframes(self) -> None:
+        result = RunResult(
+            status="success",
+            mode=ExecutionMode.PREVIEW,
+            config_type="thread",
+            config_name="dim_customer",
+            preview_data={"dim_customer": self._Poison()},
+        )
+        result._preview_metadata = {
+            "dim_customer": {
+                "output_schema": [("id", "bigint"), ("name", "string")],
+                "row_count": 42,
+            }
+        }
+        s = result.summary()
+        assert "2 cols" in s
+        assert "42 rows" in s
+
+    def test_summary_missing_metadata_degrades(self) -> None:
+        result = RunResult(
+            status="success",
+            mode=ExecutionMode.PREVIEW,
+            config_type="thread",
+            config_name="dim_customer",
+            preview_data={"dim_customer": self._Poison()},
+        )
+        s = result.summary()
+        assert "(unavailable)" in s


### PR DESCRIPTION
## Summary

- Re-displaying a preview `RunResult` in a notebook fired two `df.count()`
  jobs per thread on every cell render, `summary()` counted per thread per
  call, preview computed validation results it always discarded, and the
  DAG layout did a quadratic driver pass. Display is now pure formatting
  over metadata captured once at build time.
- Closes #202

## What changed

- **Preview builds capture the row count once**, at the same point the
  10-row sample is captured, into the preview metadata. The capture rides
  its own suppress: a flaky count degrades to "(unavailable)" in the
  rendered output and never demotes the thread to an error while its
  sample and schema remain intact (degrade shape locked by tests,
  including the count-without-samples partial state and the 0-row case).
- **Rendering and `summary()` read metadata only.** Re-rendering fires
  zero Spark jobs (listener-locked, render-twice). The metadata contract
  is now a `PreviewThreadMetadata` TypedDict defined once in the core
  wheel — which also sheds its last duck-typed DataFrame call on the
  preview path; a poison-object test proves `summary()` never touches a
  DataFrame. A source-level purity test locks the invariant that
  `display.py` contains no DataFrame method calls at all.
- **Preview skips the validation-results aggregation** it provably
  discarded (`validate_dataframe(compute_results=False)`; execute-mode
  callers keep the default, byte-identical). Chosen consequence,
  documented in the validation guide: preview has no fatal detection, so
  sampled data failing a fatal rule renders the error-split view — the
  view preview exists to show. Execute mode still aborts on fatal
  (existing suite unchanged).
- **DAG layout centering linearized** — the name-to-group map is
  precomputed once instead of scanned per node. Locked byte-identical by
  an SVG baseline fixture generated from the old implementation (review
  re-ran the fixture test against a pre-refactor checkout to prove the
  lock is not self-referential).

## How to test

- [x] uv sync --dev
- [x] uv run ruff check .
- [x] uv run ruff format .
- [x] uv run pyright .
- [x] uv run pytest (2557 passed) and the full Spark-marked suite (965 passed)
- [x] uv run mkdocs build --strict && npx markdownlint-cli2 'docs/**/*.md'

## Release / Versioning

- [x] PR title follows Conventional Commit format (feat:, fix:, chore:, docs:, ci:, etc.)
- [ ] Breaking change indicated (feat!: / fix!: or BREAKING CHANGE in body) — not breaking

## Notes

- Rendered values are parity-preserved. The one behavioral nuance (fatal
  rules undetected in preview) is preview-only, sampled-data-only, and
  documented as the chosen behavior.