### PR TITLE
chore(model): complete field descriptions for samples and assertion columns

### DIFF
--- a/docs/schema/loom.json
+++ b/docs/schema/loom.json
@@ -238,7 +238,7 @@
       "type": "object"
     },
     "ExecutionConfig": {
-      "description": "Runtime execution settings declared on the top-level ``execution:`` block.\n\nCanonical declaration sites are the top-level ``execution:`` field on\nLoom and Weave. The effective settings for a weave execution merge\nfield-level (see :func:`resolve_effective_execution`) rather than\nreplacing whole-block. Thread-scoped execution settings are declared\nbut not applied in v1.x.\n\nAttributes:\n    log_level: Logging verbosity for execution output.\n    trace: Whether to collect execution spans for telemetry.\n    max_parallel_threads: Upper bound on concurrently executing\n        threads within a weave's parallel group. Unset means\n        unbounded (pool sized to the group).\n    capture_samples: Whether output samples are captured at write\n        time. Off by default; preview always samples.",
+      "description": "Runtime execution settings declared on the top-level ``execution:`` block.\n\nCanonical declaration sites are the top-level ``execution:`` field on\nLoom and Weave. The effective settings for a weave execution merge\nfield-level (see :func:`resolve_effective_execution`) rather than\nreplacing whole-block. Thread-scoped execution settings are declared\nbut not applied in v1.x.\n\nAttributes:\n    log_level: Logging verbosity for execution output.\n    trace: Whether to collect execution spans for telemetry.\n    max_parallel_threads: Upper bound on concurrently executing\n        threads within a weave's parallel group. Unset means\n        unbounded (pool sized to the group).\n    capture_samples: Whether output and quarantine samples are\n        captured at write time. Off by default; preview always\n        samples.",
       "properties": {
         "log_level": {
           "$ref": "#/$defs/LogLevel",
@@ -267,7 +267,7 @@
         },
         "capture_samples": {
           "default": false,
-          "description": "Whether to capture 10-row output samples at write time for display. Preview mode always captures samples regardless of this setting.",
+          "description": "Whether to capture 10-row output and quarantine samples at write time for display. Preview mode always captures samples regardless of this setting.",
           "title": "Capture Samples",
           "type": "boolean"
         }

--- a/docs/schema/thread.json
+++ b/docs/schema/thread.json
@@ -135,7 +135,7 @@
             }
           ],
           "default": null,
-          "description": "Columns to assert against, used by ``column_not_null`` and ``unique``.",
+          "description": "Columns to assert against, used by ``column_not_null``, ``unique``, and (as the multi-column alternative to ``column``) ``fk_sentinel_rate``.",
           "title": "Columns"
         },
         "min": {
@@ -1348,7 +1348,7 @@
       "type": "object"
     },
     "ExecutionConfig": {
-      "description": "Runtime execution settings declared on the top-level ``execution:`` block.\n\nCanonical declaration sites are the top-level ``execution:`` field on\nLoom and Weave. The effective settings for a weave execution merge\nfield-level (see :func:`resolve_effective_execution`) rather than\nreplacing whole-block. Thread-scoped execution settings are declared\nbut not applied in v1.x.\n\nAttributes:\n    log_level: Logging verbosity for execution output.\n    trace: Whether to collect execution spans for telemetry.\n    max_parallel_threads: Upper bound on concurrently executing\n        threads within a weave's parallel group. Unset means\n        unbounded (pool sized to the group).\n    capture_samples: Whether output samples are captured at write\n        time. Off by default; preview always samples.",
+      "description": "Runtime execution settings declared on the top-level ``execution:`` block.\n\nCanonical declaration sites are the top-level ``execution:`` field on\nLoom and Weave. The effective settings for a weave execution merge\nfield-level (see :func:`resolve_effective_execution`) rather than\nreplacing whole-block. Thread-scoped execution settings are declared\nbut not applied in v1.x.\n\nAttributes:\n    log_level: Logging verbosity for execution output.\n    trace: Whether to collect execution spans for telemetry.\n    max_parallel_threads: Upper bound on concurrently executing\n        threads within a weave's parallel group. Unset means\n        unbounded (pool sized to the group).\n    capture_samples: Whether output and quarantine samples are\n        captured at write time. Off by default; preview always\n        samples.",
       "properties": {
         "log_level": {
           "$ref": "#/$defs/LogLevel",
@@ -1377,7 +1377,7 @@
         },
         "capture_samples": {
           "default": false,
-          "description": "Whether to capture 10-row output samples at write time for display. Preview mode always captures samples regardless of this setting.",
+          "description": "Whether to capture 10-row output and quarantine samples at write time for display. Preview mode always captures samples regardless of this setting.",
           "title": "Capture Samples",
           "type": "boolean"
         }

--- a/docs/schema/weave.json
+++ b/docs/schema/weave.json
@@ -238,7 +238,7 @@
       "type": "object"
     },
     "ExecutionConfig": {
-      "description": "Runtime execution settings declared on the top-level ``execution:`` block.\n\nCanonical declaration sites are the top-level ``execution:`` field on\nLoom and Weave. The effective settings for a weave execution merge\nfield-level (see :func:`resolve_effective_execution`) rather than\nreplacing whole-block. Thread-scoped execution settings are declared\nbut not applied in v1.x.\n\nAttributes:\n    log_level: Logging verbosity for execution output.\n    trace: Whether to collect execution spans for telemetry.\n    max_parallel_threads: Upper bound on concurrently executing\n        threads within a weave's parallel group. Unset means\n        unbounded (pool sized to the group).\n    capture_samples: Whether output samples are captured at write\n        time. Off by default; preview always samples.",
+      "description": "Runtime execution settings declared on the top-level ``execution:`` block.\n\nCanonical declaration sites are the top-level ``execution:`` field on\nLoom and Weave. The effective settings for a weave execution merge\nfield-level (see :func:`resolve_effective_execution`) rather than\nreplacing whole-block. Thread-scoped execution settings are declared\nbut not applied in v1.x.\n\nAttributes:\n    log_level: Logging verbosity for execution output.\n    trace: Whether to collect execution spans for telemetry.\n    max_parallel_threads: Upper bound on concurrently executing\n        threads within a weave's parallel group. Unset means\n        unbounded (pool sized to the group).\n    capture_samples: Whether output and quarantine samples are\n        captured at write time. Off by default; preview always\n        samples.",
       "properties": {
         "log_level": {
           "$ref": "#/$defs/LogLevel",
@@ -267,7 +267,7 @@
         },
         "capture_samples": {
           "default": false,
-          "description": "Whether to capture 10-row output samples at write time for display. Preview mode always captures samples regardless of this setting.",
+          "description": "Whether to capture 10-row output and quarantine samples at write time for display. Preview mode always captures samples regardless of this setting.",
           "title": "Capture Samples",
           "type": "boolean"
         }

--- a/docs/schema/weevr.json
+++ b/docs/schema/weevr.json
@@ -136,7 +136,7 @@
               }
             ],
             "default": null,
-            "description": "Columns to assert against, used by ``column_not_null`` and ``unique``.",
+            "description": "Columns to assert against, used by ``column_not_null``, ``unique``, and (as the multi-column alternative to ``column``) ``fk_sentinel_rate``.",
             "title": "Columns"
           },
           "min": {
@@ -1349,7 +1349,7 @@
         "type": "object"
       },
       "ExecutionConfig": {
-        "description": "Runtime execution settings declared on the top-level ``execution:`` block.\n\nCanonical declaration sites are the top-level ``execution:`` field on\nLoom and Weave. The effective settings for a weave execution merge\nfield-level (see :func:`resolve_effective_execution`) rather than\nreplacing whole-block. Thread-scoped execution settings are declared\nbut not applied in v1.x.\n\nAttributes:\n    log_level: Logging verbosity for execution output.\n    trace: Whether to collect execution spans for telemetry.\n    max_parallel_threads: Upper bound on concurrently executing\n        threads within a weave's parallel group. Unset means\n        unbounded (pool sized to the group).\n    capture_samples: Whether output samples are captured at write\n        time. Off by default; preview always samples.",
+        "description": "Runtime execution settings declared on the top-level ``execution:`` block.\n\nCanonical declaration sites are the top-level ``execution:`` field on\nLoom and Weave. The effective settings for a weave execution merge\nfield-level (see :func:`resolve_effective_execution`) rather than\nreplacing whole-block. Thread-scoped execution settings are declared\nbut not applied in v1.x.\n\nAttributes:\n    log_level: Logging verbosity for execution output.\n    trace: Whether to collect execution spans for telemetry.\n    max_parallel_threads: Upper bound on concurrently executing\n        threads within a weave's parallel group. Unset means\n        unbounded (pool sized to the group).\n    capture_samples: Whether output and quarantine samples are\n        captured at write time. Off by default; preview always\n        samples.",
         "properties": {
           "log_level": {
             "$ref": "#/$defs/LogLevel",
@@ -1378,7 +1378,7 @@
           },
           "capture_samples": {
             "default": false,
-            "description": "Whether to capture 10-row output samples at write time for display. Preview mode always captures samples regardless of this setting.",
+            "description": "Whether to capture 10-row output and quarantine samples at write time for display. Preview mode always captures samples regardless of this setting.",
             "title": "Capture Samples",
             "type": "boolean"
           }
@@ -5329,7 +5329,7 @@
         "type": "object"
       },
       "ExecutionConfig": {
-        "description": "Runtime execution settings declared on the top-level ``execution:`` block.\n\nCanonical declaration sites are the top-level ``execution:`` field on\nLoom and Weave. The effective settings for a weave execution merge\nfield-level (see :func:`resolve_effective_execution`) rather than\nreplacing whole-block. Thread-scoped execution settings are declared\nbut not applied in v1.x.\n\nAttributes:\n    log_level: Logging verbosity for execution output.\n    trace: Whether to collect execution spans for telemetry.\n    max_parallel_threads: Upper bound on concurrently executing\n        threads within a weave's parallel group. Unset means\n        unbounded (pool sized to the group).\n    capture_samples: Whether output samples are captured at write\n        time. Off by default; preview always samples.",
+        "description": "Runtime execution settings declared on the top-level ``execution:`` block.\n\nCanonical declaration sites are the top-level ``execution:`` field on\nLoom and Weave. The effective settings for a weave execution merge\nfield-level (see :func:`resolve_effective_execution`) rather than\nreplacing whole-block. Thread-scoped execution settings are declared\nbut not applied in v1.x.\n\nAttributes:\n    log_level: Logging verbosity for execution output.\n    trace: Whether to collect execution spans for telemetry.\n    max_parallel_threads: Upper bound on concurrently executing\n        threads within a weave's parallel group. Unset means\n        unbounded (pool sized to the group).\n    capture_samples: Whether output and quarantine samples are\n        captured at write time. Off by default; preview always\n        samples.",
         "properties": {
           "log_level": {
             "$ref": "#/$defs/LogLevel",
@@ -5358,7 +5358,7 @@
           },
           "capture_samples": {
             "default": false,
-            "description": "Whether to capture 10-row output samples at write time for display. Preview mode always captures samples regardless of this setting.",
+            "description": "Whether to capture 10-row output and quarantine samples at write time for display. Preview mode always captures samples regardless of this setting.",
             "title": "Capture Samples",
             "type": "boolean"
           }
@@ -6849,7 +6849,7 @@
         "type": "object"
       },
       "ExecutionConfig": {
-        "description": "Runtime execution settings declared on the top-level ``execution:`` block.\n\nCanonical declaration sites are the top-level ``execution:`` field on\nLoom and Weave. The effective settings for a weave execution merge\nfield-level (see :func:`resolve_effective_execution`) rather than\nreplacing whole-block. Thread-scoped execution settings are declared\nbut not applied in v1.x.\n\nAttributes:\n    log_level: Logging verbosity for execution output.\n    trace: Whether to collect execution spans for telemetry.\n    max_parallel_threads: Upper bound on concurrently executing\n        threads within a weave's parallel group. Unset means\n        unbounded (pool sized to the group).\n    capture_samples: Whether output samples are captured at write\n        time. Off by default; preview always samples.",
+        "description": "Runtime execution settings declared on the top-level ``execution:`` block.\n\nCanonical declaration sites are the top-level ``execution:`` field on\nLoom and Weave. The effective settings for a weave execution merge\nfield-level (see :func:`resolve_effective_execution`) rather than\nreplacing whole-block. Thread-scoped execution settings are declared\nbut not applied in v1.x.\n\nAttributes:\n    log_level: Logging verbosity for execution output.\n    trace: Whether to collect execution spans for telemetry.\n    max_parallel_threads: Upper bound on concurrently executing\n        threads within a weave's parallel group. Unset means\n        unbounded (pool sized to the group).\n    capture_samples: Whether output and quarantine samples are\n        captured at write time. Off by default; preview always\n        samples.",
         "properties": {
           "log_level": {
             "$ref": "#/$defs/LogLevel",
@@ -6878,7 +6878,7 @@
           },
           "capture_samples": {
             "default": false,
-            "description": "Whether to capture 10-row output samples at write time for display. Preview mode always captures samples regardless of this setting.",
+            "description": "Whether to capture 10-row output and quarantine samples at write time for display. Preview mode always captures samples regardless of this setting.",
             "title": "Capture Samples",
             "type": "boolean"
           }

--- a/packages/weevr-core/src/weevr/model/execution.py
+++ b/packages/weevr-core/src/weevr/model/execution.py
@@ -35,8 +35,9 @@ class ExecutionConfig(FrozenBase):
         max_parallel_threads: Upper bound on concurrently executing
             threads within a weave's parallel group. Unset means
             unbounded (pool sized to the group).
-        capture_samples: Whether output samples are captured at write
-            time. Off by default; preview always samples.
+        capture_samples: Whether output and quarantine samples are
+            captured at write time. Off by default; preview always
+            samples.
     """
 
     log_level: LogLevel = Field(
@@ -58,9 +59,9 @@ class ExecutionConfig(FrozenBase):
     capture_samples: bool = Field(
         default=False,
         description=(
-            "Whether to capture 10-row output samples at write time for "
-            "display. Preview mode always captures samples regardless of "
-            "this setting."
+            "Whether to capture 10-row output and quarantine samples at "
+            "write time for display. Preview mode always captures samples "
+            "regardless of this setting."
         ),
     )
 

--- a/packages/weevr-core/src/weevr/model/validation.py
+++ b/packages/weevr-core/src/weevr/model/validation.py
@@ -56,7 +56,10 @@ class Assertion(FrozenBase):
     )
     columns: list[str] | None = Field(
         default=None,
-        description="Columns to assert against, used by ``column_not_null`` and ``unique``.",
+        description=(
+            "Columns to assert against, used by ``column_not_null``, ``unique``, "
+            "and (as the multi-column alternative to ``column``) ``fk_sentinel_rate``."
+        ),
     )
     min: int | None = Field(
         default=None,


### PR DESCRIPTION
## Summary

- Two model field descriptions were incomplete relative to actual
  behavior; a docs sweep traced reference-table drift back to them.
  This completes the descriptions and regenerates the JSON schemas.

## Why

- `ExecutionConfig.capture_samples` said "output samples" only, but the
  flag also gates quarantine-sample capture — the reference pages that
  copied the description inherited the omission.
- `Assertion.columns` said "used by column_not_null and unique", but it
  is also the multi-column form for `fk_sentinel_rate` (the validator
  treats `column`/`columns` as interchangeable there).

## What changed

- Both field descriptions (and the `capture_samples` class docstring
  line) now state the full behavior. No functional change — strings
  only.
- `docs/schema/*.json` regenerated; the description text is the only
  diff.

## How to test

- [x] uv sync --dev
- [x] uv run ruff check .
- [x] uv run ruff format .
- [x] uv run pyright .
- [x] uv run pytest

Schema regenerated via `scripts/generate_schema.py`; the CI schema
check verifies the committed output matches.

## Release / Versioning

- [x] PR title follows Conventional Commit format (feat:, fix:, chore:, docs:, ci:, etc.)
- [ ] Breaking change indicated (feat!: / fix!: or BREAKING CHANGE in body)

Description-only; not a breaking change.

## Notes

- Companion to the docs-correction PR that fixed the downstream
  reference tables; this closes the drift at its source.