### PR TITLE
fix(engine): harden write existence probes and commit attribution

### DIFF
--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -262,10 +262,13 @@ depends on what was executed:
   computed as byproducts of the write itself (query observations and
   Delta commit metrics) rather than by separate Spark jobs; a
   quarantine count runs only when validation actually quarantined
-  rows, against the cached quarantine frame. When a commit-metrics
-  read fails or a concurrent writer commits between the write and the
-  read, the count degrades to zero with a logged warning — a wrong
-  number is never reported. Merge-based paths (dimensions, CDC, merge
+  rows, against the cached quarantine frame. Single-pass commits carry
+  a [lineage stamp](#commit-lineage-stamps), so the engine finds its
+  own commit exactly even when concurrent writers interleave. In the
+  rare case where attribution is truly impossible (the history read
+  itself fails), `rows_written` is `None` — unknown, never a false
+  zero — and a warning naming the thread and target is surfaced on
+  `RunResult.warnings`. Merge-based paths (dimensions, CDC, merge
   write mode) retain direct counts.
 - **validation_results** -- Per-rule pass/fail counts and severity
 - **assertion_results** -- Post-write assertion outcomes
@@ -311,9 +314,13 @@ version closes:
 `rows_unchanged` is intentionally absent: no Delta metric expresses it
 (`numTargetRowsCopied` is a file-rewrite artifact, not a logical
 count), and deriving it arithmetically risks a wrong number under
-quarantine and seeding edge cases. When metrics cannot be read — or a
-concurrent writer's commit makes attribution unsafe — the fields stay
-zero and a warning is logged.
+quarantine and seeding edge cases. When merge metrics cannot be read —
+or a concurrent writer's commit makes attribution unsafe — the fields
+stay zero and a warning is logged. The first write of a dimension is a
+plain save, not a merge: its commit carries the
+[lineage stamp](#commit-lineage-stamps), and an unattributable
+first-write count reports `rows_inserted` as `None` (unknown), never
+zero.
 
 ### Weave telemetry fields
 
@@ -345,6 +352,57 @@ for weave_name, weave_telem in telemetry.weave_telemetry.items():
         print(f"    Written:     {t.rows_written}")
         print(f"    Quarantined: {t.rows_quarantined}")
 ```
+
+`rows_written` is `int | None`: `None` means the write succeeded but
+its count could not be attributed (unknown). Sinks and dashboards that
+aggregate counts should sum the known values and treat `None` as a
+data-quality signal, not as zero.
+
+## Commit lineage stamps
+
+Every single-pass engine write — overwrite, append, an incremental
+first write, and a dimension's first write — stamps its Delta commit
+with a small JSON document in the commit's `userMetadata`, visible in
+`DESCRIBE HISTORY`:
+
+```json
+{
+  "engine": "weevr",
+  "version": 1,
+  "run_id": "5f0c9c8e-...-b2a1",
+  "thread": "dim_customer",
+  "loom": "nightly",
+  "weave": "dimensions",
+  "mode": "append"
+}
+```
+
+The stamp serves two purposes:
+
+- **Exact attribution.** After a write, the engine finds its own
+  commit by its stamp rather than assuming the newest commit is its
+  own — so `rows_written` stays exact no matter how many concurrent
+  writers (ad-hoc appends, `OPTIMIZE`, other pipelines) interleave.
+- **Lineage.** The `run_id` in the stamp is the same run identity
+  carried by audit columns (`${run.id}`) and telemetry, so a table's
+  Delta history joins back to the run that produced each commit.
+
+The **stable core** of the stamp is the engine marker (`engine`),
+`run_id`, and `thread` — attribution matches on exactly these, and
+they are safe to build tooling against. The remaining fields (`loom`,
+`weave`, `mode`, `version`) are best-effort context and may evolve.
+
+Two boundaries to be aware of:
+
+- **Merge commits are not stamped.** Delta only honors per-write
+  `userMetadata` on DataFrameWriter paths; merge commits (dimension
+  merges, CDC routing, merge write mode) would require session-level
+  configuration, which races across parallel threads. Their counts
+  come from eager inputs and guarded merge metrics instead.
+- **The stamp takes precedence.** If you set a session-level
+  `spark.databricks.delta.commitInfo.userMetadata`, engine-stamped
+  commits override it with the stamp; commits the engine does not
+  stamp (merges, seeds, warp pre-init) still carry your session value.
 
 ## Progress reporting
 

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -390,7 +390,9 @@ The stamp serves two purposes:
 The **stable core** of the stamp is the engine marker (`engine`),
 `run_id`, and `thread` — attribution matches on exactly these, and
 they are safe to build tooling against. The remaining fields (`loom`,
-`weave`, `mode`, `version`) are best-effort context and may evolve.
+`weave`, `mode`, `version`) are best-effort context and may evolve;
+`mode` records the thread's configured write mode, not the physical
+branch taken (a first write executes as an overwrite regardless).
 
 Two boundaries to be aware of:
 

--- a/docs/how-to/implement-custom-telemetry-sink.md
+++ b/docs/how-to/implement-custom-telemetry-sink.md
@@ -47,6 +47,11 @@ for weave_name, weave_telem in telemetry.weave_telemetry.items():
         print(f"    Quarantined:  {thread_telem.rows_quarantined}")
 ```
 
+`rows_written` is `int | None` — `None` means the write succeeded but
+its count could not be attributed to the engine's own commit. Sinks
+should carry the null through (and alert on it) rather than coalescing
+it to zero, which would read as "wrote nothing".
+
 ## Step 2 -- Write telemetry to a Delta table
 
 Flatten the telemetry hierarchy into rows and write to a dedicated telemetry

--- a/packages/weevr-core/src/weevr/result.py
+++ b/packages/weevr-core/src/weevr/result.py
@@ -325,19 +325,28 @@ class RunResult:
     def _summary_execute(self) -> list[str]:
         lines: list[str] = [f"Scope:  {self.config_type}:{self.config_name}"]
 
-        rows_written = 0
+        # Sum the known counts; None means a write whose count could not
+        # be attributed (unknown, never 0) — the accompanying warning
+        # qualifies the total.
+        rows_written: int | None = 0
         if self.detail is not None:
             if self.config_type == "thread":
                 rows_written = getattr(self.detail, "rows_written", 0)
-            elif self.config_type == "weave":
-                for tr in getattr(self.detail, "thread_results", []):
-                    rows_written += getattr(tr, "rows_written", 0)
-            elif self.config_type == "loom":
-                for wr in getattr(self.detail, "weave_results", []):
-                    for tr in getattr(wr, "thread_results", []):
-                        rows_written += getattr(tr, "rows_written", 0)
+            else:
+                thread_results: list[Any] = []
+                if self.config_type == "weave":
+                    thread_results = getattr(self.detail, "thread_results", [])
+                elif self.config_type == "loom":
+                    for wr in getattr(self.detail, "weave_results", []):
+                        thread_results.extend(getattr(wr, "thread_results", []))
+                rows_written = sum(
+                    rows
+                    for tr in thread_results
+                    if (rows := getattr(tr, "rows_written", 0)) is not None
+                )
 
-        lines.append(f"Rows:   {rows_written:,} written")
+        rows_text = "unknown" if rows_written is None else f"{rows_written:,}"
+        lines.append(f"Rows:   {rows_text} written")
         lines.append(f"Time:   {_format_duration(self.duration_ms)}")
 
         if self.config_type == "loom" and self.detail is not None:

--- a/packages/weevr-core/src/weevr/telemetry/results.py
+++ b/packages/weevr-core/src/weevr/telemetry/results.py
@@ -79,7 +79,8 @@ class ThreadTelemetry(FrozenBase):
         validation_results: Results of pre-write validation rules.
         assertion_results: Results of post-write assertions.
         rows_read: Total rows read from sources.
-        rows_written: Rows written to the target.
+        rows_written: Rows written to the target, or ``None`` when a
+            successful write's count could not be attributed (unknown).
         rows_quarantined: Rows written to the quarantine table.
         rows_after_transforms: Row count after transforms, before validation.
         load_mode: Load mode used (full, incremental_watermark, etc.).
@@ -106,7 +107,7 @@ class ThreadTelemetry(FrozenBase):
     validation_results: list[ValidationResult] = []
     assertion_results: list[AssertionResult] = []
     rows_read: int = 0
-    rows_written: int = 0
+    rows_written: int | None = 0
     rows_quarantined: int = 0
     rows_after_transforms: int = 0
     load_mode: str | None = None

--- a/packages/weevr/src/weevr/context.py
+++ b/packages/weevr/src/weevr/context.py
@@ -356,6 +356,7 @@ class Context:
                 config_name=resolved.config_name,
                 detail=engine_result,
                 telemetry=engine_result.telemetry,
+                warnings=self._collect_thread_warnings(engine_result),
             )
             result._resolved_threads = {resolved.config_name: model}
             return result
@@ -427,7 +428,7 @@ class Context:
                 config_name=resolved.config_name,
                 detail=engine_result,
                 telemetry=engine_result.telemetry,
-                warnings=warnings,
+                warnings=warnings + self._collect_thread_warnings(engine_result),
             )
             result._resolved_threads = dict(weave_threads)
             return result
@@ -479,7 +480,7 @@ class Context:
             config_name=resolved.config_name,
             detail=engine_result,
             telemetry=engine_result.telemetry,
-            warnings=all_warnings,
+            warnings=all_warnings + self._collect_thread_warnings(engine_result),
         )
         merged_threads: dict[str, Any] = {}
         for thread_map in filtered_threads.values():
@@ -490,6 +491,27 @@ class Context:
     # ------------------------------------------------------------------
     # Thread filtering
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _collect_thread_warnings(detail: Any) -> list[str]:
+        """Gather per-thread warnings from an engine result detail tree.
+
+        Threads surface non-fatal conditions (e.g. an unattributable
+        write count) on ``ThreadResult.warnings``; they must reach
+        ``RunResult.warnings`` at every scope.
+        """
+        threads: list[Any]
+        if hasattr(detail, "weave_results"):
+            threads = [tr for wr in detail.weave_results for tr in wr.thread_results]
+        elif hasattr(detail, "thread_results"):
+            threads = list(detail.thread_results)
+        else:
+            threads = [detail]
+        collected: list[str] = []
+        for tr in threads:
+            if getattr(tr, "warnings", None):
+                collected.extend(tr.warnings)
+        return collected
 
     @staticmethod
     def _filter_threads(

--- a/packages/weevr/src/weevr/delta.py
+++ b/packages/weevr/src/weevr/delta.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from pyspark.sql import DataFrame, SparkSession
+
+logger = logging.getLogger(__name__)
 
 
 def is_table_alias(path: str) -> bool:
@@ -32,8 +35,13 @@ def read_delta(spark: SparkSession, path: str) -> DataFrame:
     return spark.read.format("delta").load(path)
 
 
-def delta_table_exists(spark: SparkSession, path: str) -> bool:
-    """Return True if a Delta table exists at the given path or alias.
+def probe_delta_table_exists(spark: SparkSession, path: str) -> bool:
+    """Raw existence probe — raises when the probe itself fails.
+
+    Callers that must distinguish "confirmed absent" from "could not
+    ask" (the write path, where the two answers route to different
+    branches) use this directly; everyone else goes through
+    :func:`delta_table_exists`, which folds failures into False.
 
     The alias branch asks the catalog rather than resolving the table
     through a reader, so no Delta log is read and no job is launched.
@@ -47,13 +55,28 @@ def delta_table_exists(spark: SparkSession, path: str) -> bool:
         spark: Active SparkSession.
         path: Table alias or file path.
     """
-    try:
-        if is_table_alias(path):
-            return spark.catalog.tableExists(path)
-        from delta.tables import DeltaTable
+    if is_table_alias(path):
+        return spark.catalog.tableExists(path)
+    from delta.tables import DeltaTable
 
-        return DeltaTable.isDeltaTable(spark, path)
-    except Exception:
+    return DeltaTable.isDeltaTable(spark, path)
+
+
+def delta_table_exists(spark: SparkSession, path: str) -> bool:
+    """Return True if a Delta table exists at the given path or alias.
+
+    A probe failure (metastore or storage error — not a clean "absent"
+    answer) is logged with its cause and reported as False. Callers for
+    whom that conflation is unsafe use :func:`probe_delta_table_exists`.
+
+    Args:
+        spark: Active SparkSession.
+        path: Table alias or file path.
+    """
+    try:
+        return probe_delta_table_exists(spark, path)
+    except Exception as exc:
+        logger.warning("Existence probe failed for '%s'; treating as absent: %s", path, exc)
         return False
 
 

--- a/packages/weevr/src/weevr/engine/display.py
+++ b/packages/weevr/src/weevr/engine/display.py
@@ -224,6 +224,11 @@ def _xml_escape(text: str) -> str:
     )
 
 
+def _fmt_row_count(value: Any) -> str:
+    """Format a rows-written value; None means unknown, never 0."""
+    return "unknown" if value is None else f"{value:,}"
+
+
 def _estimate_node_width(name: str) -> float:
     """Estimate node width in pixels from the thread name length."""
     text_width = len(name) * _CHAR_WIDTH_ESTIMATE
@@ -1775,15 +1780,15 @@ def render_waterfall_svg(
 
     max_count = max(rows_read, rows_after, 1)
 
-    def _bh(count: int) -> float:
-        """Proportional band height."""
-        if count <= 0:
+    def _bh(count: int | None) -> float:
+        """Proportional band height (unknown counts render at minimum)."""
+        if count is None or count <= 0:
             return band_min
         return max((count / max_count) * max_band_h, band_min)
 
     # --- Compute band heights ---
     clean_rows = max(rows_after - rows_quarantined, 0) if mode == "execute" else 0
-    output_dests: list[tuple[str, int]] = []
+    output_dests: list[tuple[str, int | None]] = []
     if mode == "execute":
         output_dests.append(("Target", rows_written))
         for er in export_results:
@@ -1890,7 +1895,7 @@ def render_waterfall_svg(
         w: float,
         h: float,
         label: str,
-        count: int,
+        count: int | None,
         role: str,
     ) -> None:
         color = bc[role]
@@ -1905,7 +1910,7 @@ def render_waterfall_svg(
         parts.append(
             f'<text x="{x + w / 2:.1f}" y="{y + h / 2 - 4:.1f}" '
             f'dominant-baseline="central" class="wf-count">'
-            f"{count:,}</text>"
+            f"{_fmt_row_count(count)}</text>"
         )
         parts.append(
             f'<text x="{x + w / 2:.1f}" y="{y + h / 2 + 8:.1f}" '
@@ -2827,7 +2832,7 @@ def _render_plan_warp_summary(thread_model: Any) -> str:
     return "\n".join(parts)
 
 
-def _render_row_counts(telemetry: Any, rows_written: int = 0) -> str:
+def _render_row_counts(telemetry: Any, rows_written: int | None = 0) -> str:
     """Render rows read vs written summary."""
     rows_read = getattr(telemetry, "rows_read", 0)
     rows_quarantined = getattr(telemetry, "rows_quarantined", 0)
@@ -2851,7 +2856,8 @@ def _render_row_counts(telemetry: Any, rows_written: int = 0) -> str:
             f'<td style="{_S_TD}">{rows_quarantined:,}</td></tr>'
         )
     parts.append(
-        f'<tr><td style="{_S_TD}">Rows written</td><td style="{_S_TD}">{rows_written:,}</td></tr>'
+        f'<tr><td style="{_S_TD}">Rows written</td>'
+        f'<td style="{_S_TD}">{_fmt_row_count(rows_written)}</td></tr>'
     )
     parts.append("</table>")
     return "\n".join(parts)
@@ -2909,7 +2915,7 @@ def _render_execute_thread_detail(
     # Auto-expand failed threads
     open_attr = " open" if tr_status == "failure" else ""
     parts = [f'<details style="{_S_DETAILS}"{open_attr}>']
-    summary_detail = f"{rows:,} rows"
+    summary_detail = f"{_fmt_row_count(rows)} rows"
     if dur_text:
         summary_detail += f", {dur_text}"
     parts.append(
@@ -3109,7 +3115,7 @@ def _render_execute_html(result: Any) -> str:
             parts.append(
                 f'<tr><td style="{_S_TD}">{name}</td>'
                 f'<td style="{_S_TD}">{_status_badge(tr_status)}</td>'
-                f'<td style="{_S_TD}">{rows:,}</td>'
+                f'<td style="{_S_TD}">{_fmt_row_count(rows)}</td>'
                 f'<td style="{_S_TD}">{dur_text}</td>'
                 f'<td style="{_S_TD}">{write_mode}</td>'
                 f'<td style="{_S_TD}">{load_mode}</td></tr>'
@@ -3420,21 +3426,29 @@ def _render_preview_html(result: Any) -> str:
 
 
 def _count_total_rows(result: Any) -> int:
-    """Sum rows_written across all threads in the result detail tree."""
+    """Sum the known rows_written values across the result detail tree.
+
+    Unknown counts (None) are excluded from the sum — the warning that
+    accompanies them qualifies the total.
+    """
     detail = getattr(result, "detail", None)
     if detail is None:
         return 0
     config_type = str(getattr(result, "config_type", ""))
     if config_type == "thread":
-        return getattr(detail, "rows_written", 0)
+        return getattr(detail, "rows_written", 0) or 0
     if config_type == "weave":
-        return sum(getattr(tr, "rows_written", 0) for tr in getattr(detail, "thread_results", []))
-    if config_type == "loom":
-        total = 0
-        for wr in getattr(detail, "weave_results", []):
-            total += sum(getattr(tr, "rows_written", 0) for tr in getattr(wr, "thread_results", []))
-        return total
-    return 0
+        thread_results = getattr(detail, "thread_results", [])
+    elif config_type == "loom":
+        thread_results = [
+            tr
+            for wr in getattr(detail, "weave_results", [])
+            for tr in getattr(wr, "thread_results", [])
+        ]
+    else:
+        return 0
+    known = (getattr(tr, "rows_written", 0) for tr in thread_results)
+    return sum(rows for rows in known if rows is not None)
 
 
 def _collect_thread_results(result: Any) -> list[Any]:

--- a/packages/weevr/src/weevr/engine/display.py
+++ b/packages/weevr/src/weevr/engine/display.py
@@ -3032,7 +3032,7 @@ def _render_execute_html(result: Any) -> str:
     )
     parts.append(
         f'<tr><td style="{_S_TD}"><strong>Rows Written</strong></td>'
-        f'<td style="{_S_TD}">{total_rows:,}</td></tr>'
+        f'<td style="{_S_TD}">{_fmt_row_count(total_rows)}</td></tr>'
     )
     if len(thread_results) > 1:
         parts.append(
@@ -3425,18 +3425,20 @@ def _render_preview_html(result: Any) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _count_total_rows(result: Any) -> int:
+def _count_total_rows(result: Any) -> int | None:
     """Sum the known rows_written values across the result detail tree.
 
-    Unknown counts (None) are excluded from the sum — the warning that
-    accompanies them qualifies the total.
+    At weave/loom scope, unknown counts (None) are excluded from the
+    sum — the warning that accompanies them qualifies the total. At
+    thread scope there is nothing to sum: an unknown count stays None
+    so the renderer shows "unknown", never a false 0.
     """
     detail = getattr(result, "detail", None)
     if detail is None:
         return 0
     config_type = str(getattr(result, "config_type", ""))
     if config_type == "thread":
-        return getattr(detail, "rows_written", 0) or 0
+        return getattr(detail, "rows_written", 0)
     if config_type == "weave":
         thread_results = getattr(detail, "thread_results", [])
     elif config_type == "loom":

--- a/packages/weevr/src/weevr/engine/executor.py
+++ b/packages/weevr/src/weevr/engine/executor.py
@@ -184,8 +184,9 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
 
     validation_results: list = []
     assertion_results: list = []
+    thread_warnings: list[str] = []
     rows_read = 0
-    rows_written = 0
+    rows_written: int | None = 0
     rows_quarantined = 0
     rows_after_transforms = 0
     output_schema: list[tuple[str, str]] | None = None
@@ -784,6 +785,15 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
                     stamp=commit_stamp,
                 )
 
+            # A successful write whose count could not be attributed reads
+            # as unknown, never as zero — surface it to the caller.
+            if rows_written is None:
+                thread_warnings.append(
+                    f"Thread '{thread.name}': rows written to '{target_path}' "
+                    f"could not be attributed to the engine's commit; "
+                    f"reported as unknown"
+                )
+
             # Step 13b — post-write fact sentinel advisory. Runs against
             # the written table, where columnar stats make per-column
             # scans cheap. Advisory only: failures never block the run.
@@ -972,6 +982,7 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
                 samples=samples,
                 drift_report=drift_report_dict,
                 warp_findings=warp_findings if warp_findings else None,
+                warnings=thread_warnings or None,
             )
 
         except DataValidationError:
@@ -1306,7 +1317,7 @@ def _build_telemetry(
     validation_results: list,
     assertion_results: list,
     rows_read: int,
-    rows_written: int,
+    rows_written: int | None,
     rows_quarantined: int,
     status: SpanStatus = SpanStatus.OK,
     collector: SpanCollector | None = None,

--- a/packages/weevr/src/weevr/engine/executor.py
+++ b/packages/weevr/src/weevr/engine/executor.py
@@ -613,14 +613,11 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
             # Lineage stamp for the counted write's commit — carries the
             # same run identity as audit columns and exports, so table
             # history joins to telemetry via run_id.
-            effective_weave = weave_name or (
-                thread.qualified_key.rsplit(".", 1)[0] if "." in thread.qualified_key else ""
-            )
             commit_stamp = CommitStamp(
                 run_id=run_id,
                 thread=thread.name,
                 loom=loom_name or None,
-                weave=effective_weave or None,
+                weave=_effective_weave_name(thread, weave_name) or None,
                 mode=write_mode,
             )
 
@@ -1210,6 +1207,18 @@ def _build_thread_variable_context(thread: Thread) -> VariableContext:
     return VariableContext(None)
 
 
+def _effective_weave_name(thread: Thread, weave_name: str) -> str:
+    """The weave name as carried by run identity surfaces.
+
+    Falls back to the prefix of the thread's qualified key when no
+    weave name was passed (standalone thread runs). Shared by audit
+    context and the commit lineage stamp so the two never drift.
+    """
+    if weave_name:
+        return weave_name
+    return thread.qualified_key.rsplit(".", 1)[0] if "." in thread.qualified_key else ""
+
+
 def _build_audit_context(
     thread: Thread,
     weave_name: str,
@@ -1218,9 +1227,7 @@ def _build_audit_context(
     run_id: str,
 ) -> AuditContext:
     """Build an AuditContext for context variable resolution."""
-    effective_weave = weave_name or (
-        thread.qualified_key.rsplit(".", 1)[0] if "." in thread.qualified_key else ""
-    )
+    effective_weave = _effective_weave_name(thread, weave_name)
     primary_alias = next(iter(thread.sources))
     primary_source = thread.sources[primary_alias]
     return AuditContext(

--- a/packages/weevr/src/weevr/engine/executor.py
+++ b/packages/weevr/src/weevr/engine/executor.py
@@ -61,7 +61,7 @@ from weevr.operations.readers import (
     read_source_incremental,
 )
 from weevr.operations.seeding import build_system_member_rows, execute_seeds
-from weevr.operations.target_handle import TargetHandle
+from weevr.operations.target_handle import CommitStamp, TargetHandle
 from weevr.operations.validation import validate_dataframe
 from weevr.operations.warp import (
     append_warp_only_columns,
@@ -609,6 +609,20 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
             # Step 11/12/13 — write to Delta
             write_mode = thread.write.mode if thread.write else "overwrite"
 
+            # Lineage stamp for the counted write's commit — carries the
+            # same run identity as audit columns and exports, so table
+            # history joins to telemetry via run_id.
+            effective_weave = weave_name or (
+                thread.qualified_key.rsplit(".", 1)[0] if "." in thread.qualified_key else ""
+            )
+            commit_stamp = CommitStamp(
+                run_id=run_id,
+                thread=thread.name,
+                loom=loom_name or None,
+                weave=effective_weave or None,
+                mode=write_mode,
+            )
+
             if dim_config is not None and dim_builder is not None:
                 # Dimension merge routing
                 df = apply_target_mapping(df, thread.target, spark, handle=target_handle)
@@ -659,7 +673,13 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
                         output_sample = df.limit(10).toPandas().to_dict("records")
                 was_first_write = not target_handle.exists()
                 merge_result = execute_dimension_merge(
-                    spark, df, dim_builder, target_path, run_timestamp, handle=target_handle
+                    spark,
+                    df,
+                    dim_builder,
+                    target_path,
+                    run_timestamp,
+                    handle=target_handle,
+                    stamp=commit_stamp,
                 )
                 # Input-rows semantic. Quarantine-free merges need no new
                 # action: transforms after the eager rows_after_transforms
@@ -755,7 +775,13 @@ def execute_thread(  # type: ignore[reportGeneralTypeIssues]
                     with contextlib.suppress(Exception):
                         output_sample = df.limit(10).toPandas().to_dict("records")
                 rows_written = write_target(
-                    spark, df, thread.target, thread.write, target_path, handle=target_handle
+                    spark,
+                    df,
+                    thread.target,
+                    thread.write,
+                    target_path,
+                    handle=target_handle,
+                    stamp=commit_stamp,
                 )
 
             # Step 13b — post-write fact sentinel advisory. Runs against

--- a/packages/weevr/src/weevr/engine/result.py
+++ b/packages/weevr/src/weevr/engine/result.py
@@ -15,7 +15,9 @@ class ThreadResult(FrozenBase):
         status: Outcome of the execution — ``"success"``, ``"failure"``, or
             ``"skipped"`` (when a condition evaluated to False).
         thread_name: Name of the thread that was executed.
-        rows_written: Number of rows in the DataFrame at write time.
+        rows_written: Number of rows written to the target, or ``None``
+            when a successful write's count could not be attributed to
+            the engine's own commit (unknown, never a false 0).
         write_mode: The write mode used (``"overwrite"``, ``"append"``, or ``"merge"``).
         target_path: Physical path of the Delta table that was written.
         telemetry: Thread-level telemetry with validation/assertion results and row counts.
@@ -31,11 +33,13 @@ class ThreadResult(FrozenBase):
         warp_findings: Warp enforcement findings from this run — each entry names
             a column and the mismatch reason. ``None`` when warp enforcement is
             not configured for the target.
+        warnings: Non-fatal messages surfaced to the caller (e.g. an
+            unattributable write count). Merged into ``RunResult.warnings``.
     """
 
     status: Literal["success", "failure", "skipped"]
     thread_name: str
-    rows_written: int
+    rows_written: int | None
     write_mode: str
     target_path: str
     telemetry: ThreadTelemetry | None = None
@@ -45,6 +49,7 @@ class ThreadResult(FrozenBase):
     samples: dict[str, list[dict[str, Any]]] | None = None
     drift_report: dict[str, Any] | None = None
     warp_findings: list[dict[str, str]] | None = None
+    warnings: list[str] | None = None
 
 
 class WeaveResult(FrozenBase):

--- a/packages/weevr/src/weevr/operations/dimension.py
+++ b/packages/weevr/src/weevr/operations/dimension.py
@@ -20,7 +20,7 @@ from pyspark.sql import functions as F
 from weevr.delta import resolve_delta_table
 from weevr.model.dimension import DimensionConfig
 from weevr.model.write import WriteConfig
-from weevr.operations.target_handle import TargetHandle
+from weevr.operations.target_handle import CommitStamp, TargetHandle
 from weevr.operations.writers import quote_identifier
 
 logger = logging.getLogger(__name__)
@@ -209,6 +209,7 @@ def execute_dimension_merge(
     target_path: str,
     run_timestamp: str,
     handle: TargetHandle | None = None,
+    stamp: CommitStamp | None = None,
 ) -> DimensionMergeResult:
     """Execute the staged dimension merge against a Delta target.
 
@@ -235,6 +236,9 @@ def execute_dimension_merge(
 
         handle: Pre-resolved target handle; when absent the function
             self-resolves existence (operations stay independently usable).
+        stamp: Lineage stamp for the first-write commit (a plain save,
+            not a MERGE); enables exact own-commit attribution. Merge
+            commits are not stamped.
 
     Returns:
         DimensionMergeResult with row-level metrics.
@@ -246,9 +250,13 @@ def execute_dimension_merge(
         handle = TargetHandle(spark, target_path)
     if not handle.exists():
         # First write — insert all rows directly; the count comes from the
-        # write's own commit metrics (guarded), not a pre-count
-        source_df.write.format("delta").save(target_path)
-        metrics = handle.commit_metrics_after(None)
+        # write's own commit metrics (stamped, else version-guarded), not
+        # a pre-count
+        writer = source_df.write.format("delta")
+        if stamp is not None:
+            writer = writer.option("userMetadata", stamp.to_json())
+        writer.save(target_path)
+        metrics = handle.commit_metrics_after(None, stamp=stamp)
         if metrics is not None and "numOutputRows" in metrics:
             result.rows_inserted = int(metrics["numOutputRows"])
         else:

--- a/packages/weevr/src/weevr/operations/dimension.py
+++ b/packages/weevr/src/weevr/operations/dimension.py
@@ -33,14 +33,16 @@ class DimensionMergeResult:
     Attributes:
         rows_versioned: Rows closed and re-inserted as new versions.
         rows_overwritten: Rows updated in place.
-        rows_inserted: New rows inserted (unmatched in target).
+        rows_inserted: New rows inserted (unmatched in target), or
+            ``None`` when a first-write count could not be attributed
+            to the engine's own commit (unknown, never a false 0).
         rows_unchanged: Matched rows with no hash change.
         rows_deleted: Rows deleted or soft-deleted (unmatched by source).
     """
 
     rows_versioned: int = 0
     rows_overwritten: int = 0
-    rows_inserted: int = 0
+    rows_inserted: int | None = 0
     rows_unchanged: int = 0
     rows_deleted: int = 0
 
@@ -260,7 +262,10 @@ def execute_dimension_merge(
         if metrics is not None and "numOutputRows" in metrics:
             result.rows_inserted = int(metrics["numOutputRows"])
         else:
-            logger.warning("First-write row count unavailable for '%s'; reporting 0", target_path)
+            logger.warning(
+                "First-write row count unavailable for '%s'; reporting unknown", target_path
+            )
+            result.rows_inserted = None
         handle.mark_exists()
         return result
 

--- a/packages/weevr/src/weevr/operations/dimension.py
+++ b/packages/weevr/src/weevr/operations/dimension.py
@@ -253,7 +253,10 @@ def execute_dimension_merge(
     if not handle.exists():
         # First write — insert all rows directly; the count comes from the
         # write's own commit metrics (stamped, else version-guarded), not
-        # a pre-count
+        # a pre-count. Deliberately no .mode() here: Spark's default
+        # ErrorIfExists is what keeps a failed existence probe from
+        # silently overwriting a target that does exist — if a mode is
+        # ever added, an exists_uncertain() guard must come with it.
         writer = source_df.write.format("delta")
         if stamp is not None:
             writer = writer.option("userMetadata", stamp.to_json())

--- a/packages/weevr/src/weevr/operations/target_handle.py
+++ b/packages/weevr/src/weevr/operations/target_handle.py
@@ -12,13 +12,80 @@ three to five per thread.
 
 from __future__ import annotations
 
+import json
 import logging
+from dataclasses import dataclass
+from typing import Any
 
 from pyspark.sql import SparkSession
 
 from weevr import delta as _delta
 
 logger = logging.getLogger(__name__)
+
+STAMP_ENGINE_MARKER = "weevr"
+STAMP_VERSION = 1
+
+
+@dataclass(frozen=True)
+class CommitStamp:
+    """Lineage stamp written as Delta commit ``userMetadata`` on engine writes.
+
+    Visible in ``DESCRIBE HISTORY`` and joinable to telemetry via
+    ``run_id``. The stable core is the engine marker, ``run_id``, and
+    ``thread`` — attribution matches on exactly that; the remaining
+    fields are best-effort context and may evolve.
+
+    Attributes:
+        run_id: Run identity shared with audit columns and exports.
+        thread: Name of the thread that made the commit.
+        loom: Loom name, when the thread ran under one.
+        weave: Weave name, when the thread ran under one.
+        mode: Write mode of the commit (overwrite/append/merge).
+    """
+
+    run_id: str
+    thread: str
+    loom: str | None = None
+    weave: str | None = None
+    mode: str | None = None
+
+    def to_json(self) -> str:
+        """Serialize to the compact JSON written as commit userMetadata."""
+        payload: dict[str, Any] = {
+            "engine": STAMP_ENGINE_MARKER,
+            "version": STAMP_VERSION,
+            "run_id": self.run_id,
+            "thread": self.thread,
+        }
+        if self.loom:
+            payload["loom"] = self.loom
+        if self.weave:
+            payload["weave"] = self.weave
+        if self.mode:
+            payload["mode"] = self.mode
+        return json.dumps(payload, separators=(",", ":"))
+
+    def matches(self, user_metadata: str | None) -> bool:
+        """Whether *user_metadata* is this write's own stamp.
+
+        Matches on the stable core only (engine marker + ``run_id`` +
+        ``thread``), so an engine-shaped stamp from another run in the
+        same history window is never claimed.
+        """
+        if not user_metadata:
+            return False
+        try:
+            data = json.loads(user_metadata)
+        except ValueError:
+            return False
+        if not isinstance(data, dict):
+            return False
+        return (
+            data.get("engine") == STAMP_ENGINE_MARKER
+            and data.get("run_id") == self.run_id
+            and data.get("thread") == self.thread
+        )
 
 
 class TargetHandle:
@@ -99,15 +166,25 @@ class TargetHandle:
             logger.warning("Could not read current version for '%s'", self.path)
             return None
 
-    def commit_metrics_after(self, pre_version: int | None) -> dict[str, str] | None:
-        """Operation metrics of the commit that followed ``pre_version``.
+    def commit_metrics_after(
+        self, pre_version: int | None, stamp: CommitStamp | None = None
+    ) -> dict[str, str] | None:
+        """Operation metrics of the engine's own commit after ``pre_version``.
 
-        Accepts the latest commit ONLY when its version is exactly
-        ``pre_version + 1`` (or 0 for a fresh table) — a foreign commit
-        landing between the engine's write and this read makes the
-        version jump, and the metrics are then reported absent rather
-        than misattributed. Degrade, never misattribute.
+        With a *stamp* (single-pass writes), the history window since
+        ``pre_version`` is scanned for the commit carrying the write's
+        own stamp — exact regardless of interleaved foreign commits.
+
+        Without a stamp (merge paths, where per-write userMetadata is
+        not honored), the latest commit is accepted ONLY when its
+        version is exactly ``pre_version + 1`` (or 0 for a fresh
+        table) — a foreign commit landing between the engine's write
+        and this read makes the version jump, and the metrics are then
+        reported absent rather than misattributed. Either way: degrade,
+        never misattribute.
         """
+        if stamp is not None:
+            return self._stamped_commit_metrics(pre_version, stamp)
         if self._version_read_failed:
             logger.warning(
                 "Commit metrics for '%s' skipped: pre-write version was "
@@ -132,3 +209,36 @@ class TargetHandle:
             )
             return None
         return dict(row[1])
+
+    def _stamped_commit_metrics(
+        self, pre_version: int | None, stamp: CommitStamp
+    ) -> dict[str, str] | None:
+        """Find the own-stamped commit in the window after ``pre_version``.
+
+        A driver-side log read. The window is bounded below by
+        ``pre_version`` (full history when the pre-write version was
+        unreadable — the stamp still identifies the own commit exactly).
+        """
+        floor = -1 if pre_version is None else pre_version
+        try:
+            table = _delta.resolve_delta_table(self._spark, self.path)
+            rows = (
+                table.history()
+                .select("version", "operationMetrics", "userMetadata")
+                .where(f"version > {floor}")
+                .collect()
+            )
+        except Exception:
+            logger.warning("Commit metrics unavailable for '%s'", self.path)
+            return None
+        own = [row for row in rows if stamp.matches(row["userMetadata"])]
+        if not own:
+            logger.warning(
+                "Commit metrics for '%s' skipped: no commit stamped by this "
+                "write found after version %s (own commit unattributable)",
+                self.path,
+                "?" if pre_version is None else pre_version,
+            )
+            return None
+        latest = max(own, key=lambda row: int(row["version"]))
+        return dict(latest["operationMetrics"])

--- a/packages/weevr/src/weevr/operations/target_handle.py
+++ b/packages/weevr/src/weevr/operations/target_handle.py
@@ -41,7 +41,9 @@ class CommitStamp:
         thread: Name of the thread that made the commit.
         loom: Loom name, when the thread ran under one.
         weave: Weave name, when the thread ran under one.
-        mode: Write mode of the commit (overwrite/append/merge).
+        mode: The thread's configured write mode. Best-effort intent,
+            not the physical branch taken — a first write executes as
+            overwrite regardless of the configured mode.
     """
 
     run_id: str
@@ -237,7 +239,12 @@ class TargetHandle:
                 # No commit of ANY kind landed after pre_version: Delta
                 # skips the commit entirely for a zero-row single-pass
                 # write, so the engine provably wrote nothing — an exact
-                # zero, not an unknown.
+                # zero, not an unknown. This deduction leans on the Delta
+                # log still holding every commit after pre_version at
+                # read time; an aggressively short logRetentionDuration
+                # could in principle empty the window, but within the
+                # milliseconds between a write and its metrics read that
+                # is not a practical concern.
                 return {"numOutputRows": "0"}
             logger.warning(
                 "Commit metrics for '%s' skipped: no commit stamped by this "

--- a/packages/weevr/src/weevr/operations/target_handle.py
+++ b/packages/weevr/src/weevr/operations/target_handle.py
@@ -233,6 +233,12 @@ class TargetHandle:
             return None
         own = [row for row in rows if stamp.matches(row["userMetadata"])]
         if not own:
+            if not rows and pre_version is not None:
+                # No commit of ANY kind landed after pre_version: Delta
+                # skips the commit entirely for a zero-row single-pass
+                # write, so the engine provably wrote nothing — an exact
+                # zero, not an unknown.
+                return {"numOutputRows": "0"}
             logger.warning(
                 "Commit metrics for '%s' skipped: no commit stamped by this "
                 "write found after version %s (own commit unattributable)",

--- a/packages/weevr/src/weevr/operations/target_handle.py
+++ b/packages/weevr/src/weevr/operations/target_handle.py
@@ -34,13 +34,30 @@ class TargetHandle:
         self._spark = spark
         self.path = path
         self._exists: bool | None = None
+        self._exists_uncertain = False
         self._version_read_failed = False
 
     def exists(self) -> bool:
-        """Whether a Delta table exists at the target (cached until refresh)."""
+        """Whether a Delta table exists at the target (cached until refresh).
+
+        A probe *failure* is folded into False for this method's bool
+        contract, but recorded on :meth:`exists_uncertain` — the write
+        path must not treat "could not ask" as "confirmed absent".
+        """
         if self._exists is None:
-            self._exists = _delta.delta_table_exists(self._spark, self.path)
+            self._exists_uncertain = False
+            try:
+                self._exists = _delta.probe_delta_table_exists(self._spark, self.path)
+            except Exception as exc:
+                logger.warning("Existence probe failed for '%s': %s", self.path, exc)
+                self._exists = False
+                self._exists_uncertain = True
         return self._exists
+
+    def exists_uncertain(self) -> bool:
+        """True when the cached False came from a failed probe, not a clean answer."""
+        self.exists()
+        return self._exists_uncertain
 
     def refresh(self) -> None:
         """Invalidate the cached existence after an engine-internal commit.
@@ -49,6 +66,7 @@ class TargetHandle:
         thread makes to its own target before the primary write.
         """
         self._exists = None
+        self._exists_uncertain = False
 
     def mark_exists(self) -> None:
         """Record that the target now exists without re-probing.
@@ -57,6 +75,7 @@ class TargetHandle:
         existence is monotonic within a run.
         """
         self._exists = True
+        self._exists_uncertain = False
 
     def current_version(self) -> int | None:
         """The target's latest Delta commit version, or None when absent.

--- a/packages/weevr/src/weevr/operations/writers.py
+++ b/packages/weevr/src/weevr/operations/writers.py
@@ -111,7 +111,7 @@ def write_target(
     target_path: str,
     handle: TargetHandle | None = None,
     stamp: CommitStamp | None = None,
-) -> int:
+) -> int | None:
     """Write a DataFrame to a Delta table.
 
     If *target_path* is a table alias (e.g. ``staging.stg_customers``), the
@@ -132,7 +132,9 @@ def write_target(
             (per-write userMetadata is not honored there).
 
     Returns:
-        Number of rows in ``df`` (rows written for overwrite/append; input rows for merge).
+        Number of rows written (input rows for merge), or ``None`` when a
+        successful single-pass write's count could not be attributed to
+        the engine's own commit — unknown, never a false 0.
 
     Raises:
         ExecutionError: If the write operation fails.
@@ -158,7 +160,7 @@ def write_target(
         # rows, not the input-rows semantic this function returns, and the
         # merge action cannot fulfill observations (it zero-fires them).
         # Single-pass modes count from the write's own commit metrics.
-        row_count = df.count() if mode == "merge" and target_exists else -1
+        row_count: int | None = df.count() if mode == "merge" and target_exists else -1
         pre_version = handle.current_version() if row_count == -1 and target_exists else None
 
         if mode == "overwrite" or not target_exists:
@@ -211,10 +213,10 @@ def write_target(
                 row_count = int(metrics["numOutputRows"])
             else:
                 logger.warning(
-                    "Rows-written count unavailable for '%s'; reporting 0",
+                    "Rows-written count unavailable for '%s'; reporting unknown",
                     target_path,
                 )
-                row_count = 0
+                row_count = None
         handle.mark_exists()
         return row_count
 

--- a/packages/weevr/src/weevr/operations/writers.py
+++ b/packages/weevr/src/weevr/operations/writers.py
@@ -14,7 +14,7 @@ from weevr.model.load import CdcConfig, LoadConfig
 from weevr.model.target import Target
 from weevr.model.write import WriteConfig
 from weevr.operations.readers import typed_watermark_col
-from weevr.operations.target_handle import TargetHandle
+from weevr.operations.target_handle import CommitStamp, TargetHandle
 
 logger = logging.getLogger(__name__)
 
@@ -110,6 +110,7 @@ def write_target(
     write_config: WriteConfig | None,
     target_path: str,
     handle: TargetHandle | None = None,
+    stamp: CommitStamp | None = None,
 ) -> int:
     """Write a DataFrame to a Delta table.
 
@@ -126,6 +127,9 @@ def write_target(
 
         handle: Pre-resolved target handle; when absent the function
             self-resolves existence (operations stay independently usable).
+        stamp: Lineage stamp for single-pass commits; enables exact
+            own-commit attribution. True MERGE commits are not stamped
+            (per-write userMetadata is not honored there).
 
     Returns:
         Number of rows in ``df`` (rows written for overwrite/append; input rows for merge).
@@ -171,6 +175,8 @@ def write_target(
                     F.lit(write_config.soft_delete_active_value).cast("boolean"),
                 )
             writer = df.write.format("delta").mode("overwrite")
+            if stamp is not None:
+                writer = writer.option("userMetadata", stamp.to_json())
             if partition_cols:
                 writer = writer.partitionBy(*partition_cols)
             if use_table_api:
@@ -180,6 +186,8 @@ def write_target(
 
         elif mode == "append":
             writer = df.write.format("delta").mode("append")
+            if stamp is not None:
+                writer = writer.option("userMetadata", stamp.to_json())
             if partition_cols:
                 writer = writer.partitionBy(*partition_cols)
             if use_table_api:
@@ -195,9 +203,10 @@ def write_target(
             _execute_merge(spark, df, write_config, target_path)
 
         if row_count == -1:
-            # Single-pass write: the commit's own numOutputRows, guarded
-            # against foreign commits. Absent-with-warning on any miss.
-            metrics = handle.commit_metrics_after(pre_version)
+            # Single-pass write: the commit's own numOutputRows — found by
+            # its stamp when one was written, version-guarded otherwise.
+            # Absent-with-warning on any miss.
+            metrics = handle.commit_metrics_after(pre_version, stamp=stamp)
             if metrics is not None and "numOutputRows" in metrics:
                 row_count = int(metrics["numOutputRows"])
             else:

--- a/packages/weevr/src/weevr/operations/writers.py
+++ b/packages/weevr/src/weevr/operations/writers.py
@@ -139,6 +139,15 @@ def write_target(
     if handle is None:
         handle = TargetHandle(spark, target_path)
     target_exists = handle.exists()
+    if not target_exists and mode in ("append", "merge") and handle.exists_uncertain():
+        # A failed probe is not a confirmed absence — the first-write
+        # branch would overwrite a target that may exist. Overwrite mode
+        # is exempt: destructive by contract.
+        raise ExecutionError(
+            f"Cannot {mode} to '{target_path}': the existence probe failed, so "
+            f"the target may already exist and the first-write path would "
+            f"overwrite it; resolve the probe failure and re-run"
+        )
 
     try:
         # Merge keeps an eager input count — merge metrics express outcome
@@ -440,9 +449,17 @@ def execute_cdc_merge(
         )
 
     counts: dict[str, int] = {"inserts": 0, "updates": 0, "deletes": 0}
-    target_exists = (
-        handle.exists() if handle is not None else delta_table_exists(spark, target_path)
-    )
+    if handle is None:
+        handle = TargetHandle(spark, target_path)
+    target_exists = handle.exists()
+    if not target_exists and handle.exists_uncertain():
+        # Same posture as write_target: a failed probe must never route
+        # onto the destructive first-CDC-write (overwrite) branch.
+        raise ExecutionError(
+            f"Cannot run CDC merge on '{target_path}': the existence probe "
+            f"failed, so the target may already exist and the first-write "
+            f"path would overwrite it; resolve the probe failure and re-run"
+        )
 
     try:
         # Count operations in a single pass over the (reduced) window

--- a/tests/weevr/engine/test_display.py
+++ b/tests/weevr/engine/test_display.py
@@ -542,6 +542,37 @@ class TestRenderResultHtml:
         assert "500" in html_out
         assert "overwrite" in html_out
 
+    def test_execute_thread_scope_unknown_rows_render_as_unknown(self) -> None:
+        """A thread-scope result with an unknown count never shows a false 0."""
+        detail = type(
+            "TR",
+            (),
+            {
+                "status": "success",
+                "thread_name": "dim_unattr",
+                "rows_written": None,
+                "write_mode": "append",
+                "target_path": "Tables/dim_unattr",
+                "error": None,
+            },
+        )()
+        result = type(
+            "R",
+            (),
+            {
+                "mode": "execute",
+                "status": "success",
+                "config_type": "thread",
+                "config_name": "dim_unattr",
+                "duration_ms": 500,
+                "detail": detail,
+                "warnings": ["Thread 'dim_unattr': rows written could not be attributed"],
+            },
+        )()
+        html_out = render_result_html(result)
+        assert "unknown" in html_out
+        assert ">0<" not in html_out  # no cell renders the count as zero
+
     def test_execute_unknown_rows_render_as_unknown(self) -> None:
         """A None rows_written renders as unknown, and totals sum known values."""
         t_known = type(

--- a/tests/weevr/engine/test_display.py
+++ b/tests/weevr/engine/test_display.py
@@ -542,6 +542,62 @@ class TestRenderResultHtml:
         assert "500" in html_out
         assert "overwrite" in html_out
 
+    def test_execute_unknown_rows_render_as_unknown(self) -> None:
+        """A None rows_written renders as unknown, and totals sum known values."""
+        t_known = type(
+            "TR",
+            (),
+            {
+                "status": "success",
+                "thread_name": "dim_known",
+                "rows_written": 10,
+                "write_mode": "append",
+                "target_path": "Tables/dim_known",
+                "error": None,
+            },
+        )()
+        t_unknown = type(
+            "TR",
+            (),
+            {
+                "status": "success",
+                "thread_name": "dim_unknown",
+                "rows_written": None,
+                "write_mode": "append",
+                "target_path": "Tables/dim_unknown",
+                "error": None,
+            },
+        )()
+        t_known2 = type(
+            "TR",
+            (),
+            {
+                "status": "success",
+                "thread_name": "dim_known2",
+                "rows_written": 5,
+                "write_mode": "append",
+                "target_path": "Tables/dim_known2",
+                "error": None,
+            },
+        )()
+        detail = type("WR", (), {"thread_results": [t_known, t_unknown, t_known2]})()
+        result = type(
+            "R",
+            (),
+            {
+                "mode": "execute",
+                "status": "success",
+                "config_type": "weave",
+                "config_name": "dims",
+                "duration_ms": 800,
+                "detail": detail,
+                "warnings": ["Thread 'dim_unknown': rows written could not be attributed"],
+            },
+        )()
+        html_out = render_result_html(result)
+        assert "unknown" in html_out
+        assert "15" in html_out  # sum of the known counts
+
     def test_execute_loom_level(self) -> None:
         t1 = type(
             "TR",

--- a/tests/weevr/engine/test_executor.py
+++ b/tests/weevr/engine/test_executor.py
@@ -54,6 +54,68 @@ def _make_thread(
     )
 
 
+class TestCommitStampIntegration:
+    """The executor stamps engine commits and attributes them exactly."""
+
+    def test_rows_written_exact_under_interleaved_commit(
+        self, spark: SparkSession, tmp_delta_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A foreign commit between pre-version capture and the engine write
+        no longer degrades rows_written."""
+        from weevr.operations.target_handle import TargetHandle
+
+        src = tmp_delta_path("stampint_src")
+        tgt = tmp_delta_path("stampint_tgt")
+        create_delta_table(spark, src, [{"id": 1}, {"id": 2}, {"id": 3}])
+        create_delta_table(spark, tgt, [{"id": 0}])
+
+        original_cv = TargetHandle.current_version
+
+        def _capture_then_foreign(handle_self):  # type: ignore[no-untyped-def]
+            version = original_cv(handle_self)
+            spark.createDataFrame([{"id": 100}]).write.format("delta").mode("append").save(tgt)
+            return version
+
+        monkeypatch.setattr(TargetHandle, "current_version", _capture_then_foreign)
+        thread = _make_thread("stamp_thread", src, tgt, write=WriteConfig(mode="append"))
+        result = execute_thread(spark, thread)
+        monkeypatch.undo()
+
+        assert result.status == "success"
+        assert result.rows_written == 3
+
+    def test_stamp_run_id_matches_audit_run_identity(
+        self, spark: SparkSession, tmp_delta_path
+    ) -> None:
+        """The stamp's run_id is the same run identity audit columns carry —
+        the join key between table history and telemetry."""
+        import json
+
+        from weevr.delta import resolve_delta_table
+
+        src = tmp_delta_path("stampid_src")
+        tgt = tmp_delta_path("stampid_tgt")
+        create_delta_table(spark, src, [{"id": 1}])
+
+        thread = Thread(
+            name="stamp_identity",
+            config_version="1",
+            sources={"main": Source(type="delta", alias=src)},
+            steps=[],
+            target=Target(path=tgt, audit_columns={"_run_id": "'${run.id}'"}),
+        )
+        result = execute_thread(spark, thread)
+        assert result.status == "success"
+
+        audit_run_id = spark.read.format("delta").load(tgt).collect()[0]["_run_id"]
+        raw = resolve_delta_table(spark, tgt).history(1).select("userMetadata").collect()[0][0]
+        assert raw is not None
+        stamp = json.loads(raw)
+        assert stamp["engine"] == "weevr"
+        assert stamp["run_id"] == audit_run_id
+        assert stamp["thread"] == "stamp_identity"
+
+
 class TestExecuteThreadResult:
     """ThreadResult fields populated correctly by execute_thread."""
 

--- a/tests/weevr/engine/test_executor.py
+++ b/tests/weevr/engine/test_executor.py
@@ -913,7 +913,9 @@ class TestExecuteThreadConnections:
 
         captured_paths: list[str] = []
 
-        def fake_write_target(spark_arg, df_arg, target_arg, write_arg, path_arg, handle=None):
+        def fake_write_target(
+            spark_arg, df_arg, target_arg, write_arg, path_arg, handle=None, stamp=None
+        ):
             captured_paths.append(path_arg)
             return df_arg.count()
 
@@ -953,7 +955,9 @@ class TestExecuteThreadConnections:
 
         captured_paths: list[str] = []
 
-        def fake_write_target(spark_arg, df_arg, target_arg, write_arg, path_arg, handle=None):
+        def fake_write_target(
+            spark_arg, df_arg, target_arg, write_arg, path_arg, handle=None, stamp=None
+        ):
             captured_paths.append(path_arg)
             return df_arg.count()
 

--- a/tests/weevr/engine/test_executor.py
+++ b/tests/weevr/engine/test_executor.py
@@ -116,6 +116,47 @@ class TestCommitStampIntegration:
         assert stamp["thread"] == "stamp_identity"
 
 
+class TestUnknownRowsWritten:
+    """Attribution failure surfaces as an unknown count plus a warning."""
+
+    def test_attribution_failure_surfaces_unknown_with_warning(
+        self, spark: SparkSession, tmp_delta_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from weevr.operations.target_handle import TargetHandle
+
+        src = tmp_delta_path("unknown_src")
+        tgt = tmp_delta_path("unknown_tgt")
+        create_delta_table(spark, src, [{"id": 1}, {"id": 2}])
+        create_delta_table(spark, tgt, [{"id": 0}])
+        monkeypatch.setattr(
+            TargetHandle, "commit_metrics_after", lambda self, pre, stamp=None: None
+        )
+
+        thread = _make_thread("unknown_rows", src, tgt, write=WriteConfig(mode="append"))
+        result = execute_thread(spark, thread)
+        monkeypatch.undo()
+
+        assert result.status == "success"
+        assert result.rows_written is None
+        assert result.telemetry is not None
+        assert result.telemetry.rows_written is None
+        assert result.warnings is not None
+        assert any("unknown_rows" in w and tgt in w for w in result.warnings)
+
+    def test_success_path_reports_exact_int_without_warning(
+        self, spark: SparkSession, tmp_delta_path
+    ) -> None:
+        src = tmp_delta_path("known_src")
+        tgt = tmp_delta_path("known_tgt")
+        create_delta_table(spark, src, [{"id": 1}, {"id": 2}])
+
+        thread = _make_thread("known_rows", src, tgt)
+        result = execute_thread(spark, thread)
+
+        assert result.rows_written == 2
+        assert not result.warnings
+
+
 class TestExecuteThreadResult:
     """ThreadResult fields populated correctly by execute_thread."""
 
@@ -1983,25 +2024,23 @@ class TestTargetHandle:
 
     @pytest.fixture()
     def probe_spy(self, monkeypatch: pytest.MonkeyPatch) -> list[str]:
-        """Count real existence probes across every consuming module."""
+        """Count real existence probes across every consuming module.
+
+        Every probe funnels through ``probe_delta_table_exists`` — the
+        handle calls it directly, and ``delta_table_exists`` (the
+        failure-folding wrapper used by other consumers) delegates to
+        it — so one patch point sees them all.
+        """
         from weevr import delta as delta_mod
 
         calls: list[str] = []
-        original = delta_mod.delta_table_exists
+        original = delta_mod.probe_delta_table_exists
 
         def _spy(spark, path):  # type: ignore[no-untyped-def]
             calls.append(path)
             return original(spark, path)
 
-        # Patch the source module (the handle reads it) and each module
-        # still holding a direct reference from `from weevr.delta import ...`
-        # (dimension.py probes exclusively through the handle now)
-        import weevr.operations.seeding as seed_mod
-        import weevr.operations.writers as writers_mod
-
-        monkeypatch.setattr(delta_mod, "delta_table_exists", _spy)
-        monkeypatch.setattr(writers_mod, "delta_table_exists", _spy)
-        monkeypatch.setattr(seed_mod, "delta_table_exists", _spy)
+        monkeypatch.setattr(delta_mod, "probe_delta_table_exists", _spy)
         return calls
 
     def test_standard_path_probes_once(

--- a/tests/weevr/engine/test_warp_integration.py
+++ b/tests/weevr/engine/test_warp_integration.py
@@ -65,7 +65,7 @@ class TestDefaultBehavior:
             result = execute_thread(spark, thread)
 
         assert result.status == "success"
-        assert result.rows_written > 0
+        assert result.rows_written is not None and result.rows_written > 0
         assert result.warp_findings is None
         assert result.drift_report is None
 

--- a/tests/weevr/operations/test_dimension_merge.py
+++ b/tests/weevr/operations/test_dimension_merge.py
@@ -113,6 +113,27 @@ class TestFirstWrite:
         assert len(stamped) == 1
         assert json.loads(stamped[0])["run_id"] == "run-dim"
 
+    def test_first_write_unattributable_reports_unknown(
+        self, spark: SparkSession, tmp_delta_path, monkeypatch: pytest.MonkeyPatch, caplog
+    ) -> None:
+        """A first-write count that cannot be attributed is None, never 0."""
+        from weevr.operations.target_handle import TargetHandle
+
+        path = tmp_delta_path("dim_first_unattr")
+        dim = _make_dim()
+        source = _prepare_source(spark, [{"customer_id": "C1", "name": "Alice"}], dim)
+        builder = DimensionMergeBuilder(dim)
+        monkeypatch.setattr(
+            TargetHandle, "commit_metrics_after", lambda self, pre, stamp=None: None
+        )
+
+        result = execute_dimension_merge(spark, source, builder, path, "2026-01-01")
+        assert result.rows_inserted is None
+        assert "unavailable" in caplog.text
+
+        monkeypatch.undo()
+        assert spark.read.format("delta").load(path).count() == 1  # the write itself landed
+
 
 @pytest.mark.spark
 class TestIdempotency:

--- a/tests/weevr/operations/test_dimension_merge.py
+++ b/tests/weevr/operations/test_dimension_merge.py
@@ -62,6 +62,57 @@ class TestFirstWrite:
         target = spark.read.format("delta").load(path)
         assert target.count() == 2
 
+    def test_first_write_stamped_and_exact_under_interleaved_commit(
+        self, spark: SparkSession, tmp_delta_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The dimension first write is a plain save — stamped and attributed
+        like write_target's first write, exact when a foreign commit lands
+        between the write and the metrics read."""
+        import json
+
+        from weevr.operations import target_handle as th_mod
+        from weevr.operations.target_handle import CommitStamp
+
+        path = tmp_delta_path("dim_first_stamped")
+        dim = _make_dim()
+        source = _prepare_source(
+            spark,
+            [
+                {"customer_id": "C1", "name": "Alice"},
+                {"customer_id": "C2", "name": "Bob"},
+            ],
+            dim,
+        )
+        builder = DimensionMergeBuilder(dim)
+        stamp = CommitStamp(run_id="run-dim", thread="dim_thread", mode="merge")
+
+        # A foreign commit lands after the engine write, before the metrics
+        # read: intercept the history resolution to append it first.
+        original_resolve = th_mod._delta.resolve_delta_table
+        fired = {"done": False}
+
+        def _foreign_then_resolve(spark_arg, path_arg):  # type: ignore[no-untyped-def]
+            if not fired["done"]:
+                fired["done"] = True
+                frame = spark.createDataFrame([{"customer_id": "ZZ", "name": "foreign"}])
+                frame.write.format("delta").mode("append").option("mergeSchema", "true").save(path)
+            return original_resolve(spark_arg, path_arg)
+
+        monkeypatch.setattr(th_mod._delta, "resolve_delta_table", _foreign_then_resolve)
+        result = execute_dimension_merge(spark, source, builder, path, "2026-01-01", stamp=stamp)
+        monkeypatch.undo()
+
+        assert result.rows_inserted == 2  # exact — not 0, not the foreign 1
+
+        from weevr.delta import resolve_delta_table
+
+        history = resolve_delta_table(spark, path).history().select("userMetadata").collect()
+        stamped = [
+            row[0] for row in history if row[0] and json.loads(row[0]).get("engine") == "weevr"
+        ]
+        assert len(stamped) == 1
+        assert json.loads(stamped[0])["run_id"] == "run-dim"
+
 
 @pytest.mark.spark
 class TestIdempotency:

--- a/tests/weevr/operations/test_writers.py
+++ b/tests/weevr/operations/test_writers.py
@@ -637,12 +637,10 @@ class TestUncertainExistenceGuard:
 
     @staticmethod
     def _break_probe(monkeypatch: pytest.MonkeyPatch) -> None:
-        import weevr.delta as delta_mod
-
         def _boom(spark_arg, path_arg):  # type: ignore[no-untyped-def]
             raise RuntimeError("transient metastore outage")
 
-        monkeypatch.setattr(delta_mod, "probe_delta_table_exists", _boom)
+        monkeypatch.setattr("weevr.delta.probe_delta_table_exists", _boom)
 
     def test_append_uncertain_raises_and_preserves_content(
         self, spark: SparkSession, simple_df, tmp_delta_path, monkeypatch: pytest.MonkeyPatch

--- a/tests/weevr/operations/test_writers.py
+++ b/tests/weevr/operations/test_writers.py
@@ -631,6 +631,127 @@ class TestWriteTargetMerge:
 
 
 @pytest.mark.spark
+class TestUncertainExistenceGuard:
+    """A failed existence probe must never route append/merge onto the
+    destructive first-write (overwrite) branch."""
+
+    @staticmethod
+    def _break_probe(monkeypatch: pytest.MonkeyPatch) -> None:
+        import weevr.delta as delta_mod
+
+        def _boom(spark_arg, path_arg):  # type: ignore[no-untyped-def]
+            raise RuntimeError("transient metastore outage")
+
+        monkeypatch.setattr(delta_mod, "probe_delta_table_exists", _boom)
+
+    def test_append_uncertain_raises_and_preserves_content(
+        self, spark: SparkSession, simple_df, tmp_delta_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from weevr.errors.exceptions import ExecutionError
+
+        path = tmp_delta_path("uncertain_append")
+        create_delta_table(spark, path, [{"id": 99, "val": "keep"}])
+        self._break_probe(monkeypatch)
+
+        target = Target(path=path)
+        with pytest.raises(ExecutionError) as exc_info:
+            write_target(spark, simple_df, target, WriteConfig(mode="append"), path)
+        message = str(exc_info.value)
+        assert path in message
+        assert "append" in message
+        assert "probe" in message.lower()
+
+        monkeypatch.undo()
+        result = spark.read.format("delta").load(path)
+        assert [r["val"] for r in result.collect()] == ["keep"]
+
+    def test_merge_uncertain_raises_and_preserves_content(
+        self, spark: SparkSession, simple_df, tmp_delta_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from weevr.errors.exceptions import ExecutionError
+
+        path = tmp_delta_path("uncertain_merge")
+        create_delta_table(spark, path, [{"id": 99, "val": "keep"}])
+        self._break_probe(monkeypatch)
+
+        target = Target(path=path)
+        write_config = WriteConfig(mode="merge", match_keys=["id"])
+        with pytest.raises(ExecutionError) as exc_info:
+            write_target(spark, simple_df, target, write_config, path)
+        message = str(exc_info.value)
+        assert path in message
+        assert "merge" in message
+
+        monkeypatch.undo()
+        result = spark.read.format("delta").load(path)
+        assert [r["val"] for r in result.collect()] == ["keep"]
+
+    def test_probe_failure_logs_warning_naming_target(
+        self,
+        spark: SparkSession,
+        simple_df,
+        tmp_delta_path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog,
+    ) -> None:
+        from weevr.errors.exceptions import ExecutionError
+
+        path = tmp_delta_path("uncertain_logged")
+        self._break_probe(monkeypatch)
+
+        with pytest.raises(ExecutionError):
+            write_target(spark, simple_df, Target(path=path), WriteConfig(mode="append"), path)
+        assert path in caplog.text
+        assert "transient metastore outage" in caplog.text
+
+    def test_overwrite_uncertain_proceeds(
+        self, spark: SparkSession, simple_df, tmp_delta_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Overwrite is destructive by contract — uncertainty does not block it."""
+        path = tmp_delta_path("uncertain_overwrite")
+        create_delta_table(spark, path, [{"id": 99, "val": "old"}])
+        self._break_probe(monkeypatch)
+
+        write_target(spark, simple_df, Target(path=path), WriteConfig(mode="overwrite"), path)
+
+        monkeypatch.undo()
+        result = spark.read.format("delta").load(path)
+        assert result.count() == 2
+        assert result.filter("id = 99").count() == 0
+
+    def test_cdc_first_write_uncertain_raises_and_preserves_content(
+        self, spark: SparkSession, tmp_delta_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from weevr.errors.exceptions import ExecutionError
+        from weevr.model.load import CdcConfig
+        from weevr.operations.writers import execute_cdc_merge
+
+        path = tmp_delta_path("uncertain_cdc")
+        create_delta_table(spark, path, [{"id": 99, "val": "keep"}])
+        self._break_probe(monkeypatch)
+
+        incoming = spark.createDataFrame([{"id": 1, "val": "a", "op": "I"}])
+        write_config = WriteConfig(mode="merge", match_keys=["id"])
+        cdc_config = CdcConfig(operation_column="op", insert_value="I")
+        with pytest.raises(ExecutionError) as exc_info:
+            execute_cdc_merge(spark, incoming, path, write_config, cdc_config)
+        assert path in str(exc_info.value)
+
+        monkeypatch.undo()
+        result = spark.read.format("delta").load(path)
+        assert [r["val"] for r in result.collect()] == ["keep"]
+
+    def test_clean_absent_first_write_unaffected(
+        self, spark: SparkSession, simple_df, tmp_delta_path
+    ) -> None:
+        """A probe that cleanly answers False keeps today's first-write behavior."""
+        path = tmp_delta_path("clean_absent_append")
+        rows = write_target(spark, simple_df, Target(path=path), WriteConfig(mode="append"), path)
+        assert rows == 2
+        assert spark.read.format("delta").load(path).count() == 2
+
+
+@pytest.mark.spark
 class TestCommitMetricsCounts:
     """Write counts come from guarded commit metrics on single-pass paths."""
 

--- a/tests/weevr/operations/test_writers.py
+++ b/tests/weevr/operations/test_writers.py
@@ -884,6 +884,26 @@ class TestCommitStamp:
         write_target(spark, simple_df, Target(path=path), WriteConfig(mode="overwrite"), path)
         assert self._latest_user_metadata(spark, path) is None
 
+    def test_zero_row_append_reports_exact_zero(
+        self, spark: SparkSession, simple_df, tmp_delta_path
+    ) -> None:
+        """Delta skips the commit for a zero-row append — an empty commit
+        window since the pre-version is a provable zero, not an unknown."""
+        path = tmp_delta_path("stamp_zero_rows")
+        create_delta_table(spark, path, [{"id": 0, "val": "seed"}])
+
+        empty_df = simple_df.filter("id > 99")
+        rows = write_target(
+            spark,
+            empty_df,
+            Target(path=path),
+            WriteConfig(mode="append"),
+            path,
+            stamp=self._stamp(),
+        )
+        assert rows == 0
+        assert spark.read.format("delta").load(path).count() == 1
+
     def test_interleaved_foreign_commit_count_is_exact(
         self, spark: SparkSession, simple_df, tmp_delta_path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/weevr/operations/test_writers.py
+++ b/tests/weevr/operations/test_writers.py
@@ -904,6 +904,25 @@ class TestCommitStamp:
         assert rows == 0
         assert spark.read.format("delta").load(path).count() == 1
 
+    def test_zero_row_first_write_reports_exact_zero(
+        self, spark: SparkSession, simple_df, tmp_delta_path
+    ) -> None:
+        """Unlike an append to an existing table, a zero-row FIRST write
+        does create the table's initializing commit — the stamp scan
+        attributes it normally and reports an exact 0."""
+        path = tmp_delta_path("stamp_zero_first")
+        empty_df = simple_df.filter("id > 99")
+        rows = write_target(
+            spark,
+            empty_df,
+            Target(path=path),
+            WriteConfig(mode="append"),
+            path,
+            stamp=self._stamp(),
+        )
+        assert rows == 0
+        assert spark.read.format("delta").load(path).count() == 0
+
     def test_interleaved_foreign_commit_count_is_exact(
         self, spark: SparkSession, simple_df, tmp_delta_path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/weevr/operations/test_writers.py
+++ b/tests/weevr/operations/test_writers.py
@@ -837,6 +837,134 @@ class TestCommitMetricsCounts:
 
 
 @pytest.mark.spark
+class TestCommitStamp:
+    """Engine writes stamp their commits; attribution finds the own stamp
+    exactly, regardless of interleaved foreign commits."""
+
+    @staticmethod
+    def _stamp(run_id: str = "run-abc", thread: str = "t1"):
+        from weevr.operations.target_handle import CommitStamp
+
+        return CommitStamp(run_id=run_id, thread=thread, loom="loomy", weave="weavy", mode="append")
+
+    @staticmethod
+    def _latest_user_metadata(spark: SparkSession, path: str) -> str | None:
+        from weevr.delta import resolve_delta_table
+
+        row = resolve_delta_table(spark, path).history(1).select("userMetadata").collect()[0]
+        return row[0]
+
+    def test_stamp_visible_and_parseable_in_history(
+        self, spark: SparkSession, simple_df, tmp_delta_path
+    ) -> None:
+        import json
+
+        path = tmp_delta_path("stamp_visible")
+        stamp = self._stamp()
+        write_target(
+            spark, simple_df, Target(path=path), WriteConfig(mode="overwrite"), path, stamp=stamp
+        )
+
+        raw = self._latest_user_metadata(spark, path)
+        assert raw is not None
+        assert len(raw.encode()) < 1024
+        data = json.loads(raw)
+        assert data["engine"] == "weevr"
+        assert isinstance(data["version"], int)
+        assert data["run_id"] == "run-abc"
+        assert data["thread"] == "t1"
+        assert data["loom"] == "loomy"
+        assert data["weave"] == "weavy"
+        assert data["mode"] == "append"
+
+    def test_unstamped_write_leaves_no_user_metadata(
+        self, spark: SparkSession, simple_df, tmp_delta_path
+    ) -> None:
+        path = tmp_delta_path("stamp_absent")
+        write_target(spark, simple_df, Target(path=path), WriteConfig(mode="overwrite"), path)
+        assert self._latest_user_metadata(spark, path) is None
+
+    def test_interleaved_foreign_commit_count_is_exact(
+        self, spark: SparkSession, simple_df, tmp_delta_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The F-006 guard-degrade scenario, upgraded: a foreign commit
+        between pre-version capture and the engine write no longer costs
+        the engine its own count."""
+        from weevr.operations.target_handle import TargetHandle
+
+        path = tmp_delta_path("stamp_interleave")
+        create_delta_table(spark, path, [{"id": 0, "val": "seed"}])
+        handle = TargetHandle(spark, path)
+
+        original_cv = handle.current_version
+
+        def _capture_then_foreign():
+            version = original_cv()
+            frame = spark.createDataFrame([{"id": 100, "val": "foreign"}])
+            frame.write.format("delta").mode("append").save(path)
+            return version
+
+        monkeypatch.setattr(handle, "current_version", _capture_then_foreign)
+        rows = write_target(
+            spark,
+            simple_df,
+            Target(path=path),
+            WriteConfig(mode="append"),
+            path,
+            handle=handle,
+            stamp=self._stamp(),
+        )
+        assert rows == 2  # the engine's own commit, not 0 and not the foreign 1
+
+    def test_foreign_only_window_is_unattributable(
+        self, spark: SparkSession, tmp_delta_path, caplog
+    ) -> None:
+        """No own stamp in the window → absent, never another commit's metrics."""
+        from weevr.operations.target_handle import TargetHandle
+
+        path = tmp_delta_path("stamp_foreign_only")
+        create_delta_table(spark, path, [{"id": 0}])
+        handle = TargetHandle(spark, path)
+        pre = handle.current_version()
+
+        # An engine-shaped stamp from a DIFFERENT run lands in the window.
+        other = self._stamp(run_id="run-other")
+        frame = spark.createDataFrame([{"id": 1}])
+        frame.write.format("delta").mode("append").option("userMetadata", other.to_json()).save(
+            path
+        )
+
+        metrics = handle.commit_metrics_after(pre, stamp=self._stamp())
+        assert metrics is None
+        assert "unattributable" in caplog.text
+
+    def test_own_stamp_wins_over_foreign_engine_shaped_stamp(
+        self, spark: SparkSession, tmp_delta_path
+    ) -> None:
+        """Attribution matches on the run_id+thread core — an engine-shaped
+        stamp with a different run_id in the same window is not attributed."""
+        from weevr.operations.target_handle import TargetHandle
+
+        path = tmp_delta_path("stamp_core_match")
+        create_delta_table(spark, path, [{"id": 0}])
+        handle = TargetHandle(spark, path)
+        pre = handle.current_version()
+
+        own = self._stamp()
+        other = self._stamp(run_id="run-other")
+        spark.createDataFrame([{"id": 1}, {"id": 2}, {"id": 3}]).write.format("delta").mode(
+            "append"
+        ).option("userMetadata", other.to_json()).save(path)
+        spark.createDataFrame([{"id": 4}, {"id": 5}]).write.format("delta").mode("append").option(
+            "userMetadata", own.to_json()
+        ).save(path)
+
+        metrics = handle.commit_metrics_after(pre, stamp=own)
+        assert metrics is not None
+        assert int(metrics["numOutputRows"]) == 2  # the own commit, not the foreign 3
+
+
+@pytest.mark.spark
 class TestVersionReadFailureDistinction:
     """A failed history read on an existing table is not a fresh table."""
 

--- a/tests/weevr/operations/test_writers.py
+++ b/tests/weevr/operations/test_writers.py
@@ -965,6 +965,34 @@ class TestCommitStamp:
 
 
 @pytest.mark.spark
+class TestUnattributableCount:
+    """An unattributable count is unknown (None), never a false 0."""
+
+    def test_write_target_returns_none_on_attribution_miss(
+        self,
+        spark: SparkSession,
+        simple_df,
+        tmp_delta_path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog,
+    ) -> None:
+        from weevr.operations.target_handle import TargetHandle
+
+        path = tmp_delta_path("unattr_write")
+        create_delta_table(spark, path, [{"id": 0, "val": "seed"}])
+        monkeypatch.setattr(
+            TargetHandle, "commit_metrics_after", lambda self, pre, stamp=None: None
+        )
+
+        rows = write_target(spark, simple_df, Target(path=path), WriteConfig(mode="append"), path)
+        assert rows is None
+        assert "unavailable" in caplog.text
+
+        monkeypatch.undo()
+        assert spark.read.format("delta").load(path).count() == 3  # the write itself landed
+
+
+@pytest.mark.spark
 class TestVersionReadFailureDistinction:
     """A failed history read on an existing table is not a fresh table."""
 

--- a/tests/weevr/test_context.py
+++ b/tests/weevr/test_context.py
@@ -554,6 +554,29 @@ class TestContextRunExecute:
         assert result.detail is not None
         assert result.duration_ms >= 0
 
+    def test_run_execute_thread_unknown_rows_warning_reaches_run_result(
+        self, spark: SparkSession, tmp_path: Path, monkeypatch
+    ) -> None:
+        """An unattributable write count surfaces on RunResult.warnings."""
+        from weevr.operations.target_handle import TargetHandle
+
+        src = str(tmp_path / "src_unattr")
+        tgt = str(tmp_path / "tgt_unattr")
+        spark.createDataFrame([{"id": 1, "val": "a"}]).write.format("delta").save(src)
+        monkeypatch.setattr(
+            TargetHandle, "commit_metrics_after", lambda self, pre, stamp=None: None
+        )
+
+        thread_yaml = _create_thread_yaml(tmp_path, "t_unattr", src, tgt)
+        ctx = Context(spark=spark, project=_project_dir(tmp_path))
+        result = ctx.run(thread_yaml)
+        monkeypatch.undo()
+
+        assert result.status == "success"
+        assert result.detail is not None
+        assert result.detail.rows_written is None
+        assert any("t_unattr" in w and tgt in w for w in result.warnings)
+
     def test_run_execute_weave(self, spark: SparkSession, tmp_path: Path) -> None:
         src = str(tmp_path / "src_wexec")
         tgt = str(tmp_path / "tgt_wexec")

--- a/tests/weevr/test_delta.py
+++ b/tests/weevr/test_delta.py
@@ -75,3 +75,25 @@ class TestDeltaTableExists:
         with job_counter() as jc:
             assert delta_table_exists(spark, alias_table) is True
         assert jc.jobs == 0
+
+
+class TestProbeFailure:
+    """A probe failure is not a probe answer — it must leave a diagnostic trail."""
+
+    def test_probe_failure_returns_false_with_warning(self, spark, monkeypatch, caplog):
+        """The bool contract holds (False), but the failure is logged with its cause."""
+        import weevr.delta as delta_mod
+
+        def _boom(spark_arg, path_arg):
+            raise RuntimeError("transient catalog outage")
+
+        monkeypatch.setattr(delta_mod, "probe_delta_table_exists", _boom)
+        assert delta_table_exists(spark, "default.exists_probe_broken") is False
+        assert "default.exists_probe_broken" in caplog.text
+        assert "transient catalog outage" in caplog.text
+
+    def test_probe_success_logs_nothing(self, spark, tmp_delta_path, caplog):
+        """A clean absent answer stays silent — no phantom failure warnings."""
+        path = tmp_delta_path("exists_probe_clean_absent")
+        assert delta_table_exists(spark, path) is False
+        assert "probe" not in caplog.text.lower()

--- a/tests/weevr/test_delta.py
+++ b/tests/weevr/test_delta.py
@@ -82,12 +82,11 @@ class TestProbeFailure:
 
     def test_probe_failure_returns_false_with_warning(self, spark, monkeypatch, caplog):
         """The bool contract holds (False), but the failure is logged with its cause."""
-        import weevr.delta as delta_mod
 
         def _boom(spark_arg, path_arg):
             raise RuntimeError("transient catalog outage")
 
-        monkeypatch.setattr(delta_mod, "probe_delta_table_exists", _boom)
+        monkeypatch.setattr("weevr.delta.probe_delta_table_exists", _boom)
         assert delta_table_exists(spark, "default.exists_probe_broken") is False
         assert "default.exists_probe_broken" in caplog.text
         assert "transient catalog outage" in caplog.text

--- a/tests/weevr/test_result.py
+++ b/tests/weevr/test_result.py
@@ -235,6 +235,60 @@ class TestRunResult:
         s = result.summary()
         assert "1,234 written" in s
 
+    def test_summary_execute_thread_unknown_rows(self) -> None:
+        from weevr.engine.result import ThreadResult
+
+        detail = ThreadResult(
+            status="success",
+            thread_name="dim_customer",
+            rows_written=None,
+            write_mode="append",
+            target_path="/data/dim_customer",
+        )
+        result = RunResult(
+            status="success",
+            mode=ExecutionMode.EXECUTE,
+            config_type="thread",
+            config_name="dim_customer",
+            duration_ms=800,
+            detail=detail,
+        )
+        s = result.summary()
+        assert "unknown" in s
+        assert "0 written" not in s
+
+    def test_summary_execute_weave_sums_known_rows(self) -> None:
+        from weevr.engine.result import ThreadResult, WeaveResult
+
+        def _tr(name: str, rows: int | None) -> ThreadResult:
+            return ThreadResult(
+                status="success",
+                thread_name=name,
+                rows_written=rows,
+                write_mode="append",
+                target_path=f"/data/{name}",
+            )
+
+        weave = WeaveResult(
+            status="success",
+            weave_name="dims",
+            thread_results=[_tr("a", 10), _tr("b", None), _tr("c", 5)],
+            threads_skipped=[],
+            duration_ms=100,
+        )
+        result = RunResult(
+            status="success",
+            mode=ExecutionMode.EXECUTE,
+            config_type="weave",
+            config_name="dims",
+            duration_ms=100,
+            detail=weave,
+            warnings=["Thread 'b': rows written to '/data/b' could not be attributed"],
+        )
+        s = result.summary()
+        assert "15 written" in s
+        assert "Warnings:" in s
+
     def test_summary_validate_success(self) -> None:
         result = RunResult(
             status="success",


### PR DESCRIPTION
## Summary

- A failed target-existence probe can no longer silently route an
  `append`/`merge` write onto the destructive first-write overwrite branch —
  the thread now fails loudly with an error naming the target, the mode, and
  the probe failure.
- Single-pass engine writes stamp their Delta commit with a structured
  `userMetadata` lineage stamp, making `rows_written` attribution exact under
  concurrent writers.
- When attribution is truly impossible, `rows_written` reports `None`
  (unknown) with a surfaced warning — never a false `0`.

## Why

Two write-path defects shared a theme: degrading silently where the engine
must be loud (or not degrade at all).

- `delta_table_exists` folded probe *failures* into a clean "absent" answer
  with no logging. A transient metastore or storage error during target
  resolution therefore read as "table missing", and the first-write branch
  overwrote an existing `append`/`merge` target — data loss with no
  diagnostic trail.
- On single-pass writes, `rows_written` came from commit history guarded by
  "newest commit == pre-version + 1". Any interleaved foreign commit (ad-hoc
  writer, `OPTIMIZE`) or transient history-read failure produced
  `rows_written=0` on a successful write, visible only in server-side logs.
  Downstream automation gating on `rows_written == 0` misfires; dashboards
  show a false "wrote nothing".

## What changed

- `delta.py`: raw probe (`probe_delta_table_exists`, raises) split from the
  failure-folding `delta_table_exists`, which now logs failures with their
  cause. Bool contract unchanged for existing callers.
- `TargetHandle` distinguishes confirmed-absent from probe-failed
  (`exists_uncertain()`); `write_target` and `execute_cdc_merge` refuse the
  destructive branch on uncertainty. `overwrite` mode is unaffected
  (destructive by contract).
- Overwrite/append/incremental first writes and the dimension first write
  stamp their commit with compact JSON `userMetadata` (stable core: engine
  marker, `run_id`, `thread`; best-effort: loom, weave, mode). Attribution
  scans the history window since the pre-write version for the write's own
  stamp — exact regardless of interleaved commits, and the `run_id` joins
  `DESCRIBE HISTORY` to audit columns and telemetry. True MERGE commits are
  not stamped (per-write `userMetadata` is not honored there); they keep the
  version guard. The per-write stamp overrides session-level `userMetadata`
  on engine commits (documented).
- `rows_written` widened to `int | None` across `ThreadResult`,
  `ThreadTelemetry`, and `DimensionMergeResult.rows_inserted`. The residual
  unattributable case reports `None` plus a warning naming the thread and
  target on `RunResult.warnings`; `summary()` and the HTML report render
  "unknown", and weave/loom totals sum the known values. A zero-row write
  whose commit Delta skips entirely is reported as an exact `0`. The field
  shipped in an unreleased surface, so no external consumer exists.
- Observability guide documents the stamp shape, the stable-core vs
  best-effort split, the telemetry join, and the precedence caveat.

## How to test

- [x] uv sync --dev
- [x] uv run ruff check .
- [x] uv run ruff format .
- [x] uv run pyright .
- [x] uv run pytest (2561 passed) and uv run pytest -m spark (988 passed)

New coverage: probe-failure guards assert pre-existing content untouched by
re-read; interleaved-commit exactness at writer, dimension, and executor
levels; adversarial foreign engine-shaped stamp with a different `run_id` is
never attributed; zero-row append and zero-row first write both report exact
`0`; unknown-count rendering locked at thread and weave scope for both text
and HTML paths; warning propagation locked end-to-end through `Context`.

## Release / Versioning

- [x] PR title follows Conventional Commit format (feat:, fix:, chore:, docs:, ci:, etc.)
- [ ] Breaking change indicated (feat!: / fix!: or BREAKING CHANGE in body)

Not a breaking change: the probe fix replaces a data-loss hazard, and the
`rows_written` widening lands while the field's surface is still unreleased.

## Notes

- A stamp opt-out / custom-fields config was deliberately not added; the
  stamp is standard lineage practice. Revisit on first user request.
- Merge-path stamping via session configuration was rejected — it races
  across parallel threads.