### PR TITLE
fix(engine): allow condition-gated writers to share a target safely

### DIFF
--- a/docs/guides/engine-internals.md
+++ b/docs/guides/engine-internals.md
@@ -77,14 +77,14 @@ The planner builds a DAG from thread configurations:
    Declaring conditions on all writers asserts they are **mutually
    exclusive** — at most one runs per execution (say, a full-load thread
    and an incremental thread for the same table). The planner cannot prove
-   disjointness (conditions may read live table state), so the engine
-   enforces the assertion at runtime: if a second writer's condition also
-   evaluates true, the weave aborts before that writer executes. Consumers
-   of such a target depend on *every* writer, and a lookup reading it
-   materializes only after the last writer's group. Unordered,
-   uncondition-gated threads sharing a target are rejected with a
-   `ConfigError` naming the target and every writer — running them
-   concurrently would corrupt the table.
+   the conditions exclude each other (they may read live table state), so
+   the engine enforces the assertion at runtime: if a second writer's
+   condition also evaluates true, the weave aborts before that writer
+   executes. Consumers of such a target depend on *every* writer, and a
+   lookup reading it materializes only after the last writer's group.
+   Unordered writers sharing a target where any writer lacks a condition
+   are rejected with a `ConfigError` naming the target and every writer —
+   running them concurrently would corrupt the table.
 2. **Infer dependencies** — If thread B reads from thread A's target path, B
    depends on A. This happens automatically by matching source paths/aliases
    to target paths/aliases across all threads.

--- a/docs/guides/engine-internals.md
+++ b/docs/guides/engine-internals.md
@@ -70,11 +70,21 @@ execute -> aggregate: results + telemetry
 The planner builds a DAG from thread configurations:
 
 1. **Check target ownership** — Each target may have only one writing thread,
-   unless explicit dependencies fully serialize the writers into a chain.
-   Unordered threads sharing a target are rejected with a `ConfigError` naming
-   the target and every writer — running them concurrently would corrupt the
-   table. For an ordered chain, downstream consumers depend on the *last*
-   writer, so they always see the target's final state.
+   unless one of two exemptions applies. Explicit dependencies that fully
+   serialize the writers into a chain are one; downstream consumers then
+   depend on the *last* writer, so they always see the target's final state.
+   The other: every writer of the target carries a thread-entry `condition`.
+   Declaring conditions on all writers asserts they are **mutually
+   exclusive** — at most one runs per execution (say, a full-load thread
+   and an incremental thread for the same table). The planner cannot prove
+   disjointness (conditions may read live table state), so the engine
+   enforces the assertion at runtime: if a second writer's condition also
+   evaluates true, the weave aborts before that writer executes. Consumers
+   of such a target depend on *every* writer, and a lookup reading it
+   materializes only after the last writer's group. Unordered,
+   uncondition-gated threads sharing a target are rejected with a
+   `ConfigError` naming the target and every writer — running them
+   concurrently would corrupt the table.
 2. **Infer dependencies** — If thread B reads from thread A's target path, B
    depends on A. This happens automatically by matching source paths/aliases
    to target paths/aliases across all threads.
@@ -144,10 +154,19 @@ skipped.
    loom + weave connection dict. Results are captured in
    `WeaveTelemetry.column_set_results`.
 5. **Thread execution** — Parallel groups are processed
-   sequentially. Within each group, threads are submitted to a
-   `ThreadPoolExecutor` for concurrent execution. Threads
-   reference lookups via `source.lookup` and receive the cached
-   DataFrame.
+   sequentially. At each group's top, thread conditions evaluate
+   (fresh per group, memoized within it); threads whose condition
+   is false are skipped without cascading to their dependents.
+   Where condition-gated writers share a target, survivors are
+   tracked as conditions resolve: a second surviving writer means
+   the conditions overlap, and the weave aborts before that
+   writer executes. In the same group this happens before *any*
+   write; across groups the earlier writer's complete, sequential
+   write stands, and the error says so — the abort exists to
+   prevent the second write, not to undo the first. Remaining
+   threads are then submitted to a `ThreadPoolExecutor` for
+   concurrent execution. Threads reference lookups via
+   `source.lookup` and receive the cached DataFrame.
 6. **Post-steps** — After all threads complete, `post_steps` hook
    steps run. Failures with `on_failure: abort` mark the weave
    as failed.

--- a/packages/weevr-core/src/weevr/engine/planner.py
+++ b/packages/weevr-core/src/weevr/engine/planner.py
@@ -43,6 +43,15 @@ class ExecutionPlan(FrozenBase):
         lookup_consumers: Maps lookup names to the list of threads that
             consume each lookup. Only populated when ``build_plan`` was
             called with lookups.
+        conditional_target_writers: Maps a normalized target path to the
+            writers sharing it under the condition exemption — every
+            writer carries a thread-entry condition, and the conditions
+            assert mutual exclusion (the runner enforces it at
+            condition-resolution time). ``None`` when no target is
+            shared this way. Lookups reading such a target have no
+            single producer: ``lookup_producers`` records ``None`` for
+            them, while the schedule places them after the last
+            writer's group and consumers depend on every writer.
     """
 
     weave_name: str
@@ -56,6 +65,7 @@ class ExecutionPlan(FrozenBase):
     lookup_schedule: dict[int, list[str]] | None = None
     lookup_producers: dict[str, str | None] | None = None
     lookup_consumers: dict[str, list[str]] | None = None
+    conditional_target_writers: dict[str, list[str]] | None = None
 
     def dag(self, *, dark: bool | None = None) -> DAGDiagram:
         """Return an inline SVG DAG diagram of this execution plan.
@@ -217,30 +227,45 @@ def _build_target_index(
     threads: dict[str, Thread],
     explicit_index: dict[str, list[str]],
     weave_name: str,
-) -> dict[str, str]:
+    conditioned: set[str],
+) -> tuple[dict[str, str], dict[str, list[str]]]:
     """Build a mapping of normalized target path to producing thread name.
 
     Used by thread and lookup dependency inference to identify which thread
     produces a given data path.
 
-    A target written by two or more threads is rejected unless explicit
-    dependencies totally order the writers: unordered writers would land in
-    one parallel group and race concurrent writes against a single table.
-    For an ordered writer chain, the target resolves to the last writer, so
-    downstream consumers run after the target's final state exists.
+    A target written by two or more threads is rejected unless one of two
+    exemptions applies:
+
+    - Explicit dependencies totally order the writers. The target then
+      resolves to the last writer, so downstream consumers run after the
+      target's final state exists.
+    - Every writer carries a thread-entry condition. The conditions assert
+      mutual exclusion (at most one writer survives per run); the runner
+      enforces the assertion at condition-resolution time. Such a target
+      has no single producer — it is returned in the conditional map
+      instead of the index, and consumers depend on every writer.
+
+    Unordered, uncondition-gated writers would land in one parallel group
+    and race concurrent writes against a single table.
 
     Args:
         threads: Mapping of thread name to Thread config.
         explicit_index: Explicit dependency index, used to check whether
             same-target writers are serialized by declared dependencies.
         weave_name: Weave name for error messages.
+        conditioned: Effective names of threads whose entry carries a
+            condition.
 
     Returns:
-        A dict mapping normalized target path to the producing thread's name.
+        A tuple of ``(target_index, conditional_writers)``: the normalized
+        target path → producing thread mapping, and the normalized target
+        path → sorted writer names mapping for condition-exempted targets.
 
     Raises:
         ConfigError: If two or more threads write the same target without
-            explicit dependencies totally ordering them.
+            explicit dependencies totally ordering them and without every
+            writer being condition-gated.
     """
     writers_by_path: dict[str, list[str]] = {}
     for name, thread in threads.items():
@@ -249,36 +274,47 @@ def _build_target_index(
             writers_by_path.setdefault(path, []).append(name)
 
     target_index: dict[str, str] = {}
+    conditional_writers: dict[str, list[str]] = {}
     for path, writers in writers_by_path.items():
         if len(writers) == 1:
             target_index[path] = writers[0]
             continue
         last_writer = _resolve_writer_chain(writers, explicit_index)
-        if last_writer is None:
-            names = ", ".join(f"'{n}'" for n in sorted(writers))
-            raise ConfigError(
-                f"Threads {names} all write target '{path}' in weave "
-                f"'{weave_name}' but are not ordered by explicit dependencies, "
-                f"so concurrent writes would corrupt the target. Declare "
-                f"explicit dependencies to serialize the writers, or give each "
-                f"thread its own target."
-            )
-        target_index[path] = last_writer
-    return target_index
+        if last_writer is not None:
+            target_index[path] = last_writer
+            continue
+        if all(w in conditioned for w in writers):
+            conditional_writers[path] = sorted(writers)
+            continue
+        names = ", ".join(f"'{n}'" for n in sorted(writers))
+        raise ConfigError(
+            f"Threads {names} all write target '{path}' in weave "
+            f"'{weave_name}' but are not ordered by explicit dependencies, "
+            f"so concurrent writes would corrupt the target. Declare "
+            f"explicit dependencies to serialize the writers, give each "
+            f"thread its own target, or put a mutually exclusive condition "
+            f"on every writer."
+        )
+    return target_index, conditional_writers
 
 
 def _infer_dependencies(
     threads: dict[str, Thread],
     target_index: dict[str, str],
+    conditional_writers: dict[str, list[str]],
 ) -> dict[str, list[str]]:
     """Build the inferred dependency dict from source/target path matching.
 
     For each thread, auto-infers an edge when another thread's target path
-    appears in this thread's source paths.
+    appears in this thread's source paths. A source matching a
+    condition-exempted shared target has no single producer — the consumer
+    depends on EVERY writer, so it runs after whichever one survived.
 
     Args:
         threads: Mapping of thread name to Thread config.
         target_index: Pre-built target path index.
+        conditional_writers: Condition-exempted shared targets and their
+            writer sets.
 
     Returns:
         A ``dict[thread_name, list[upstream_thread_name]]`` of inferred edges.
@@ -287,9 +323,13 @@ def _infer_dependencies(
     for name, thread in threads.items():
         source_paths = _extract_source_paths(thread)
         for src_path in source_paths:
-            producer = target_index.get(src_path)
-            if producer is not None and producer != name and producer not in inferred[name]:
-                inferred[name].append(producer)
+            producers = conditional_writers.get(src_path)
+            if producers is None:
+                single = target_index.get(src_path)
+                producers = [single] if single is not None else []
+            for producer in producers:
+                if producer != name and producer not in inferred[name]:
+                    inferred[name].append(producer)
     return inferred
 
 
@@ -432,34 +472,55 @@ def _infer_lookup_dependencies(
     threads: dict[str, Thread],
     lookups: dict[str, Lookup],
     target_index: dict[str, str],
-) -> tuple[dict[str, list[str]], dict[str, str | None], dict[str, list[str]]]:
+    conditional_writers: dict[str, list[str]],
+) -> tuple[
+    dict[str, list[str]],
+    dict[str, str | None],
+    dict[str, list[str]],
+    dict[str, list[str]],
+]:
     """Infer implicit thread dependencies mediated by lookups.
 
     When a lookup's source reads from a table produced by thread A, and
-    thread B consumes that lookup, then B implicitly depends on A.
+    thread B consumes that lookup, then B implicitly depends on A. A lookup
+    reading a condition-exempted shared target has no single producer:
+    ``lookup_producer`` records ``None`` and the conditional map carries
+    the full writer set — consumers depend on every writer, and the
+    schedule places the lookup after the last writer's group.
 
     Args:
         threads: Mapping of thread name to Thread config.
         lookups: Mapping of lookup name to Lookup config.
         target_index: Pre-built target path to thread name index.
+        conditional_writers: Condition-exempted shared targets and their
+            writer sets.
 
     Returns:
-        A tuple of ``(lookup_deps, lookup_producer, lookup_consumers)`` where:
+        A tuple of ``(lookup_deps, lookup_producer, lookup_consumers,
+        lookup_conditional)`` where:
         - ``lookup_deps`` maps consumer thread names to the list of producer
           thread names they implicitly depend on (via lookups).
         - ``lookup_producer`` maps lookup names to the producing thread name,
           or ``None`` for external lookups.
         - ``lookup_consumers`` maps lookup names to the list of thread names
           that consume each lookup.
+        - ``lookup_conditional`` maps lookup names to the writer set of the
+          conditional shared target they read (empty when they don't).
     """
-    # Find the producer thread for each lookup
+    # Find the producer thread(s) for each lookup
     lookup_producer: dict[str, str | None] = {}
+    lookup_conditional: dict[str, list[str]] = {}
     for lk_name, lk in lookups.items():
         src = lk.source
         raw = src.alias or src.path
         if raw is not None:
             normalized = _normalize_path(raw)
-            lookup_producer[lk_name] = target_index.get(normalized)
+            writers = conditional_writers.get(normalized)
+            if writers is not None:
+                lookup_conditional[lk_name] = writers
+                lookup_producer[lk_name] = None
+            else:
+                lookup_producer[lk_name] = target_index.get(normalized)
         else:
             lookup_producer[lk_name] = None
 
@@ -474,21 +535,25 @@ def _infer_lookup_dependencies(
             ):
                 lookup_consumers[source.lookup].append(thread_name)
 
-    # Build implicit deps: consumer depends on producer
+    # Build implicit deps: consumer depends on producer(s)
     lookup_deps: dict[str, list[str]] = {name: [] for name in threads}
-    for lk_name, producer in lookup_producer.items():
-        if producer is None:
-            continue
-        for consumer in lookup_consumers.get(lk_name, []):
-            if consumer != producer and producer not in lookup_deps[consumer]:
-                lookup_deps[consumer].append(producer)
+    for lk_name in lookups:
+        producers = lookup_conditional.get(lk_name)
+        if producers is None:
+            single = lookup_producer[lk_name]
+            producers = [single] if single is not None else []
+        for producer in producers:
+            for consumer in lookup_consumers.get(lk_name, []):
+                if consumer != producer and producer not in lookup_deps[consumer]:
+                    lookup_deps[consumer].append(producer)
 
-    return lookup_deps, lookup_producer, lookup_consumers
+    return lookup_deps, lookup_producer, lookup_consumers, lookup_conditional
 
 
 def _compute_lookup_schedule(
     lookups: dict[str, Lookup],
     lookup_producer: dict[str, str | None],
+    lookup_conditional: dict[str, list[str]],
     execution_order: list[list[str]],
 ) -> dict[int, list[str]]:
     """Compute when each materialized lookup should be read.
@@ -496,10 +561,14 @@ def _compute_lookup_schedule(
     Lookups with no producer (external data) are scheduled at group 0 (before
     the first execution group). Lookups whose source is produced by a thread
     in group N are scheduled at group N+1 (after the producer completes).
+    Lookups reading a condition-exempted shared target are scheduled after
+    the LAST writer's group — the surviving writer may sit in any of them.
 
     Args:
         lookups: Mapping of lookup name to Lookup config.
         lookup_producer: Maps lookup name to its producer thread, or ``None``.
+        lookup_conditional: Maps lookup names to the writer set of the
+            conditional shared target they read.
         execution_order: Parallel execution groups from topological sort.
 
     Returns:
@@ -516,8 +585,12 @@ def _compute_lookup_schedule(
     for lk_name, lk in lookups.items():
         if not lk.materialize:
             continue
-        producer = lookup_producer.get(lk_name)
-        group_idx = 0 if producer is None else thread_group_index[producer] + 1
+        writers = lookup_conditional.get(lk_name)
+        if writers:
+            group_idx = max(thread_group_index[w] for w in writers) + 1
+        else:
+            producer = lookup_producer.get(lk_name)
+            group_idx = 0 if producer is None else thread_group_index[producer] + 1
         schedule.setdefault(group_idx, []).append(lk_name)
 
     # Sort lookup names within each group for determinism
@@ -567,22 +640,32 @@ def build_plan(
     thread_names = list(threads.keys())
 
     # 0. Build the explicit dependency index first — the target index needs it
-    #    to decide whether same-target writers are serialized.
+    #    to decide whether same-target writers are serialized. Conditioned
+    #    effective names feed the condition exemption for shared targets.
     explicit = _build_explicit_index(threads, thread_entries)
+    conditioned = {
+        (entry.as_ or entry.name or (Path(entry.ref).stem if entry.ref else ""))
+        for entry in thread_entries
+        if entry.condition is not None
+    }
 
-    # 0b. Build shared target index (rejects unordered duplicate targets)
-    target_index = _build_target_index(threads, explicit, weave_name)
+    # 0b. Build shared target index (rejects unordered duplicate targets
+    #     unless chained or fully condition-gated)
+    target_index, conditional_writers = _build_target_index(
+        threads, explicit, weave_name, conditioned
+    )
 
     # 1. Infer data-based dependencies from source/target path matching
-    inferred = _infer_dependencies(threads, target_index)
+    inferred = _infer_dependencies(threads, target_index, conditional_writers)
 
     # 1b. Infer lookup-mediated dependencies when lookups are provided
     lookup_deps: dict[str, list[str]] | None = None
     lookup_producer: dict[str, str | None] | None = None
     lookup_consumers: dict[str, list[str]] | None = None
+    lookup_conditional: dict[str, list[str]] = {}
     if lookups:
-        lookup_deps, lookup_producer, lookup_consumers = _infer_lookup_dependencies(
-            threads, lookups, target_index
+        lookup_deps, lookup_producer, lookup_consumers, lookup_conditional = (
+            _infer_lookup_dependencies(threads, lookups, target_index, conditional_writers)
         )
         # Merge lookup deps into inferred deps
         for name, deps in lookup_deps.items():
@@ -611,7 +694,9 @@ def build_plan(
     # 7. Compute lookup materialization schedule
     lookup_schedule: dict[int, list[str]] | None = None
     if lookups and lookup_producer is not None:
-        lookup_schedule = _compute_lookup_schedule(lookups, lookup_producer, execution_order)
+        lookup_schedule = _compute_lookup_schedule(
+            lookups, lookup_producer, lookup_conditional, execution_order
+        )
 
     return ExecutionPlan(
         weave_name=weave_name,
@@ -625,4 +710,5 @@ def build_plan(
         lookup_schedule=lookup_schedule,
         lookup_producers=lookup_producer,
         lookup_consumers=lookup_consumers,
+        conditional_target_writers=conditional_writers or None,
     )

--- a/packages/weevr-core/src/weevr/engine/planner.py
+++ b/packages/weevr-core/src/weevr/engine/planner.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from collections import deque
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from weevr.config.onelake import resolve_connection_path
@@ -176,7 +175,7 @@ def _build_explicit_index(
     """
     explicit_index: dict[str, list[str]] = {name: [] for name in threads}
     for entry in thread_entries:
-        effective_name = entry.as_ or entry.name or (Path(entry.ref).stem if entry.ref else "")
+        effective_name = entry.effective_name
         if entry.dependencies:
             for dep in entry.dependencies:
                 if dep not in threads:
@@ -643,11 +642,7 @@ def build_plan(
     #    to decide whether same-target writers are serialized. Conditioned
     #    effective names feed the condition exemption for shared targets.
     explicit = _build_explicit_index(threads, thread_entries)
-    conditioned = {
-        (entry.as_ or entry.name or (Path(entry.ref).stem if entry.ref else ""))
-        for entry in thread_entries
-        if entry.condition is not None
-    }
+    conditioned = {entry.effective_name for entry in thread_entries if entry.condition is not None}
 
     # 0b. Build shared target index (rejects unordered duplicate targets
     #     unless chained or fully condition-gated)

--- a/packages/weevr-core/src/weevr/engine/planner.py
+++ b/packages/weevr-core/src/weevr/engine/planner.py
@@ -297,6 +297,24 @@ def _build_target_index(
     return target_index, conditional_writers
 
 
+def _resolve_producers(
+    path: str,
+    conditional_writers: dict[str, list[str]],
+    target_index: dict[str, str],
+) -> list[str]:
+    """Every thread that may produce ``path`` — the crux of the exemption.
+
+    A condition-exempted shared target has no single producer: consumers
+    must wait on every writer, since any one of them may be the survivor.
+    Otherwise the single-valued index answers (empty when external).
+    """
+    writers = conditional_writers.get(path)
+    if writers is not None:
+        return writers
+    single = target_index.get(path)
+    return [single] if single is not None else []
+
+
 def _infer_dependencies(
     threads: dict[str, Thread],
     target_index: dict[str, str],
@@ -322,11 +340,7 @@ def _infer_dependencies(
     for name, thread in threads.items():
         source_paths = _extract_source_paths(thread)
         for src_path in source_paths:
-            producers = conditional_writers.get(src_path)
-            if producers is None:
-                single = target_index.get(src_path)
-                producers = [single] if single is not None else []
-            for producer in producers:
+            for producer in _resolve_producers(src_path, conditional_writers, target_index):
                 if producer != name and producer not in inferred[name]:
                     inferred[name].append(producer)
     return inferred
@@ -506,22 +520,26 @@ def _infer_lookup_dependencies(
         - ``lookup_conditional`` maps lookup names to the writer set of the
           conditional shared target they read (empty when they don't).
     """
-    # Find the producer thread(s) for each lookup
+    # Find the producer thread(s) for each lookup. A conditional set
+    # (2+ writers) has no single producer: the public mapping records
+    # None and the conditional map carries the full set.
     lookup_producer: dict[str, str | None] = {}
     lookup_conditional: dict[str, list[str]] = {}
+    producers_by_lookup: dict[str, list[str]] = {}
     for lk_name, lk in lookups.items():
         src = lk.source
         raw = src.alias or src.path
-        if raw is not None:
-            normalized = _normalize_path(raw)
-            writers = conditional_writers.get(normalized)
-            if writers is not None:
-                lookup_conditional[lk_name] = writers
-                lookup_producer[lk_name] = None
-            else:
-                lookup_producer[lk_name] = target_index.get(normalized)
-        else:
+        producers = (
+            _resolve_producers(_normalize_path(raw), conditional_writers, target_index)
+            if raw is not None
+            else []
+        )
+        producers_by_lookup[lk_name] = producers
+        if len(producers) > 1:
+            lookup_conditional[lk_name] = producers
             lookup_producer[lk_name] = None
+        else:
+            lookup_producer[lk_name] = producers[0] if producers else None
 
     # Find which threads consume each lookup
     lookup_consumers: dict[str, list[str]] = {lk: [] for lk in lookups}
@@ -536,11 +554,7 @@ def _infer_lookup_dependencies(
 
     # Build implicit deps: consumer depends on producer(s)
     lookup_deps: dict[str, list[str]] = {name: [] for name in threads}
-    for lk_name in lookups:
-        producers = lookup_conditional.get(lk_name)
-        if producers is None:
-            single = lookup_producer[lk_name]
-            producers = [single] if single is not None else []
+    for lk_name, producers in producers_by_lookup.items():
         for producer in producers:
             for consumer in lookup_consumers.get(lk_name, []):
                 if consumer != producer and producer not in lookup_deps[consumer]:

--- a/packages/weevr-core/src/weevr/model/weave.py
+++ b/packages/weevr-core/src/weevr/model/weave.py
@@ -1,5 +1,6 @@
 """Weave domain model."""
 
+from pathlib import PurePath
 from typing import Any
 
 from pydantic import Field, model_validator
@@ -99,6 +100,21 @@ class ThreadEntry(FrozenBase):
             "only if the condition evaluates to True."
         ),
     )
+
+    @property
+    def effective_name(self) -> str:
+        """The name this entry is known by downstream (planner, runner).
+
+        ``as`` aliasing overrides the raw name; ref-only entries fall
+        back to the file stem. Anything keyed by thread name (plan
+        states, condition maps, telemetry) MUST use this — keying an
+        aliased entry by its raw name silently misses it.
+        """
+        if self.as_:
+            return self.as_
+        if self.name:
+            return self.name
+        return PurePath(self.ref).stem if self.ref else ""
 
 
 class Weave(FrozenBase):

--- a/packages/weevr/src/weevr/context.py
+++ b/packages/weevr/src/weevr/context.py
@@ -387,11 +387,13 @@ class Context:
                 thread_entries=filtered_entries,
                 lookups=weave_lookups,
             )
-            # Build thread condition map from ThreadEntry conditions
+            # Build thread condition map from ThreadEntry conditions,
+            # keyed by EFFECTIVE name — an aliased entry's condition
+            # keyed by its raw name would silently never evaluate
             thread_conditions: dict[str, ConditionSpec] = {}
             for te in model.threads:
                 if te.condition is not None:
-                    thread_conditions[te.name] = te.condition
+                    thread_conditions[te.effective_name] = te.condition
 
             from weevr.telemetry.collector import SpanCollector
             from weevr.telemetry.span import generate_trace_id

--- a/packages/weevr/src/weevr/engine/runner.py
+++ b/packages/weevr/src/weevr/engine/runner.py
@@ -78,6 +78,13 @@ def _compute_weave_status(
     return "partial"
 
 
+def _skip_pending(thread_states: dict[str, _ThreadState]) -> None:
+    """Mark every still-pending thread skipped (weave abort)."""
+    for name, state in thread_states.items():
+        if state == "pending":
+            thread_states[name] = "skipped"
+
+
 def execute_weave(
     spark: SparkSession,
     plan: ExecutionPlan,
@@ -171,6 +178,14 @@ def execute_weave(
     cache = CacheManager(plan.cache_targets, plan.dependents)
     uk_memo = UniqueKeyMemo()
     aborted = False
+    # Mutual-exclusion backstop state for condition-exempted shared
+    # targets: writer → target path, and target path → first survivor.
+    conditional_writer_target: dict[str, str] = {}
+    if plan.conditional_target_writers:
+        for path, writer_names in plan.conditional_target_writers.items():
+            for writer in writer_names:
+                conditional_writer_target[writer] = path
+    conditional_survivors: dict[str, str] = {}
     _weave_raised = False
     max_parallel_threads = execution.max_parallel_threads if execution is not None else None
     group_thread_counts: list[int] = []
@@ -320,6 +335,48 @@ def execute_weave(
                         name,
                         conditions[name].when,
                     )
+
+            # Mutual-exclusion backstop: conditions on a shared target's
+            # writers assert that at most one survives per run. A second
+            # survivor means the conditions overlap — abort before its
+            # write executes (same-group overlaps abort before ANY write;
+            # for cross-group overlaps the completed first write stands).
+            for name in group:
+                if thread_states[name] != "pending" or name not in conditional_writer_target:
+                    continue
+                path = conditional_writer_target[name]
+                first = conditional_survivors.setdefault(path, name)
+                if first == name:
+                    continue
+                if thread_states[first] == "pending":
+                    completed_note = ""
+                else:
+                    completed_note = (
+                        f" Thread '{first}' has already written the target; "
+                        f"aborting before the second write — its complete "
+                        f"write stands."
+                    )
+                error_msg = (
+                    f"Conditional writers of target '{path}' overlap in weave "
+                    f"'{plan.weave_name}': threads '{first}' and '{name}' both "
+                    f"survived their conditions, but the conditions must be "
+                    f"mutually exclusive.{completed_note}"
+                )
+                thread_states[name] = "failed"
+                thread_results.append(
+                    ThreadResult(
+                        status="failure",
+                        thread_name=name,
+                        rows_written=0,
+                        write_mode="",
+                        target_path=path,
+                        error=error_msg,
+                    )
+                )
+                _skip_pending(thread_states)
+                aborted = True
+                logger.error("%s", error_msg)
+                break
 
             # Separate threads that should run vs those already skipped
             to_run = [n for n in group if thread_states[n] == "pending"]
@@ -472,10 +529,7 @@ def execute_weave(
                         downstream = _get_transitive_dependents(name, plan.dependents)
 
                         if on_failure == "abort_weave":
-                            # Mark all remaining pending threads as skipped
-                            for t in plan.threads:
-                                if thread_states[t] == "pending":
-                                    thread_states[t] = "skipped"
+                            _skip_pending(thread_states)
                             aborted = True
                             logger.debug(
                                 "Thread '%s' abort_weave — remaining threads skipped", name
@@ -760,11 +814,13 @@ def execute_loom(
                 lookups=weave_lookups,
             )
 
-            # Build thread condition map from ThreadEntry conditions
+            # Build thread condition map from ThreadEntry conditions,
+            # keyed by EFFECTIVE name — an aliased entry's condition
+            # keyed by its raw name would silently never evaluate
             thread_conditions: dict[str, ConditionSpec] = {}
             for te in weave.threads:
                 if te.condition is not None:
-                    thread_conditions[te.name] = te.condition
+                    thread_conditions[te.effective_name] = te.condition
 
             # Merge loom and weave resources using cascade helpers (weave wins)
             loom_cs = dict(loom.column_sets) if loom.column_sets else None

--- a/packages/weevr/src/weevr/engine/runner.py
+++ b/packages/weevr/src/weevr/engine/runner.py
@@ -298,10 +298,9 @@ def execute_weave(
                 _materialize_scheduled(group_idx)
 
             if aborted:
-                for name in group:
-                    if thread_states[name] == "pending":
-                        thread_states[name] = "skipped"
-                        threads_skipped.append(name)
+                # Every abort site already swept pending threads to
+                # skipped via _skip_pending; the final bookkeeping loop
+                # backfills threads_skipped from the states.
                 continue
 
             # Evaluate conditions for pending threads before execution.
@@ -348,14 +347,27 @@ def execute_weave(
                 first = conditional_survivors.setdefault(path, name)
                 if first == name:
                     continue
-                if thread_states[first] == "pending":
-                    completed_note = ""
-                else:
+                # The first survivor's terminal state decides the framing:
+                # a SUCCEEDED writer's complete write stands; a FAILED one
+                # may have failed before or after its write, so no claim
+                # about the target's state is safe. Either way the second
+                # write is blocked — the exclusivity contract is broken,
+                # and proceeding could double-write a post-write failure.
+                if thread_states[first] == "succeeded":
                     completed_note = (
                         f" Thread '{first}' has already written the target; "
                         f"aborting before the second write — its complete "
                         f"write stands."
                     )
+                elif thread_states[first] == "failed":
+                    completed_note = (
+                        f" Thread '{first}' survived its condition but "
+                        f"failed during execution, so whether it wrote the "
+                        f"target is unverified; aborting before the second "
+                        f"write."
+                    )
+                else:
+                    completed_note = ""
                 error_msg = (
                     f"Conditional writers of target '{path}' overlap in weave "
                     f"'{plan.weave_name}': threads '{first}' and '{name}' both "

--- a/tests/weevr/engine/test_orchestration.py
+++ b/tests/weevr/engine/test_orchestration.py
@@ -11,7 +11,7 @@ from weevr.engine import build_plan, execute_loom, execute_weave
 from weevr.errors.exceptions import ConfigError
 from weevr.model.loom import Loom
 from weevr.model.thread import Thread
-from weevr.model.weave import ThreadEntry, Weave
+from weevr.model.weave import ConditionSpec, ThreadEntry, Weave
 
 pytestmark = pytest.mark.spark
 
@@ -422,7 +422,6 @@ class TestConditionMemoScope:
     ) -> None:
         """Two same-group threads with the same builtin probe share one scan."""
         from weevr.engine import conditions as conditions_mod
-        from weevr.model.weave import ConditionSpec
 
         src_c = tmp_delta_path("memo_group_src_c")
         src_d = tmp_delta_path("memo_group_src_d")
@@ -538,3 +537,132 @@ class TestConditionMemoScope:
 
         assert result.status == "success"
         assert [w.status for w in result.weave_results] == ["success", "success"]
+
+
+# ---------------------------------------------------------------------------
+# Conditional shared-target writers — runtime mutual-exclusion backstop
+# ---------------------------------------------------------------------------
+
+
+class TestConditionalSharedTarget:
+    """Condition-gated writers of one target: exactly one may survive."""
+
+    @staticmethod
+    def _cond(gate_path: str) -> ConditionSpec:
+        return ConditionSpec(when=f"table_exists('{gate_path}')")
+
+    def _setup(self, spark, tmp_delta_path, prefix: str):
+        """Two conditional writers of one shared target plus a consumer."""
+        src_a = tmp_delta_path(f"{prefix}_src_a")
+        src_b = tmp_delta_path(f"{prefix}_src_b")
+        shared = tmp_delta_path(f"{prefix}_shared")
+        tgt_out = tmp_delta_path(f"{prefix}_out")
+        create_delta_table(spark, src_a, [{"id": 1, "who": "A"}])
+        create_delta_table(spark, src_b, [{"id": 2, "who": "B"}])
+
+        threads = {
+            "A": _thread("A", src_a, shared),
+            "B": _thread("B", src_b, shared),
+            "consumer": _thread("consumer", shared, tgt_out),
+        }
+        entries = [
+            ThreadEntry(name="A", condition=ConditionSpec(when="1 == 1")),
+            ThreadEntry(name="B", condition=ConditionSpec(when="1 == 1")),
+            ThreadEntry(name="consumer"),
+        ]
+        plan = build_plan("test_weave", threads, entries)
+        return threads, plan, shared, tgt_out
+
+    def test_disjoint_conditions_one_writer_runs(self, spark: SparkSession, tmp_delta_path) -> None:
+        gate_a = tmp_delta_path("csd_gate_a")
+        gate_b = tmp_delta_path("csd_gate_b")  # never created — B's condition is False
+        create_delta_table(spark, gate_a, [{"id": 1}])
+        threads, plan, shared, tgt_out = self._setup(spark, tmp_delta_path, "csd")
+
+        result = execute_weave(
+            spark,
+            plan,
+            threads,
+            thread_conditions={"A": self._cond(gate_a), "B": self._cond(gate_b)},
+        )
+
+        assert result.status == "success"
+        assert "B" in result.threads_skipped
+        assert "consumer" not in result.threads_skipped  # condition-skips don't cascade
+        consumer_results = [r for r in result.thread_results if r.thread_name == "consumer"]
+        assert consumer_results and consumer_results[0].status == "success"
+        out_rows = spark.read.format("delta").load(tgt_out).collect()
+        assert [r["who"] for r in out_rows] == ["A"]
+
+    def test_same_group_overlap_aborts_before_any_write(
+        self, spark: SparkSession, tmp_delta_path
+    ) -> None:
+        gate = tmp_delta_path("cso_gate")
+        create_delta_table(spark, gate, [{"id": 1}])
+        threads, plan, shared, tgt_out = self._setup(spark, tmp_delta_path, "cso")
+
+        result = execute_weave(
+            spark,
+            plan,
+            threads,
+            thread_conditions={"A": self._cond(gate), "B": self._cond(gate)},
+        )
+
+        assert result.status == "failure"
+        failures = [r for r in result.thread_results if r.status == "failure"]
+        assert failures
+        message = failures[0].error or ""
+        assert shared in message
+        assert "A" in message and "B" in message
+        assert "consumer" in result.threads_skipped
+        # Neither writer executed — the shared target was never created
+        from weevr.delta import delta_table_exists
+
+        assert delta_table_exists(spark, shared) is False
+        assert delta_table_exists(spark, tgt_out) is False
+
+    def test_cross_group_overlap_aborts_before_second_write(
+        self, spark: SparkSession, tmp_delta_path
+    ) -> None:
+        gate = tmp_delta_path("cxg_gate")
+        create_delta_table(spark, gate, [{"id": 1}])
+        src_a = tmp_delta_path("cxg_src_a")
+        src_b = tmp_delta_path("cxg_src_b")
+        src_x = tmp_delta_path("cxg_src_x")
+        shared = tmp_delta_path("cxg_shared")
+        tgt_x = tmp_delta_path("cxg_tgt_x")
+        create_delta_table(spark, src_a, [{"id": 1, "who": "A"}])
+        create_delta_table(spark, src_b, [{"id": 2, "who": "B"}])
+        create_delta_table(spark, src_x, [{"id": 3, "who": "X"}])
+
+        threads = {
+            "A": _thread("A", src_a, shared),
+            "X": _thread("X", src_x, tgt_x),
+            "B": _thread("B", src_b, shared),
+        }
+        entries = [
+            ThreadEntry(name="A", condition=ConditionSpec(when="1 == 1")),
+            ThreadEntry(name="X"),
+            ThreadEntry(name="B", condition=ConditionSpec(when="1 == 1"), dependencies=["X"]),
+        ]
+        plan = build_plan("test_weave", threads, entries)
+
+        result = execute_weave(
+            spark,
+            plan,
+            threads,
+            thread_conditions={"A": self._cond(gate), "B": self._cond(gate)},
+        )
+
+        # A succeeded before the overlap was detectable, so the weave
+        # reports partial — the established mixed-outcome status
+        assert result.status == "partial"
+        failures = [r for r in result.thread_results if r.status == "failure"]
+        assert failures
+        message = failures[0].error or ""
+        assert shared in message
+        assert "A" in message and "B" in message
+        assert "already" in message  # notes the completed first write
+        # A's complete write stands; B never executed a second write
+        rows = spark.read.format("delta").load(shared).collect()
+        assert [r["who"] for r in rows] == ["A"]

--- a/tests/weevr/engine/test_orchestration.py
+++ b/tests/weevr/engine/test_orchestration.py
@@ -468,8 +468,6 @@ class TestConditionMemoScope:
         written it and must run. A memo outliving the group batch would
         replay C's zero and wrongly skip B.
         """
-        from weevr.model.weave import ConditionSpec
-
         src_a = tmp_delta_path("memo_stale_src_a")
         src_c = tmp_delta_path("memo_stale_src_c")
         tgt_a = tmp_delta_path("memo_stale_tgt_a")
@@ -666,3 +664,102 @@ class TestConditionalSharedTarget:
         # A's complete write stands; B never executed a second write
         rows = spark.read.format("delta").load(shared).collect()
         assert [r["who"] for r in rows] == ["A"]
+
+    def test_failed_first_writer_is_not_reported_as_written(
+        self, spark: SparkSession, tmp_delta_path
+    ) -> None:
+        """A first survivor that FAILED at execution may never have written
+        the target — the overlap abort must not claim its write stands."""
+        gate = tmp_delta_path("cff_gate")
+        create_delta_table(spark, gate, [{"id": 1}])
+        src_b = tmp_delta_path("cff_src_b")
+        src_x = tmp_delta_path("cff_src_x")
+        shared = tmp_delta_path("cff_shared")
+        tgt_x = tmp_delta_path("cff_tgt_x")
+        missing_src = tmp_delta_path("cff_src_missing")  # never created — A fails
+        create_delta_table(spark, src_b, [{"id": 2, "who": "B"}])
+        create_delta_table(spark, src_x, [{"id": 3, "who": "X"}])
+
+        threads = {
+            "A": _thread("A", missing_src, shared, on_failure="continue"),
+            "X": _thread("X", src_x, tgt_x),
+            "B": _thread("B", src_b, shared),
+        }
+        entries = [
+            ThreadEntry(name="A", condition=ConditionSpec(when="1 == 1")),
+            ThreadEntry(name="X"),
+            ThreadEntry(name="B", condition=ConditionSpec(when="1 == 1"), dependencies=["X"]),
+        ]
+        plan = build_plan("test_weave", threads, entries)
+
+        result = execute_weave(
+            spark,
+            plan,
+            threads,
+            thread_conditions={"A": self._cond(gate), "B": self._cond(gate)},
+        )
+
+        backstop = [
+            r for r in result.thread_results if r.thread_name == "B" and r.status == "failure"
+        ]
+        assert backstop
+        message = backstop[0].error or ""
+        assert "unverified" in message
+        assert "complete write stands" not in message
+        from weevr.delta import delta_table_exists
+
+        assert delta_table_exists(spark, shared) is False  # A failed before writing
+
+    def test_three_true_conditions_abort_before_any_write(
+        self, spark: SparkSession, tmp_delta_path
+    ) -> None:
+        gate = tmp_delta_path("c3_gate")
+        create_delta_table(spark, gate, [{"id": 1}])
+        srcs = {}
+        for n in ("A", "B", "C"):
+            srcs[n] = tmp_delta_path(f"c3_src_{n}")
+            create_delta_table(spark, srcs[n], [{"id": 1, "who": n}])
+        shared = tmp_delta_path("c3_shared")
+
+        threads = {n: _thread(n, srcs[n], shared) for n in ("A", "B", "C")}
+        entries = [
+            ThreadEntry(name=n, condition=ConditionSpec(when="1 == 1")) for n in ("A", "B", "C")
+        ]
+        plan = build_plan("test_weave", threads, entries)
+
+        result = execute_weave(
+            spark,
+            plan,
+            threads,
+            thread_conditions={n: self._cond(gate) for n in ("A", "B", "C")},
+        )
+
+        assert result.status == "failure"
+        from weevr.delta import delta_table_exists
+
+        assert delta_table_exists(spark, shared) is False
+        failures = [r for r in result.thread_results if r.status == "failure"]
+        assert failures and shared in (failures[0].error or "")
+
+    def test_backstop_unaffected_by_max_parallel_threads(
+        self, spark: SparkSession, tmp_delta_path
+    ) -> None:
+        """The backstop runs before the pool is built — pool sizing is moot."""
+        from weevr.model.execution import ExecutionConfig
+
+        gate = tmp_delta_path("cmp_gate")
+        create_delta_table(spark, gate, [{"id": 1}])
+        threads, plan, shared, tgt_out = self._setup(spark, tmp_delta_path, "cmp")
+
+        result = execute_weave(
+            spark,
+            plan,
+            threads,
+            thread_conditions={"A": self._cond(gate), "B": self._cond(gate)},
+            execution=ExecutionConfig(max_parallel_threads=1),
+        )
+
+        assert result.status == "failure"
+        from weevr.delta import delta_table_exists
+
+        assert delta_table_exists(spark, shared) is False

--- a/tests/weevr/engine/test_planner.py
+++ b/tests/weevr/engine/test_planner.py
@@ -769,6 +769,23 @@ class TestConditionalWriterExemption:
         plan = build_plan("w", threads, entries)
         assert plan.conditional_target_writers is None
 
+    def test_three_conditioned_writers_accepted(self):
+        threads = {
+            "w1": _make_thread("w1", target_alias="sales.monthly"),
+            "w2": _make_thread("w2", target_alias="sales.monthly"),
+            "w3": _make_thread("w3", target_alias="sales.monthly"),
+            "report": _make_thread("report", source_aliases=["sales.monthly"]),
+        }
+        entries = [
+            _cond_entry("w1"),
+            _cond_entry("w2"),
+            _cond_entry("w3"),
+            ThreadEntry(name="report"),
+        ]
+        plan = build_plan("w", threads, entries)
+        assert plan.conditional_target_writers == {"sales.monthly": ["w1", "w2", "w3"]}
+        assert set(plan.dependencies["report"]) == {"w1", "w2", "w3"}
+
     def test_consumer_depends_on_all_conditional_writers(self):
         threads = {
             "load_full": _make_thread("load_full", target_alias="sales.monthly"),

--- a/tests/weevr/engine/test_planner.py
+++ b/tests/weevr/engine/test_planner.py
@@ -11,7 +11,7 @@ from weevr.errors.exceptions import ConfigError
 from weevr.model.lookup import Lookup
 from weevr.model.source import Source
 from weevr.model.thread import Thread
-from weevr.model.weave import ThreadEntry
+from weevr.model.weave import ConditionSpec, ThreadEntry
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -727,6 +727,113 @@ class TestDuplicateTargets:
         plan = build_plan("w", threads, entries, lookups=lookups)
         assert plan.lookup_producers is not None
         assert plan.lookup_producers["monthly"] == "load_feb"
+
+
+def _cond_entry(name: str, when: str = "${param.branch} == 'x'") -> ThreadEntry:
+    return ThreadEntry(name=name, condition=ConditionSpec(when=when))
+
+
+class TestConditionalWriterExemption:
+    """Writers of one target are exempt from the rejection when every one
+    of them carries a condition — conditions assert mutual exclusion."""
+
+    def test_all_conditioned_writers_accepted(self):
+        threads = {
+            "load_full": _make_thread("load_full", target_alias="sales.monthly"),
+            "load_incr": _make_thread("load_incr", target_alias="sales.monthly"),
+        }
+        entries = [_cond_entry("load_full"), _cond_entry("load_incr")]
+        plan = build_plan("w", threads, entries)
+        assert plan.conditional_target_writers == {"sales.monthly": ["load_full", "load_incr"]}
+
+    def test_one_unconditioned_writer_still_raises(self):
+        threads = {
+            "load_full": _make_thread("load_full", target_alias="sales.monthly"),
+            "load_incr": _make_thread("load_incr", target_alias="sales.monthly"),
+        }
+        entries = [_cond_entry("load_full"), ThreadEntry(name="load_incr")]
+        with pytest.raises(ConfigError, match="explicit dependencies"):
+            build_plan("w", threads, entries)
+
+    def test_explicit_chain_exemption_takes_precedence(self):
+        """A totally ordered writer pair keeps today's chain semantics even
+        when conditions are also present — no conditional set is recorded."""
+        threads = {
+            "load_jan": _make_thread("load_jan", target_alias="sales.monthly"),
+            "load_feb": _make_thread("load_feb", target_alias="sales.monthly"),
+        }
+        entries = [
+            ThreadEntry(name="load_jan"),
+            _entry_with_deps("load_feb", ["load_jan"]),
+        ]
+        plan = build_plan("w", threads, entries)
+        assert plan.conditional_target_writers is None
+
+    def test_consumer_depends_on_all_conditional_writers(self):
+        threads = {
+            "load_full": _make_thread("load_full", target_alias="sales.monthly"),
+            "load_incr": _make_thread("load_incr", target_alias="sales.monthly"),
+            "report": _make_thread("report", source_aliases=["sales.monthly"]),
+        }
+        entries = [
+            _cond_entry("load_full"),
+            _cond_entry("load_incr"),
+            ThreadEntry(name="report"),
+        ]
+        plan = build_plan("w", threads, entries)
+        assert set(plan.dependencies["report"]) == {"load_full", "load_incr"}
+        groups = {name: idx for idx, group in enumerate(plan.execution_order) for name in group}
+        assert groups["report"] > groups["load_full"]
+        assert groups["report"] > groups["load_incr"]
+
+    def test_aliased_writer_resolves_to_effective_name(self):
+        """The conditional set is keyed by effective (as-aliased) names."""
+        threads = {
+            "load_full": _make_thread("load_full", target_alias="sales.monthly"),
+            "variant": _make_thread("variant", target_alias="sales.monthly"),
+        }
+        entries = [
+            _cond_entry("load_full"),
+            ThreadEntry(
+                name="load_incr",
+                as_="variant",
+                condition=ConditionSpec(when="${param.branch} == 'y'"),
+            ),
+        ]
+        plan = build_plan("w", threads, entries)
+        assert plan.conditional_target_writers == {"sales.monthly": ["load_full", "variant"]}
+
+    def test_lookup_on_conditional_target_scheduled_after_all_writers(self):
+        """A lookup reading the shared target materializes only after the
+        LAST writer's group, and its consumers depend on every writer."""
+        threads = {
+            "gate": _make_thread("gate", target_alias="out_gate"),
+            "load_full": _make_thread("load_full", target_alias="sales.monthly"),
+            "load_incr": _make_thread("load_incr", target_alias="sales.monthly"),
+            "consumer": _make_thread_with_lookup("consumer", "monthly"),
+        }
+        entries = [
+            ThreadEntry(name="gate"),
+            _cond_entry("load_full"),
+            ThreadEntry(
+                name="load_incr",
+                condition=ConditionSpec(when="${param.branch} == 'y'"),
+                dependencies=["gate"],
+            ),
+            ThreadEntry(name="consumer"),
+        ]
+        lookups = {"monthly": _make_lookup("sales.monthly")}
+        plan = build_plan("w", threads, entries, lookups=lookups)
+
+        groups = {name: idx for idx, group in enumerate(plan.execution_order) for name in group}
+        assert groups["load_incr"] == 1  # forced later than load_full by the gate dep
+        assert plan.lookup_schedule is not None
+        scheduled_at = next(
+            idx for idx, names in plan.lookup_schedule.items() if "monthly" in names
+        )
+        assert scheduled_at > groups["load_incr"]
+        assert scheduled_at > groups["load_full"]
+        assert {"load_full", "load_incr"} <= set(plan.dependencies["consumer"])
 
 
 class TestExecutionPlanDisplay:

--- a/tests/weevr/test_context.py
+++ b/tests/weevr/test_context.py
@@ -577,6 +577,41 @@ class TestContextRunExecute:
         assert result.detail.rows_written is None
         assert any("t_unattr" in w and tgt in w for w in result.warnings)
 
+    def test_aliased_entry_condition_gates_the_thread(
+        self, spark: SparkSession, tmp_path: Path
+    ) -> None:
+        """An as-aliased entry's condition must actually be evaluated —
+        conditions are keyed by effective name, not raw entry name."""
+        src = str(tmp_path / "src_alias_cond")
+        tgt = str(tmp_path / "tgt_alias_cond")
+        absent_gate = str(tmp_path / "gate_never_created")
+        spark.createDataFrame([{"id": 1, "val": "a"}]).write.format("delta").save(src)
+
+        project = _project_dir(tmp_path)
+        _create_thread_yaml(project, "t_base", src, tgt)
+        weave_dir = project / "weaves"
+        weave_dir.mkdir(parents=True, exist_ok=True)
+        weave_yaml = weave_dir / "walias.weave"
+        weave_yaml.write_text(
+            f"""\
+config_version: "1.0"
+threads:
+  - ref: "threads/t_base.thread"
+    as: "gated_variant"
+    condition:
+      when: "table_exists('{absent_gate}')"
+"""
+        )
+        ctx = Context(spark=spark, project=project)
+        result = ctx.run(weave_yaml)
+
+        assert result.status == "success"
+        assert result.detail is not None
+        assert "gated_variant" in result.detail.threads_skipped
+        from weevr.delta import delta_table_exists
+
+        assert delta_table_exists(spark, tgt) is False  # the write never ran
+
     def test_run_execute_weave(self, spark: SparkSession, tmp_path: Path) -> None:
         src = str(tmp_path / "src_wexec")
         tgt = str(tmp_path / "tgt_wexec")

--- a/tests/weevr/test_context.py
+++ b/tests/weevr/test_context.py
@@ -734,6 +734,39 @@ class TestValidateMode:
         assert result.validation_errors is not None
         assert any("not found" in e for e in result.validation_errors)
 
+    def test_validate_accepts_condition_gated_same_target_writers(
+        self, spark: SparkSession, tmp_path: Path
+    ) -> None:
+        """Writers of one target all carrying conditions validate cleanly —
+        the conditions assert mutual exclusion."""
+        src = str(tmp_path / "src_cdup")
+        tgt = str(tmp_path / "tgt_cdup")
+        spark.createDataFrame([{"id": 1}]).write.format("delta").save(src)
+
+        project = _project_dir(tmp_path)
+        _create_thread_yaml(project, "load_full", src, tgt)
+        _create_thread_yaml(project, "load_incr", src, tgt)
+        weave_dir = project / "weaves"
+        weave_dir.mkdir(parents=True, exist_ok=True)
+        weave_yaml = weave_dir / "vcdup.weave"
+        weave_yaml.write_text(
+            f"""\
+config_version: "1.0"
+threads:
+  - ref: "threads/load_full.thread"
+    condition:
+      when: "table_empty('{tgt}')"
+  - ref: "threads/load_incr.thread"
+    condition:
+      when: "not table_empty('{tgt}')"
+"""
+        )
+        ctx = Context(spark=spark, project=project)
+        result = ctx.run(weave_yaml, mode="validate")
+
+        assert result.status == "success"
+        assert result.validation_errors is None
+
 
 @pytest.mark.spark
 class TestPlanMode:


### PR DESCRIPTION
## Summary

- Threads that all carry a `condition:` may share a target again — the
  planner exempts fully condition-gated writer sets from the same-target
  rejection, treating the conditions as an assertion of mutual exclusion.
- The engine enforces that assertion at runtime: if a second writer's
  condition also comes true, the weave aborts before that write executes.
- A pre-existing bug is fixed along the way: an `as:`-aliased entry's
  condition was silently never evaluated.

## Why

The same-target rejection (shipped earlier in this train) correctly stops
unordered writers from racing concurrent writes — but it also rejected a
pattern that was valid before it: a full-load thread and an incremental
thread for the same table, gated by conditions so only one runs per
execution. Those configs stopped validating with no remediation short of
restructuring.

The conditions can't be proven disjoint at plan time (they may read live
table state), so the contract is: declaring conditions on every writer
asserts mutual exclusion, and the engine enforces it when conditions
resolve.

## What changed

- `build_plan` accepts a shared target when every writer's thread entry
  carries a condition, recording the set on a new
  `ExecutionPlan.conditional_target_writers` field. One unconditioned
  writer restores the rejection unchanged; an explicit-dependency chain
  remains an independent exemption. Consumers of such a target depend on
  every writer (they run after whichever one survived), and a lookup
  reading it materializes only after the last writer's group.
- `execute_weave` tracks survivors per conditional target as conditions
  resolve, before the thread pool is built. A second survivor fails the
  weave with an error naming the target and both proven-overlapping
  threads. Same-group overlaps abort before any write. Cross-group
  overlaps abort before the second write: a succeeded first writer's
  complete, sequential write stands and the error says so; a failed
  first writer's write state is reported as unverified, never claimed.
- Conditions on `as:`-aliased entries now actually gate the thread. Both
  condition-map construction sites keyed by the raw entry name while the
  plan keys by effective name, so an aliased entry's condition never
  evaluated. The aliasing rule now lives in one place
  (`ThreadEntry.effective_name`) used by the planner and both call sites.
- Engine-internals guide documents the contract and both abort timings.

## How to test

- [x] uv sync --dev
- [x] uv run ruff check .
- [x] uv run ruff format .
- [x] uv run pyright .
- [x] uv run pytest (2568 passed) and uv run pytest -m spark (996 passed)

New coverage: exemption acceptance (two- and three-writer sets, aliased
writers, chain precedence, one-unconditioned rejection, validate mode);
consumer and lookup ordering across the writer set; runtime disjoint /
same-group overlap / cross-group overlap with real Delta content
assertions; a failed first survivor is not misreported as having written;
backstop under `max_parallel_threads`; aliased-condition gating end-to-end
through `Context.run`.

## Release / Versioning

- [x] PR title follows Conventional Commit format (feat:, fix:, chore:, docs:, ci:, etc.)
- [ ] Breaking change indicated (feat!: / fix!: or BREAKING CHANGE in body)

Not breaking: this restores a previously valid pattern the unreleased
train had started rejecting, and the overlap abort only fires on configs
whose conditions overlap — previously a silent race. Weaves that relied on
an aliased entry's condition being ignored will see the condition start
gating the thread; the prior behavior was non-functional.

## Notes

- The planner performs no analysis of condition expressions — enforcement
  happens at condition-resolution time by design.
- On a cross-group overlap the weave reports `partial` (one writer
  succeeded, one failed), consistent with the engine's mixed-outcome
  status convention.